### PR TITLE
Add requirements file for RTD

### DIFF
--- a/docs/user_manual/requirements.txt
+++ b/docs/user_manual/requirements.txt
@@ -1,0 +1,4 @@
+sphinx
+sphinx-rtd-theme
+recommonmark
+sphinxcontrib-svg2pdfconverter


### PR DESCRIPTION
Apparently the svg2pdf converter required to render inkscape files is not part of the standard RTD toolkit and therefore a 'requirements' file is required.   Note that the cv32e40s user manual will require the same file to be added - let me know if you would like a specific pull-request to add that.

Signed-off-by: MikeOpenHWGroup <mike@openhwgroup.org>