### PR TITLE
Assertion cleanup

### DIFF
--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -165,12 +165,13 @@ module cv32e40x_wrapper
                 .cs_registers_mcause_q            (core_i.cs_registers_i.mcause_q),
                 .cs_registers_mstatus_q           (core_i.cs_registers_i.mstatus_q),
                 .cs_registers_csr_cause_i         (core_i.cs_registers_i.ctrl_fsm_i.csr_cause),
-                .ex_wb_pipe_i                     (core_i.ex_wb_pipe),
                 .branch_taken_in_ex               (core_i.controller_i.controller_fsm_i.branch_taken_ex),
                 .exc_cause                        (core_i.controller_i.controller_fsm_i.exc_cause),
                 // probed controller signals
                 .ctrl_fsm_ns  (core_i.controller_i.controller_fsm_i.ctrl_fsm_ns),
-                .id_stage_controller_debug_mode_n (core_i.controller_i.controller_fsm_i.debug_mode_n),
+                .ctrl_debug_mode_n                (core_i.controller_i.controller_fsm_i.debug_mode_n),
+                .ctrl_pending_debug               (core_i.controller_i.controller_fsm_i.pending_debug),
+                .ctrl_debug_allowed               (core_i.controller_i.controller_fsm_i.debug_allowed),
                 .id_stage_is_last                 (core_i.id_stage_i.is_last),
                 .id_stage_id_valid                (core_i.id_stage_i.id_valid),
                 .*);
@@ -195,13 +196,15 @@ bind cv32e40x_sleep_unit:
         .PMA_CFG(PMA_CFG))
   mpu_if_sva(.*);
 
+  // TODO: Reintroduce once LSU PMA support has been properly implemented in the controller
+  /*
   bind cv32e40x_mpu:
     core_i.load_store_unit_i.mpu_i
     cv32e40x_mpu_sva
       #(.PMA_NUM_REGIONS(PMA_NUM_REGIONS),
         .PMA_CFG(PMA_CFG))
   mpu_lsu_sva(.*);
-
+  */
 `endif //  `ifndef COREV_ASSERT_OFF
 
 

--- a/rtl/cv32e40x_controller_fsm.sv
+++ b/rtl/cv32e40x_controller_fsm.sv
@@ -471,10 +471,10 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
         single_step_halt_if_n = 1'b0;
         single_step_issue_n   = 1'b0;
 
-        // Kill all stages
-        ctrl_fsm_o.kill_if = 1'b1;
-        ctrl_fsm_o.kill_id = 1'b1;
-        ctrl_fsm_o.kill_ex = 1'b1;
+        // Kill stages
+        ctrl_fsm_o.kill_if = 1'b1; // Needed regardless of single_step, to invalidate alignment_buffer
+        ctrl_fsm_o.kill_id = !debug_single_step_i; // Should not be anything to kill for single step
+        ctrl_fsm_o.kill_ex = !debug_single_step_i; // Should not be anything to kill for single step
         ctrl_fsm_o.kill_wb = !debug_single_step_i; // Do not kill WB for single step
 
         // Set pc

--- a/sva/cv32e40x_div_sva.sv
+++ b/sva/cv32e40x_div_sva.sv
@@ -49,11 +49,14 @@ module cv32e40x_div_sva
 
   // Assert that valid_o is set in the 34th cycle 
   // cycle_count==33 in the 34th cycle because the counter is reset in the cycle after division is accepted.
+  //TODO: This only applies to the 40S, data_ind_timing_i only exists there.
+  //      Keep commented until 40S fork, and then delete from 40X
+  /*
   a_data_ind_timing :
     assert property (@(posedge clk) disable iff (!rst_n)
                      ($rose(valid_o) && data_ind_timing_i |-> cycle_count == 33))
       else `uvm_error("div", "Data independent cycle count failed")
-
+  */
   a_ready_o :  
     assert property (@(posedge clk) disable iff (!rst_n)
                      (valid_o && ready_i |-> ready_o))


### PR DESCRIPTION
Commented away assertions for not yet implemented features.
Fixed mepc and single step assertions.

Minor update to contoller, not killing ID and EX in case of single stepping, as there shall not be any instructions in those stages when the stepped instruction reaches WB.