### PR TITLE
Multiplier helper assertions

### DIFF
--- a/sva/cv32e40x_mult_sva.sv
+++ b/sva/cv32e40x_mult_sva.sv
@@ -83,64 +83,6 @@ module cv32e40x_mult_sva
                      (result_o == mulhu_result))
       else `uvm_error("mult", "MULHU result check failed")
 
-  logic [33:0] shift_result_ll;
-  assign shift_result_ll = $signed({{16{mulh_al[16]}}, mulh_al[15:0]}) * $signed({{16{mulh_bl[16]}}, mulh_bl[15:0]});
-  a_shift_result_ll : // TODO describe
-    assert property (@(posedge clk) disable iff (!rst_n)
-                     ((mulh_state == ALBL) && enable_i && (operator_i == MUL_H)) |->
-                     (int_result == shift_result_ll))
-      else `uvm_error("mult", "TODO error msg")
-
-  logic [33:0] shift_result_lh;
-  assign shift_result_lh = $signed({{16{mulh_al[16]}}, mulh_al[15:0]}) * $signed({{16{mulh_bh[16]}}, mulh_bh[15:0]});
-  a_shift_result_lh : // TODO describe
-    assert property (@(posedge clk) disable iff (!rst_n)
-                     (mulh_state == ALBH) |->
-                     (int_result == shift_result_lh))
-      else `uvm_error("mult", "TODO error msg")
-
-  logic [33:0] shift_result_hl;
-  assign shift_result_hl = $signed({{16{mulh_ah[16]}}, mulh_ah[15:0]}) * $signed({{16{mulh_bl[16]}}, mulh_bl[15:0]});
-  a_shift_result_hl : // TODO describe
-    assert property (@(posedge clk) disable iff (!rst_n)
-                     (mulh_state == AHBL) |->
-                     (int_result == shift_result_hl))
-      else `uvm_error("mult", "TODO error msg")
-
-  logic [33:0] shift_result_hh;
-  assign shift_result_hh = $signed({{16{mulh_ah[16]}}, mulh_ah[15:0]}) * $signed({{16{mulh_bh[16]}}, mulh_bh[15:0]});
-  a_shift_result_hh : // TODO describe
-    assert property (@(posedge clk) disable iff (!rst_n)
-                     (mulh_state == AHBH) |->
-                     (int_result == shift_result_hh))
-      else `uvm_error("mult", "TODO error msg")
-
-  logic [33:0] shift_result_ll_shift;
-  assign shift_result_ll_shift = (shift_result_ll) >> 16;
-  a_shift_result_ll_shift : // TODO describe
-    assert property (@(posedge clk) disable iff (!rst_n)
-                     (mulh_state == ALBH) |->
-                     (mulh_acc == shift_result_ll_shift))
-      else `uvm_error("mult", "TODO error msg")
-
-  logic [32:0] shift_result_ll_lh;
-  assign shift_result_ll_lh = $signed(shift_result_ll_shift) + $signed(shift_result_lh);
-  a_shift_result_ll_lh : // TODO describe
-    assert property (@(posedge clk) disable iff (!rst_n)
-                     (mulh_state == AHBL) |->
-                     (mulh_acc == shift_result_ll_lh))
-      else `uvm_error("mult", "TODO error msg")
-
-  logic [33:0] shift_result_ll_lh_hl;
-  logic [32:0] shift_result_ll_lh_hl_shift;
-  assign shift_result_ll_lh_hl = $signed(shift_result_ll_lh) + $signed(shift_result_hl);
-  assign shift_result_ll_lh_hl_shift = $signed(shift_result_ll_lh_hl) >>> 16;
-  a_shift_result_ll_lh_hl_shift : // TODO describe
-    assert property (@(posedge clk) disable iff (!rst_n)
-                     (mulh_state == AHBH) |->
-                     (mulh_acc == shift_result_ll_lh_hl_shift))
-      else `uvm_error("mult", "TODO error msg")
-
 
   // Check that multiplier inputs are not changed in the middle of a MULH operation
   logic         ready;
