### PR TITLE
fix tracer printing that deviates from riscv assembly format

### DIFF
--- a/bhv/cv32e40x_instr_trace.svh
+++ b/bhv/cv32e40x_instr_trace.svh
@@ -79,8 +79,6 @@
 
       // use casex instead of case inside due to ModelSim bug
       casex (instr)
-        // Aliases
-        32'h00_00_00_13:   this.printMnemonic("nop");
         // Regular opcodes
         INSTR_LUI:        this.printUInstr("lui");
         INSTR_AUIPC:      this.printUInstr("auipc");
@@ -117,7 +115,7 @@
 
         // FENCE
         INSTR_FENCE:      this.printMnemonic("fence");
-        INSTR_FENCEI:     this.printMnemonic("fencei");
+        INSTR_FENCEI:     this.printMnemonic("fence.i");
         // SYSTEM (CSR manipulation)
         INSTR_CSRRW:      this.printCSRInstr("csrrw");
         INSTR_CSRRS:      this.printCSRInstr("csrrs");
@@ -359,7 +357,7 @@
         mnemonic = {compressed ? "c." : "", mnemonic};
         regs_read.push_back('{rs1, rs1_value, 0});
         regs_write.push_back('{rd, 'x, 0});
-        str = $sformatf("%-16s x%0d, x%0d, 0x%0x", mnemonic, rd, rs1, imm_i_type);
+        str = $sformatf("%-16s x%0d, x%0d, 0x%0x", mnemonic, rd, rs1, 5'(imm_i_type));
       end
     endfunction // printIuInstr
 


### PR DESCRIPTION
I know this tracer is planned to be obsoleted by the rvfi tracer, but in the meantime there are 3 issues that are a bit in my way.
This PR does not necessarily _need_ to be accepted, because one can just use the CV_CORE_PATH variable in core-v-verif, but it would be nice to have the actual fixes in place.

Problem 1 is "nop". This is a pseudo instruction and this is exceptional in the tracer because there are no other pseudoinstructions. And it causes problems when diffing against other execution logs.

Problem 2 is that "fencei" is actually named "fence.i" (as seen in e.g. objdump).

Problem 3 is that "shamt" was printed wrong, because it essentially included "funct7".