### PR TITLE
Temporarily disconnected most performance counter events. minstret is non-functional. Non-SEC clean change

### DIFF
--- a/bhv/cv32e40x_rvfi.sv
+++ b/bhv/cv32e40x_rvfi.sv
@@ -427,7 +427,7 @@ module cv32e40x_rvfi
 
   assign wb_valid = wb_valid_i &&
                     !lsu_misaligned_ex_i || // Suppress first misaligned access in wb
-                    illegal_insn_wb_i && is_exception_wb; // Illegal instructions are valid in RVFI (w/trap=1)
+                    illegal_insn_wb_i && is_exception_wb; // Illegal instructions are valid in RVFI (w/trap=1) // todo: use brackets in this expression; also this doesn't take into account ebreak, etc.
 
 
   // Pipeline stage model //
@@ -478,7 +478,7 @@ module cv32e40x_rvfi
       if(instr_id_valid_i) begin
         is_debug_entry_id   <= is_debug_entry_if;
         debug    [STAGE_ID] <= is_debug_entry_id;
-        pc_wdata [STAGE_ID] <= (pc_set_i && is_jump_id) ? jump_target_id_i : pc_id_i + 4;
+        pc_wdata [STAGE_ID] <= (pc_set_i && is_jump_id) ? jump_target_id_i : pc_id_i + 4; // todo: why +4 (how about compressed instructions; why did pc_if_i not work)?
         rs1_addr [STAGE_ID] <= rs1_addr_id_i;
         rs2_addr [STAGE_ID] <= rs2_addr_id_i;
         rs1_rdata[STAGE_ID] <= (rs1_addr_id_i != '0)         ? rs1_rdata_id_i    : '0;
@@ -514,7 +514,7 @@ module cv32e40x_rvfi
         rvfi_dbg        <= debug[STAGE_EX];
         rvfi_pc_rdata   <= pc_wb_i;
         rvfi_insn       <= instr_rdata_wb_i;
-        rvfi_trap       <= illegal_insn_wb_i;
+        rvfi_trap       <= illegal_insn_wb_i; // todo: factor in other trap conditions
 
         rvfi_mem_rdata  <= lsu_rdata_wb_i;
 

--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -201,7 +201,7 @@ module cv32e40x_wrapper
                 .ctrl_debug_mode_n                (core_i.controller_i.controller_fsm_i.debug_mode_n),
                 .ctrl_pending_debug               (core_i.controller_i.controller_fsm_i.pending_debug),
                 .ctrl_debug_allowed               (core_i.controller_i.controller_fsm_i.debug_allowed),
-                .id_stage_is_last                 (core_i.id_stage_i.is_last),
+                .id_stage_multi_cycle_id_stall    (core_i.id_stage_i.multi_cycle_id_stall),
                 .id_stage_id_valid                (core_i.id_stage_i.id_valid),
                 .*);
 
@@ -293,8 +293,8 @@ bind cv32e40x_sleep_unit:
          .branch_target_ex_i       ( core_i.if_stage_i.branch_target_ex_i                                 ),
 
          .lsu_en_wb_i              ( core_i.wb_stage_i.ex_wb_pipe_i.lsu_en                                ),
-         .lsu_addr_ex_i            ( core_i.load_store_unit_i.trans.addr                                  ),
-         .lsu_wdata_ex_i           ( core_i.load_store_unit_i.trans.wdata                                 ),
+         .lsu_addr_ex_i            ( core_i.load_store_unit_i.trans.addr                                  ), // todo: should really use further downstream signals, ideally OBI
+         .lsu_wdata_ex_i           ( core_i.load_store_unit_i.trans.wdata                                 ), // todo: should really use further downstream signals, ideally OBI
          .lsu_misaligned_ex_i      ( core_i.load_store_unit_i.id_ex_pipe_i.lsu_misaligned                 ),
 
          .rd_we_wb_i               ( core_i.wb_stage_i.rf_we_wb_o                                         ),

--- a/rtl/cv32e40x_core.sv
+++ b/rtl/cv32e40x_core.sv
@@ -207,21 +207,6 @@ module cv32e40x_core import cv32e40x_pkg::*;
   // trigger match detected in cs_registers (using ID timing)
   logic        debug_trigger_match_id;
 
-  // Performance Counters
-  // Currently from ID
-  // TODO:OK: perf counter events should be moved to the controller, leaving as is for now
-  logic        mhpmevent_minstret;
-  logic        mhpmevent_load;
-  logic        mhpmevent_store;
-  logic        mhpmevent_jump;
-  logic        mhpmevent_branch;
-  logic        mhpmevent_branch_taken;
-  logic        mhpmevent_compressed;
-  logic        mhpmevent_jr_stall;
-  logic        mhpmevent_imiss;
-  logic        mhpmevent_ld_stall;
-  logic        perf_imiss;
-
   // WB is writing back a LSU result
   logic        lsu_en_wb;
 
