### PR TITLE
Separate adder and shifter functionality

### DIFF
--- a/rtl/cv32e40x_alu.sv
+++ b/rtl/cv32e40x_alu.sv
@@ -115,11 +115,9 @@ module cv32e40x_alu import cv32e40x_pkg::*;
   ////////////////////////////////////////
 
   logic        shift_left;         // should we shift left
-  logic        shift_use_round;
   logic        shift_arithmetic;
 
-  logic  [4:0] shift_amt;          // amount of shift, to the right
-  logic  [4:0] shift_amt_int;      // amount of shift, used for the actual shifters
+  logic  [4:0] shift_amt;          // amount of shift used for the actual shifter
   logic [31:0] shift_op_a;         // input of the shifter
   logic [31:0] shift_result;
   logic [31:0] shift_right_result;
@@ -132,22 +130,18 @@ module cv32e40x_alu import cv32e40x_pkg::*;
                       (operator_i == ALU_DIV) || (operator_i == ALU_DIVU) ||
                       (operator_i == ALU_REM) || (operator_i == ALU_REMU);
 
-  assign shift_use_round = (operator_i == ALU_ADD) || (operator_i == ALU_SUB);
-
   assign shift_arithmetic = (operator_i == ALU_SRA) ||
                             (operator_i == ALU_ADD) || (operator_i == ALU_SUB);
 
   // choose the bit reversed or the normal input for shift operand a
-  assign shift_op_a    = shift_left ? operand_a_rev :
-                          (shift_use_round ? adder_result : operand_a_i);
-  assign shift_amt_int = shift_use_round ? 5'b0 : shift_amt;
+  assign shift_op_a    = shift_left ? operand_a_rev : operand_a_i;
 
   // right shifts, we let the synthesizer optimize this
   logic [63:0] shift_op_a_32;
 
   assign shift_op_a_32 = $signed({ {32{shift_arithmetic & shift_op_a[31]}}, shift_op_a});
 
-  assign shift_right_result = shift_op_a_32 >> shift_amt_int;
+  assign shift_right_result = shift_op_a_32 >> shift_amt;
 
   // bit reverse the shift_right_result for left shifts
   genvar       j;
@@ -341,9 +335,11 @@ module cv32e40x_alu import cv32e40x_pkg::*;
       ALU_OR:   result_o = operand_a_i | operand_b_i;
       ALU_XOR:  result_o = operand_a_i ^ operand_b_i;
 
-      // Shift Operations
+      // Adder Operations
       ALU_ADD,
-      ALU_SUB,
+      ALU_SUB : result_o = adder_result;
+
+      // Shift Operations
       ALU_SLL,
       ALU_SRL, ALU_SRA:  result_o = shift_result;
 


### PR DESCRIPTION
Don't let adder results flow through shifter. Slightly smaller.
Initial step for the introduction of an improved shifter (including B extension additions)
SEC clean.
Signed-off-by: Arjan Bink <Arjan.Bink@silabs.com>