### PR TITLE
Remove second register file write port

### DIFF
--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -213,7 +213,7 @@ module cv32e40x_wrapper
 
       .ex_valid       ( core_i.ex_valid                             ),
       .ex_reg_addr    ( core_i.id_stage_i.regfile_waddr[1]          ),
-      .ex_reg_we      ( core_i.id_stage_i.regfile_we[1]             ),
+      .ex_reg_we      ( 1'b0                                        ),
       .ex_reg_wdata   ( core_i.id_stage_i.regfile_wdata[1]          ),
 
       .ex_data_addr   ( core_i.data_addr_o                          ),

--- a/rtl/cv32e40x_core.sv
+++ b/rtl/cv32e40x_core.sv
@@ -207,6 +207,9 @@ module cv32e40x_core import cv32e40x_pkg::*;
   // Wake signal
   logic        wake_from_sleep;
 
+  // WB is writing back an ALU result
+  logic        wb_alu_en;
+
   // Internal OBI interfaces
   if_c_obi #(.REQ_TYPE(obi_inst_req_t), .RESP_TYPE(obi_inst_resp_t))  m_c_obi_instr_if();
   if_c_obi #(.REQ_TYPE(obi_data_req_t), .RESP_TYPE(obi_data_resp_t))  m_c_obi_data_if();
@@ -439,6 +442,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .rf_we_wb_i                   ( rf_we_wb             ),
     .rf_waddr_wb_i                ( rf_waddr_wb          ),
     .rf_wdata_wb_i                ( rf_wdata_wb          ),
+    .rf_wdata_wb_alu_i            ( ex_wb_pipe.rf_wdata  ),
 
     // Performance Counters
     .mhpmevent_minstret_o         ( mhpmevent_minstret   ),
@@ -452,7 +456,9 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .mhpmevent_imiss_o            ( mhpmevent_imiss      ),
     .mhpmevent_ld_stall_o         ( mhpmevent_ld_stall   ),
 
-    .perf_imiss_i                 ( perf_imiss           )
+    .perf_imiss_i                 ( perf_imiss           ),
+
+    .wb_alu_en_i                  ( wb_alu_en            )
   );
 
 
@@ -542,7 +548,8 @@ module cv32e40x_core import cv32e40x_pkg::*;
     // Write back to register file
     .rf_we_wb_o                 ( rf_we_wb                     ),
     .rf_waddr_wb_o              ( rf_waddr_wb                  ),
-    .rf_wdata_wb_o              ( rf_wdata_wb                  )
+    .rf_wdata_wb_o              ( rf_wdata_wb                  ),
+    .wb_alu_en_o                ( wb_alu_en                    )
   );
 
   // Tracer signal

--- a/rtl/cv32e40x_ex_stage.sv
+++ b/rtl/cv32e40x_ex_stage.sv
@@ -152,15 +152,23 @@ module cv32e40x_ex_stage import cv32e40x_pkg::*;
     begin
       ex_wb_pipe_o.rf_we    <= 1'b0;
       ex_wb_pipe_o.rf_waddr <= '0;
-      ex_wb_pipe_o.rf_wdata <= 32'b0; // todo: regular assignment needs to be added while removing 2nd rf write port
+      ex_wb_pipe_o.rf_wdata <= 32'b0;
+      ex_wb_pipe_o.rf_wdata_ex_en <= 1'b0;
     end
     else
     begin
       if (ex_valid_o) // wb_ready_i is implied
       begin
-        ex_wb_pipe_o.rf_we <= id_ex_pipe_i.rf_we && id_ex_pipe_i.data_req;
-        if (id_ex_pipe_i.rf_we && id_ex_pipe_i.data_req) begin
+        ex_wb_pipe_o.rf_we <= id_ex_pipe_i.rf_we;
+        if (id_ex_pipe_i.rf_we) begin
           ex_wb_pipe_o.rf_waddr <= id_ex_pipe_i.rf_waddr;