@@ -350,6 +335,8 @@ module cv32e40x_core import cv32e40x_pkg::*;
 
     .ex_wb_pipe_i        ( ex_wb_pipe                ),
     
+    .ctrl_fsm_i          ( ctrl_fsm                  ),
+
     .mepc_i              ( mepc                      ), // exception return address
 
     .dpc_i               ( dpc                       ), // debug return address
@@ -362,16 +349,12 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .jump_target_id_i    ( jump_target_id            ),
     .branch_target_ex_i  ( branch_target_ex          ),
 
-    // pipeline stalls
-    .id_ready_i          ( id_ready                  ),
+    .if_busy_o           ( if_busy                   ),
 
+    // Pipeline handshakes
     .if_valid_o          ( if_valid                  ),
     .if_ready_o          ( if_ready                  ),
-
-    .if_busy_o           ( if_busy                   ),
-    .perf_imiss_o        ( perf_imiss                ),
-
-    .ctrl_fsm_i          ( ctrl_fsm                  )
+    .id_ready_i          ( id_ready                  )
   );
 
 
@@ -396,12 +379,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .rst_n                        ( rst_ni                    ),
 
     // Jumps and branches
-    .branch_decision_i            ( branch_decision_ex        ),
     .jmp_target_o                 ( jump_target_id            ),
-
-    // IF and ID control signals
-    .id_ready_o                   ( id_ready                  ),
-    .ex_ready_i                   ( ex_ready                  ),
 
     // IF/ID pipeline
     .if_id_pipe_i                 ( if_id_pipe                ),
@@ -428,20 +406,6 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .rf_wdata_ex_i                ( rf_wdata_ex               ),
     .rf_wdata_wb_i                ( rf_wdata_wb               ),
 
-    // Performance Counters
-    .mhpmevent_minstret_o         ( mhpmevent_minstret        ),
-    .mhpmevent_load_o             ( mhpmevent_load            ),
-    .mhpmevent_store_o            ( mhpmevent_store           ),
-    .mhpmevent_jump_o             ( mhpmevent_jump            ),
-    .mhpmevent_branch_o           ( mhpmevent_branch          ),
-    .mhpmevent_branch_taken_o     ( mhpmevent_branch_taken    ),
-    .mhpmevent_compressed_o       ( mhpmevent_compressed      ),
-    .mhpmevent_jr_stall_o         ( mhpmevent_jr_stall        ),
-    .mhpmevent_imiss_o            ( mhpmevent_imiss           ),
-    .mhpmevent_ld_stall_o         ( mhpmevent_ld_stall        ),
-
-    .perf_imiss_i                 ( perf_imiss                ),
-
     .lsu_en_wb_i                  ( lsu_en_wb                 ),
 
     .mret_insn_o                  ( mret_insn_id              ),
@@ -458,7 +422,11 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .rf_waddr_o                   ( rf_waddr_id               ),
 
     .regfile_alu_we_id_o          ( regfile_alu_we_id         ),
-    .regfile_rdata_i              ( regfile_rdata_id          )
+    .regfile_rdata_i              ( regfile_rdata_id          ),
+
+    // Pipeline handshakes
+    .id_ready_o                   ( id_ready                  ),
+    .ex_ready_i                   ( ex_ready                  )
   );
 
 
@@ -660,18 +628,6 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .priv_lvl_o                 ( current_priv_lvl       ),
 
     .pc_if_i                    ( pc_if                  ),
-
-    // performance counter related signals
-    .mhpmevent_minstret_i       ( mhpmevent_minstret     ),
-    .mhpmevent_load_i           ( mhpmevent_load         ),
-    .mhpmevent_store_i          ( mhpmevent_store        ),
-    .mhpmevent_jump_i           ( mhpmevent_jump         ),
-    .mhpmevent_branch_i         ( mhpmevent_branch       ),
-    .mhpmevent_branch_taken_i   ( mhpmevent_branch_taken ),
-    .mhpmevent_compressed_i     ( mhpmevent_compressed   ),
-    .mhpmevent_jr_stall_i       ( mhpmevent_jr_stall     ),
-    .mhpmevent_imiss_i          ( mhpmevent_imiss        ),
-    .mhpmevent_ld_stall_i       ( mhpmevent_ld_stall     ),
 
     // Handshakes
     .valid_i                    ( csr_valid_ex           ),

--- a/rtl/cv32e40x_cs_registers.sv
+++ b/rtl/cv32e40x_cs_registers.sv
@@ -81,18 +81,6 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
 
   input  logic [31:0]     pc_if_i,
 