@@ -186,5 +128,67 @@ module cv32e40x_mult_sva
     assert property (@(posedge clk) disable iff (!rst_n)
                      (operator_i == MUL_M32) |-> (mulh_acc == '0))
       else `uvm_error("mult", "Accumulate register not 0 for MUL instruction")
+
+
+  // Check result for intermediary stages
+
+  logic [33:0] shift_result_ll;
+  logic [33:0] shift_result_lh;
+  logic [33:0] shift_result_hl;
+  logic [33:0] shift_result_hh;
+  logic [33:0] shift_result_ll_shift;
+  logic [32:0] shift_result_ll_lh;
+  logic [33:0] shift_result_ll_lh_hl;
+  logic [32:0] shift_result_ll_lh_hl_shift;
+
+  assign shift_result_ll = $signed({{16{mulh_al[16]}}, mulh_al[15:0]}) * $signed({{16{mulh_bl[16]}}, mulh_bl[15:0]});
+  a_shift_result_ll : // TODO describe
+    assert property (@(posedge clk) disable iff (!rst_n)
+                     ((mulh_state == ALBL) && enable_i && (operator_i == MUL_H)) |->
+                     (int_result == shift_result_ll))
+      else `uvm_error("mult", "TODO error msg")
+
+  assign shift_result_lh = $signed({{16{mulh_al[16]}}, mulh_al[15:0]}) * $signed({{16{mulh_bh[16]}}, mulh_bh[15:0]});
+  a_shift_result_lh : // TODO describe
+    assert property (@(posedge clk) disable iff (!rst_n)
+                     (mulh_state == ALBH) |->
+                     (int_result == shift_result_lh))
+      else `uvm_error("mult", "TODO error msg")
+
+  assign shift_result_hl = $signed({{16{mulh_ah[16]}}, mulh_ah[15:0]}) * $signed({{16{mulh_bl[16]}}, mulh_bl[15:0]});
+  a_shift_result_hl : // TODO describe
+    assert property (@(posedge clk) disable iff (!rst_n)
+                     (mulh_state == AHBL) |->
+                     (int_result == shift_result_hl))
+      else `uvm_error("mult", "TODO error msg")
+
+  assign shift_result_hh = $signed({{16{mulh_ah[16]}}, mulh_ah[15:0]}) * $signed({{16{mulh_bh[16]}}, mulh_bh[15:0]});
+  a_shift_result_hh : // TODO describe
+    assert property (@(posedge clk) disable iff (!rst_n)
+                     (mulh_state == AHBH) |->
+                     (int_result == shift_result_hh))
+      else `uvm_error("mult", "TODO error msg")
+
+  assign shift_result_ll_shift = (shift_result_ll) >> 16;
+  a_shift_result_ll_shift : // TODO describe
+    assert property (@(posedge clk) disable iff (!rst_n)
+                     (mulh_state == ALBH) |->
+                     (mulh_acc == shift_result_ll_shift))
+      else `uvm_error("mult", "TODO error msg")
+
+  assign shift_result_ll_lh = $signed(shift_result_ll_shift) + $signed(shift_result_lh);
+  a_shift_result_ll_lh : // TODO describe
+    assert property (@(posedge clk) disable iff (!rst_n)
+                     (mulh_state == AHBL) |->
+                     (mulh_acc == shift_result_ll_lh))
+      else `uvm_error("mult", "TODO error msg")
+
+  assign shift_result_ll_lh_hl = $signed(shift_result_ll_lh) + $signed(shift_result_hl);
+  assign shift_result_ll_lh_hl_shift = $signed(shift_result_ll_lh_hl) >>> 16;
+  a_shift_result_ll_lh_hl_shift : // TODO describe
+    assert property (@(posedge clk) disable iff (!rst_n)
+                     (mulh_state == AHBH) |->
+                     (mulh_acc == shift_result_ll_lh_hl_shift))
+      else `uvm_error("mult", "TODO error msg")
 
 endmodule // cv32e40x_mult


### PR DESCRIPTION
These are helper assertions created as part of formal verification.
In simulation, the overhead of these single-cycle checks should be minimal.
Tested in various formal configurations and in core-v-verif (ci_check and isa_fcov_holes).