+
+          if (!id_ex_pipe_i.data_req) begin
+            ex_wb_pipe_o.rf_wdata <= rf_wdata_ex_o;
+            ex_wb_pipe_o.rf_wdata_ex_en <= 1'b1;
+          end else begin
+            ex_wb_pipe_o.rf_wdata_ex_en <= 1'b0;
+          end
         end
       end else if (wb_ready_i) begin
         // we are ready for a new instruction, but there is none available,

--- a/rtl/cv32e40x_id_stage.sv
+++ b/rtl/cv32e40x_id_stage.sv
@@ -116,6 +116,7 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
     input  logic           rf_we_wb_i,
     input  rf_addr_t       rf_waddr_wb_i,
     input  logic [31:0]    rf_wdata_wb_i,
+    input  logic [31:0]    rf_wdata_wb_alu_i,
 
     input  logic           rf_we_ex_i,
     input  rf_addr_t       rf_waddr_ex_i,
@@ -133,7 +134,9 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
     output logic        mhpmevent_imiss_o,
     output logic        mhpmevent_ld_stall_o,
 
-    input  logic        perf_imiss_i
+    input  logic        perf_imiss_i,
+
+    input  logic        wb_alu_en_i
 );
 
   // Source/Destination register instruction index
@@ -244,8 +247,12 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
   // Forwarding
   op_fw_mux_e  operand_a_fw_mux_sel;
   op_fw_mux_e  operand_b_fw_mux_sel;
+  op_fw_mux_e  jalr_fw_mux_sel;
+
   logic [31:0] operand_a_fw;
   logic [31:0] operand_b_fw;
+
+  logic [31:0] jalr_fw;
 
   logic [31:0] operand_b;
 
@@ -304,7 +311,7 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
     unique case (ctrl_transfer_target_mux_sel)
       JT_JAL:  jump_target_o = if_id_pipe_i.pc + imm_uj_type;
       JT_COND: jump_target_o = if_id_pipe_i.pc + imm_sb_type;
-      JT_JALR: jump_target_o = regfile_rdata[0] + imm_i_type;             // JALR: Cannot forward RS1, since the path is too long
+      JT_JALR: jump_target_o = jalr_fw + imm_i_type;             // JALR: Allowing forwdard iff result comes from ALU
       default: jump_target_o = regfile_rdata[0] + imm_i_type;
     endcase
   end
@@ -352,6 +359,14 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
 */
     endcase; // case (operand_a_fw_mux_sel)
   end
+
+  always_comb begin: jalr_fw_mux
+    case (jalr_fw_mux_sel)
+      SEL_FW_WB:   jalr_fw = rf_wdata_wb_alu_i;
+      SEL_REGFILE: jalr_fw = regfile_rdata[0];
+      default:     jalr_fw = regfile_rdata[0];
+    endcase // jalr_fw_mux_sel
+  end // jalr_fw_mux
 
   //////////////////////////////////////////////////////
   //   ___                                 _   ____   //
@@ -437,10 +452,6 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
   assign regfile_we[0]    = rf_we_wb_i;
   assign regfile_waddr[0] = rf_waddr_wb_i;
   assign regfile_wdata[0] = rf_wdata_wb_i;
-
-  assign regfile_we[1]    = rf_we_ex_i && !id_ex_pipe_o.data_req;
-  assign regfile_waddr[1] = rf_waddr_ex_i;
-  assign regfile_wdata[1] = rf_wdata_ex_i;
 
   cv32e40x_register_file_wrapper
   register_file_wrapper_i
@@ -647,6 +658,7 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
     // Forwarding signals
     .operand_a_fw_mux_sel_o         ( operand_a_fw_mux_sel   ),
     .operand_b_fw_mux_sel_o         ( operand_b_fw_mux_sel   ),
+    .jalr_fw_mux_sel_o              ( jalr_fw_mux_sel        ),
 
     // Stall signals
     .halt_if_o                      ( halt_if                ),
@@ -659,7 +671,8 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
     .id_ready_i                     ( id_ready_o             ),
     .id_valid_i                     ( id_valid_o             ),
     .ex_valid_i                     ( ex_valid_i             ),
