### PR TITLE
Changed order of compilation files to avoid errors

### DIFF
--- a/cv32e40x_manifest.flist
+++ b/cv32e40x_manifest.flist
@@ -31,6 +31,7 @@
 ${DESIGN_RTL_DIR}/include/cv32e40x_pkg.sv
 ${DESIGN_RTL_DIR}/if_c_obi.sv
 ${DESIGN_RTL_DIR}/../bhv/include/cv32e40x_tracer_pkg.sv
+${DESIGN_RTL_DIR}/../bhv/cv32e40x_wrapper.sv
 ${DESIGN_RTL_DIR}/cv32e40x_if_stage.sv
 ${DESIGN_RTL_DIR}/cv32e40x_csr.sv
 ${DESIGN_RTL_DIR}/cv32e40x_cs_registers.sv
@@ -65,4 +66,3 @@ ${DESIGN_RTL_DIR}/cv32e40x_mpu.sv
 ${DESIGN_RTL_DIR}/cv32e40x_pma.sv
 ${DESIGN_RTL_DIR}/cv32e40x_pc_target.sv
 ${DESIGN_RTL_DIR}/../bhv/cv32e40x_sim_clock_gate.sv
-${DESIGN_RTL_DIR}/../bhv/cv32e40x_wrapper.sv


### PR DESCRIPTION
Hey!
In this pull request I changed order of compilation files to avoid errors in Riviera-PRO