### PR TITLE
rename E40P defines to E40X to include the tracer for core-v-verif testbench

### DIFF
--- a/bhv/cv32e40x_instr_trace.svh
+++ b/bhv/cv32e40x_instr_trace.svh
@@ -22,7 +22,7 @@
 // Engineer:       Steve Richmond - steve.richmond@silabs.com                 //
 //                                                                            //
 // Design Name:    cv32e40x_tracer data structures                            //
-// Project Name:   CV32E40P                                                   //
+// Project Name:   CV32E40X                                                   //
 // Language:       SystemVerilog                                              //
 //                                                                            //
 // Description:    Moves the class definition for instr_trace_t out of the    //

--- a/bhv/cv32e40x_tracer.sv
+++ b/bhv/cv32e40x_tracer.sv
@@ -22,7 +22,7 @@
 //                                                                            //
 ////////////////////////////////////////////////////////////////////////////////
 
-`ifdef CV32E40P_TRACE_EXECUTION
+`ifdef CV32E40X_TRACE_EXECUTION
 
 `include "uvm_macros.svh"
 
@@ -459,4 +459,4 @@ module cv32e40x_tracer
 endmodule : cv32e40x_tracer
 
 
-`endif // CV32E40P_TRACE_EXECUTION
+`endif // CV32E40X_TRACE_EXECUTION

--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -30,11 +30,11 @@
 
 `include "cv32e40x_core_log.sv"
 
-`ifdef CV32E40P_APU_TRACE
+`ifdef CV32E40X_APU_TRACE
   `include "cv32e40x_apu_tracer.sv"
 `endif
 
-`ifdef CV32E40P_TRACE_EXECUTION
+`ifdef CV32E40X_TRACE_EXECUTION
   `include "cv32e40x_tracer.sv"
 `endif
 
@@ -186,7 +186,7 @@ module cv32e40x_wrapper
   );
 `endif
 
-`ifdef CV32E40P_TRACE_EXECUTION
+`ifdef CV32E40X_TRACE_EXECUTION
     cv32e40x_tracer tracer_i(
       .clk_i          ( core_i.clk_i                                   ), // always-running clock for tracing
       .rst_n          ( core_i.rst_ni                                  ),


### PR DESCRIPTION
No other functional changes.

Signed-off-by: Steve Richmond <Steve.Richmond@silabs.com>