-  // Performance Counters
-  input  logic            mhpmevent_minstret_i,
-  input  logic            mhpmevent_load_i,
-  input  logic            mhpmevent_store_i,
-  input  logic            mhpmevent_jump_i,                // Jump instruction retired (j, jr, jal, jalr)
-  input  logic            mhpmevent_branch_i,              // Branch instruction retired (beq, bne, etc.)
-  input  logic            mhpmevent_branch_taken_i,        // Branch instruction taken
-  input  logic            mhpmevent_compressed_i,
-  input  logic            mhpmevent_jr_stall_i,
-  input  logic            mhpmevent_imiss_i,
-  input  logic            mhpmevent_ld_stall_i,
-
   // Handshakes
   input  logic            valid_i,
   output logic            ready_o,
@@ -770,19 +758,21 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
   //                                                             //
   /////////////////////////////////////////////////////////////////
 
+  // todo: decide on whether events need to be registered first (to break critical timing paths)
+
   // ------------------------
   // Events to count
-  assign hpm_events[0]  = 1'b1;                                          // cycle counter
-  assign hpm_events[1]  = mhpmevent_minstret_i;                          // instruction counter
-  assign hpm_events[2]  = mhpmevent_ld_stall_i;                          // nr of load use hazards
-  assign hpm_events[3]  = mhpmevent_jr_stall_i;                          // nr of jump register hazards
-  assign hpm_events[4]  = mhpmevent_imiss_i;                             // cycles waiting for instruction fetches, excluding jumps and branches
-  assign hpm_events[5]  = mhpmevent_load_i;                              // nr of loads
-  assign hpm_events[6]  = mhpmevent_store_i;                             // nr of stores
-  assign hpm_events[7]  = mhpmevent_jump_i;                              // nr of jumps (unconditional)
-  assign hpm_events[8]  = mhpmevent_branch_i;                            // nr of branches (conditional)
-  assign hpm_events[9]  = mhpmevent_branch_taken_i;                      // nr of taken branches (conditional)
-  assign hpm_events[10] = mhpmevent_compressed_i;                        // compressed instruction counter
+  assign hpm_events[0]  = 1'b1;                                                 // Cycle counter
+  assign hpm_events[1]  = ctrl_fsm_i.mhpmevent.minstret;                        // Instruction counter
+  assign hpm_events[2]  = ctrl_fsm_i.mhpmevent.ld_stall;                        // Nr of load use hazards
+  assign hpm_events[3]  = ctrl_fsm_i.mhpmevent.jr_stall;                        // Nr of jump register hazards
+  assign hpm_events[4]  = ctrl_fsm_i.mhpmevent.imiss;                           // Cycles waiting for instruction fetches, excluding jumps and branches
+  assign hpm_events[5]  = ctrl_fsm_i.mhpmevent.load;                            // Nr of loads
+  assign hpm_events[6]  = ctrl_fsm_i.mhpmevent.store;                           // Nr of stores
+  assign hpm_events[7]  = ctrl_fsm_i.mhpmevent.jump;                            // Nr of jumps (unconditional)
+  assign hpm_events[8]  = ctrl_fsm_i.mhpmevent.branch;                          // Nr of branches (conditional)
+  assign hpm_events[9]  = ctrl_fsm_i.mhpmevent.branch_taken;                    // Nr of taken branches (conditional)
+  assign hpm_events[10] = ctrl_fsm_i.mhpmevent.compressed;                      // Compressed instruction counter
   assign hpm_events[11] = 1'b0;
   assign hpm_events[12] = 1'b0;
   assign hpm_events[13] = 1'b0;
@@ -966,7 +956,7 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
   endgenerate
 
   // No multicycle operations in the CSR. Valid/ready are passed through.
-  assign valid_o = valid_i;
+  assign valid_o = valid_i; // todo: not consistent with MUL/DIV
   assign ready_o = ready_i;
 
 endmodule

--- a/rtl/cv32e40x_ex_stage.sv
+++ b/rtl/cv32e40x_ex_stage.sv
@@ -342,6 +342,9 @@ module cv32e40x_ex_stage import cv32e40x_pkg::*;
   // As valid always goes to the right and ready to the left, and we are able
   // to finish branches without going to the WB stage, ex_valid does not
   // depend on ex_ready.
+
+// todo: wb_ready_i should already be factored into the other ready signals now
+
   assign ex_ready_o = ctrl_fsm_i.kill_ex || (alu_ready && mul_ready && div_ready && csr_ready_i && lsu_ready_i && wb_ready_i && !ctrl_fsm_i.halt_ex); // || (id_ex_pipe_i.branch_in_ex); // TODO: This is a simplification for RVFI and has not been verified //TODO: Check if removing branch_in_ex only causes counters to cex 
 
   // TODO: Reconsider setting alu_en for exception/trigger instead of using 'previous_exception'

