### PR TITLE
Use structs for internal OBI control signals

### DIFF
--- a/rtl/cv32e40x_core.sv
+++ b/rtl/cv32e40x_core.sv
@@ -274,16 +274,16 @@ module cv32e40x_core import cv32e40x_pkg::*;
   if_c_obi #(.REQ_TYPE(obi_data_req_t), .RESP_TYPE(obi_data_resp_t))  m_c_obi_data_if();
 
   // Connect toplevel OBI signals to internal interfaces
-  assign instr_req_o                         = m_c_obi_instr_if.req;
+  assign instr_req_o                         = m_c_obi_instr_if.s_req.req;
   assign instr_addr_o                        = m_c_obi_instr_if.req_payload.addr;
   assign instr_memtype_o                     = m_c_obi_instr_if.req_payload.memtype;
   assign instr_prot_o                        = m_c_obi_instr_if.req_payload.prot;
-  assign m_c_obi_instr_if.gnt                = instr_gnt_i;
-  assign m_c_obi_instr_if.rvalid             = instr_rvalid_i;
+  assign m_c_obi_instr_if.s_gnt.gnt          = instr_gnt_i;
+  assign m_c_obi_instr_if.s_rvalid.rvalid    = instr_rvalid_i;
   assign m_c_obi_instr_if.resp_payload.rdata = instr_rdata_i;
   assign m_c_obi_instr_if.resp_payload.err   = instr_err_i;
   
-  assign data_req_o                          = m_c_obi_data_if.req;
+  assign data_req_o                          = m_c_obi_data_if.s_req.req;
   assign data_we_o                           = m_c_obi_data_if.req_payload.we;
   assign data_be_o                           = m_c_obi_data_if.req_payload.be;
   assign data_addr_o                         = m_c_obi_data_if.req_payload.addr;
@@ -291,8 +291,8 @@ module cv32e40x_core import cv32e40x_pkg::*;
   assign data_prot_o                         = m_c_obi_data_if.req_payload.prot;
   assign data_wdata_o                        = m_c_obi_data_if.req_payload.wdata;
   assign data_atop_o                         = m_c_obi_data_if.req_payload.atop;
-  assign m_c_obi_data_if.gnt                 = data_gnt_i;
-  assign m_c_obi_data_if.rvalid              = data_rvalid_i;
+  assign m_c_obi_data_if.s_gnt.gnt           = data_gnt_i;
+  assign m_c_obi_data_if.s_rvalid.rvalid     = data_rvalid_i;
   assign m_c_obi_data_if.resp_payload.rdata  = data_rdata_i;
   assign m_c_obi_data_if.resp_payload.err    = data_err_i;
   assign m_c_obi_data_if.resp_payload.exokay = data_exokay_i;

--- a/rtl/cv32e40x_data_obi_interface.sv
+++ b/rtl/cv32e40x_data_obi_interface.sv
@@ -64,7 +64,7 @@ module cv32e40x_data_obi_interface import cv32e40x_pkg::*;
   // interface (resp_*). It is assumed that the consumer of the transaction response
   // is always receptive when resp_valid_o = 1 (otherwise a response would get dropped)
 
-  assign resp_valid_o = m_c_obi_data_if.rvalid;
+  assign resp_valid_o = m_c_obi_data_if.s_rvalid.rvalid;
   assign resp_o       = m_c_obi_data_if.resp_payload;
 
   
@@ -75,10 +75,10 @@ module cv32e40x_data_obi_interface import cv32e40x_pkg::*;
 
   // If the incoming transaction itself is stable, then it satisfies the OBI protocol
   // and signals can be passed to/from OBI directly.
-  assign m_c_obi_data_if.req         = trans_valid_i;
+  assign m_c_obi_data_if.s_req.req   = trans_valid_i;
   assign m_c_obi_data_if.req_payload = trans_i;
 
-  assign trans_ready_o = m_c_obi_data_if.gnt;
+  assign trans_ready_o = m_c_obi_data_if.s_gnt.gnt;
 
 
   

--- a/rtl/if_c_obi.sv
+++ b/rtl/if_c_obi.sv
@@ -30,23 +30,23 @@ interface if_c_obi import cv32e40x_pkg::*;
     parameter type RESP_TYPE = obi_inst_resp_t
 );
     // A channel signals
-    logic                      req;
-    logic                      gnt;
+    obi_req_t                  s_req;
+    obi_gnt_t                  s_gnt;
     REQ_TYPE                   req_payload;
     // R channel signals
-    logic                      rvalid;
+    obi_rvalid_t               s_rvalid;
     RESP_TYPE                  resp_payload;
   
     modport master
        (
-       output req, req_payload,
-       input  gnt, rvalid, resp_payload
+       output s_req, req_payload,
+       input  s_gnt, s_rvalid, resp_payload
        );
   
     modport monitor
        (
-       input  req, req_payload,
-              gnt, rvalid, resp_payload
+       input  s_req, req_payload,
+              s_gnt, s_rvalid, resp_payload
        );
 
 endinterface : if_c_obi

--- a/rtl/include/cv32e40x_pkg.sv
+++ b/rtl/include/cv32e40x_pkg.sv
@@ -822,6 +822,18 @@ parameter DATA_ADDR_WIDTH = 32;
 parameter DATA_DATA_WIDTH = 32;
 
 typedef struct packed {
+  logic        req;
+} obi_req_t;
+
+typedef struct packed {
+  logic        gnt;
+} obi_gnt_t;
+
+typedef struct packed {
+  logic        rvalid;
+} obi_rvalid_t;
+
+typedef struct packed {
   logic [INSTR_ADDR_WIDTH-1:0] addr;
   logic [1:0]                  memtype;
   logic [2:0]                  prot;

--- a/sva/cv32e40x_load_store_unit_sva.sv
+++ b/sva/cv32e40x_load_store_unit_sva.sv
@@ -47,7 +47,7 @@ module cv32e40x_load_store_unit_sva
     
   // Check that an rvalid only occurs when there are outstanding transaction(s)
   property p_no_spurious_rvalid;
-        @(posedge clk) (m_c_obi_data_if.rvalid == 1'b1) |-> (cnt_q > 0);
+        @(posedge clk) (m_c_obi_data_if.s_rvalid.rvalid == 1'b1) |-> (cnt_q > 0);
   endproperty
 
   a_no_spurious_rvalid :
@@ -55,7 +55,7 @@ module cv32e40x_load_store_unit_sva
 
   // Check that the address/we/be/atop does not contain X when request is sent
   property p_address_phase_signals_defined;
-      @(posedge clk) (m_c_obi_data_if.req == 1'b1) |-> 
+      @(posedge clk) (m_c_obi_data_if.s_req.req == 1'b1) |->
                      (!($isunknown(m_c_obi_data_if.req_payload.addr) ||
                         $isunknown(m_c_obi_data_if.req_payload.we)   ||
                         $isunknown(m_c_obi_data_if.req_payload.be)   ||


### PR DESCRIPTION
Use structs for internal OBI control signals in preparation for parity bit addition

SEC clean

Signed-off-by: Oivind Ekelund <oivind.ekelund@silabs.com>