### PR TITLE
Fix assertion checking idle outputs from sub-decoders upon illegal in…

### DIFF
--- a/rtl/cv32e40x_i_decoder.sv
+++ b/rtl/cv32e40x_i_decoder.sv
@@ -490,8 +490,11 @@ module cv32e40x_i_decoder import cv32e40x_pkg::*;
 
           endcase // case (instr_rdata_i[31:20])
 
-        end
+          if (decoder_ctrl_o.illegal_insn) begin
+            decoder_ctrl_o = DECODER_CTRL_ILLEGAL_INSN;
+          end
 
+        end
       end
 
       default: begin


### PR DESCRIPTION
Fix assertion checking for idle outputs from I sub-decoder upon illegal instruction
SEC clean.

Signed-off-by: Oivind Ekelund <oivind.ekelund@silabs.com>