--- a/rtl/cv32e40x_wb_stage.sv
+++ b/rtl/cv32e40x_wb_stage.sv
@@ -54,7 +54,7 @@ module cv32e40x_wb_stage import cv32e40x_pkg::*;
   output logic [31:0]   rf_wdata_wb_o,  // Register file write data
 
   // LSU handshake interface
-  input  logic          lsu_valid_i,    // Not used on purpose
+  input  logic          lsu_valid_i,
   output logic          lsu_ready_o,
   output logic          lsu_valid_o,
   input  logic          lsu_ready_i,
@@ -65,7 +65,7 @@ module cv32e40x_wb_stage import cv32e40x_pkg::*;
 
   logic                 instr_valid;
   logic                 wb_valid;       // Only used by RVFI
-  logic                 lsu_en_gated;    // LSU enabled gated with all disqualifiers
+  logic                 lsu_en_gated;   // LSU enabled gated with all disqualifiers
 
   assign instr_valid = ex_wb_pipe_i.instr_valid && !ctrl_fsm_i.kill_wb && !ctrl_fsm_i.halt_wb;
 
@@ -110,8 +110,11 @@ module cv32e40x_wb_stage import cv32e40x_pkg::*;
   // todo: Want the following expression, but currently not SEC clean; might just be caused by fact that OBI assumes are not loaded during SEC
   //  assign wb_ready_o = ctrl_fsm_i.kill_wb || (lsu_ready_i && !ctrl_fsm_i.halt_wb);
 
+// todo: document how wb_valid will behave for synchronous exceptions, i.e. wb_valid will be 1 (this is for easier interfacing with RVFI)
+// wb_valid will be 0 for interrupted instructions, debug entry, etc.
+
   assign wb_valid = ((!ex_wb_pipe_i.lsu_en && 1'b1) ||          // Non-LSU instructions always have valid result in WB
                      ( ex_wb_pipe_i.lsu_en && lsu_valid_i)      // LSU instructions have valid result based on data_rvalid_i
-                    ) && instr_valid;
+                    ) && instr_valid; // todo: for misaligned load/store only signal valid during 2nd phase, factor this into lsu_valid_i in the LSU
   
 endmodule // cv32e40x_wb_stage

--- a/rtl/include/cv32e40x_pkg.sv
+++ b/rtl/include/cv32e40x_pkg.sv
@@ -998,6 +998,20 @@ typedef struct packed {
   logic         dret_insn; // TODO:OK: May be removed if dret is handled by the pipeline and not the controller
 } ex_wb_pipe_t;
 
+// Performance counter events
+typedef struct packed {
+  logic                              minstret;
+  logic                              load;
+  logic                              store;
+  logic                              jump;
+  logic                              branch;
+  logic                              branch_taken;
+  logic                              compressed;
+  logic                              jr_stall;
+  logic                              imiss;
+  logic                              ld_stall;
+} mhpmevent_t;
+
 // Controller Bypass outputs
 typedef struct packed {
   op_fw_mux_e  operand_a_fw_mux_sel;  // Operand A forward mux sel
@@ -1049,6 +1063,9 @@ typedef struct packed {
   logic        csr_restore_dret; // Restore CSR due to dret
   logic        csr_save_cause;      // Update CSRs
 
+  // Performance counter events
+  mhpmevent_t  mhpmevent;
+
   // Halt signals
   logic        halt_if; // Halt IF stage
   logic        halt_id; // Halt ID stage
@@ -1061,8 +1078,7 @@ typedef struct packed {
   logic        kill_ex; // Kill EX stage
   logic        kill_wb; // Kill WB stage
 } ctrl_fsm_t;
-  
-  
+
   ///////////////////////////
   //                       //
   //    /\/\ (_)___  ___   //
@@ -1075,11 +1091,6 @@ typedef struct packed {
   // OBI interface FSM state encoding
   typedef enum logic {TRANSPARENT, REGISTERED} obi_if_state_e;
 
-  
   // Enum used for configuration of B extension
   typedef enum logic [1:0] {NONE, ZBA_ZBB_ZBS, ZBA_ZBB_ZBC_ZBS} b_ext_e;
-
-
-  
-
 endpackage


### PR DESCRIPTION
Not SEC clean (on purpose)
Performance counter events are mostly tied to 0.
minstret is NOT functional yet (but was already broken)

Signed-off-by: Arjan Bink <Arjan.Bink@silabs.com>