### PR TITLE
Removed writeback bypass for branches 

### DIFF
--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -270,7 +270,7 @@ module cv32e40x_wrapper
       .debug_mode     ( core_i.debug_mode                           ),
       .ebrk_force_debug_mode ( core_i.controller_i.controller_fsm_i.ebrk_force_debug_mode ),
 
-      .wb_bypass      ( core_i.ex_stage_i.id_ex_pipe_i.branch_in_ex ),
+      .wb_bypass      ( 1'b0 ), //( core_i.ex_stage_i.id_ex_pipe_i.branch_in_ex ), // TODO: This done to support a simplification for RVFI and has not been verified
 
       .wb_valid       ( core_i.wb_valid                             ),
       .wb_reg_addr    ( core_i.rf_waddr_wb                          ),

--- a/rtl/cv32e40x_ex_stage.sv
+++ b/rtl/cv32e40x_ex_stage.sv
@@ -203,7 +203,7 @@ module cv32e40x_ex_stage import cv32e40x_pkg::*;
   // to finish branches without going to the WB stage, ex_valid does not
   // depend on ex_ready.
   assign ex_ready_o = (alu_ready && mult_ready && lsu_ready_ex_i
-                       && wb_ready_i) || (id_ex_pipe_i.branch_in_ex); //TODO: Check if removing branch_in_ex only causes counters to cex
+                       && wb_ready_i); // || (id_ex_pipe_i.branch_in_ex); // TODO: This is a simplification for RVFI and has not been verified //TODO: Check if removing branch_in_ex only causes counters to cex 
   assign ex_valid_o = (id_ex_pipe_i.alu_en || id_ex_pipe_i.mult_en || id_ex_pipe_i.csr_en || id_ex_pipe_i.data_req)
                        && (alu_ready && mult_ready && lsu_ready_ex_i && wb_ready_i);
 

--- a/sva/cv32e40x_controller_fsm_sva.sv
+++ b/sva/cv32e40x_controller_fsm_sva.sv
@@ -42,12 +42,13 @@ module cv32e40x_controller_fsm_sva
    input       ctrl_state_e ctrl_fsm_ns
    );
 
+  // TODO: This assertion has been removed for a simplification for RVFI and has not been verified
   // make sure that taken branches do not happen back-to-back, as this is not
   // possible without branch prediction in the IF stage
-  a_no_back_to_back_branching :
-    assert property (@(posedge clk)
-                     (branch_taken_ex_i) |=> (~branch_taken_ex_i) )
-      else `uvm_error("controller", "Two branches back-to-back are taken")
+  //a_no_back_to_back_branching :
+  //  assert property (@(posedge clk)
+  //                   (branch_taken_ex_i) |=> (~branch_taken_ex_i) )
+  //    else `uvm_error("controller", "Two branches back-to-back are taken")
 
   // Ensure DBG_TAKEN_IF can only be enterred if in single step mode or woken
   // up from sleep by debug_req_i


### PR DESCRIPTION
Removed writeback bypass for branches to achieve NRET=1 and avoid unnecessary RVFI updates before switching to the new controller.

This change allows modelling the pipeline as if all instructions retire in the writeback stage, which will be the case when the new controller updates are in.  

Signed-off-by: Halfdan Bechmann <halfdan.bechmann@silabs.com>