-    .wb_ready_i                     ( wb_ready_i             )
+    .wb_ready_i                     ( wb_ready_i             ),
+    .wb_alu_en_i                    ( wb_alu_en_i            )
   );
 
 
@@ -832,7 +845,7 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
         id_ex_pipe_o.mult_en                <= 1'b0;
 
       end else if (id_ex_pipe_o.csr_access) begin
-       //In the EX stage there was a CSR access, to avoid multiple
+       //In the EX stage there was a CSR access. To avoid multiple
        //writes to the RF, disable csr_access (cs_registers will keep it's rdata as it was when csr_access was 1'b1).
        //Not doing it can overwrite the RF file with the currennt CSR value rather than the old one
        id_ex_pipe_o.csr_access              <= 1'b0;

--- a/rtl/cv32e40x_register_file.sv
+++ b/rtl/cv32e40x_register_file.sv
@@ -36,7 +36,7 @@ module cv32e40x_register_file import cv32e40x_pkg::*;
 
     // Write ports
     input rf_addr_t      waddr_i [REGFILE_NUM_WRITE_PORTS],
-    input rf_data_t      wdata_i [REGFILE_NUM_READ_PORTS],
+    input rf_data_t      wdata_i [REGFILE_NUM_WRITE_PORTS],
     input logic          we_i [REGFILE_NUM_WRITE_PORTS]
 );
 

--- a/rtl/cv32e40x_register_file_wrapper.sv
+++ b/rtl/cv32e40x_register_file_wrapper.sv
@@ -40,7 +40,7 @@ module cv32e40x_register_file_wrapper import cv32e40x_pkg::*;
     
         // Write ports
         input rf_addr_t     waddr_i [REGFILE_NUM_WRITE_PORTS],
-        input rf_data_t     wdata_i [REGFILE_NUM_READ_PORTS],
+        input rf_data_t     wdata_i [REGFILE_NUM_WRITE_PORTS],
         input logic         we_i [REGFILE_NUM_WRITE_PORTS]
 );
     

--- a/rtl/cv32e40x_wb_stage.sv
+++ b/rtl/cv32e40x_wb_stage.sv
@@ -39,11 +39,15 @@ module cv32e40x_wb_stage import cv32e40x_pkg::*;
 
   output logic          rf_we_wb_o,
   output rf_addr_t      rf_waddr_wb_o,
-  output logic [31:0]   rf_wdata_wb_o
+  output logic [31:0]   rf_wdata_wb_o,
+
+  // to JR forward logic
+  output logic          wb_alu_en_o
 );
 
   assign rf_we_wb_o    = ex_wb_pipe_i.rf_we;
   assign rf_waddr_wb_o = ex_wb_pipe_i.rf_waddr;
-  assign rf_wdata_wb_o = lsu_rdata_i;
+  assign rf_wdata_wb_o = ex_wb_pipe_i.rf_wdata_ex_en ? ex_wb_pipe_i.rf_wdata : lsu_rdata_i;
+  assign wb_alu_en_o   = ex_wb_pipe_i.rf_wdata_ex_en;
 
 endmodule // cv32e40x_wb_stage

--- a/rtl/include/cv32e40x_pkg.sv
+++ b/rtl/include/cv32e40x_pkg.sv
@@ -555,7 +555,7 @@ parameter logic [31:0] TMATCH_CONTROL_RST_VAL = {
 
 // Register file read/write ports
 parameter REGFILE_NUM_READ_PORTS  = 2;
-parameter REGFILE_NUM_WRITE_PORTS = 2;
+parameter REGFILE_NUM_WRITE_PORTS = 1;
 
 // Address width of register file
 parameter REGFILE_ADDR_WIDTH = 5;
@@ -694,6 +694,7 @@ typedef struct packed {
   logic         rf_we;
   rf_addr_t     rf_waddr;
   logic [31:0]  rf_wdata;
+  logic         rf_wdata_ex_en;
 } ex_wb_pipe_t;
 
 // Decoder control signals


### PR DESCRIPTION
All RF writes are now done from WB stage. Forwarding from WB to PC in case of JALR is now allowed iff WB result comes from the ALU.  SEC equivalent and passes ci_check.