### PR TITLE
Removed the signal csr_access.

### DIFF
--- a/rtl/cv32e40x_ex_stage.sv
+++ b/rtl/cv32e40x_ex_stage.sv
@@ -280,7 +280,6 @@ module cv32e40x_ex_stage import cv32e40x_pkg::*;
       ex_wb_pipe_o.lsu_en         <= 1'b0;
       ex_wb_pipe_o.lsu_mpu_status <= MPU_OK;
       ex_wb_pipe_o.csr_en         <= 1'b0;
-      ex_wb_pipe_o.csr_access     <= 1'b0;
       ex_wb_pipe_o.csr_op         <= CSR_OP_READ;
       ex_wb_pipe_o.csr_addr       <= 12'h000;
       ex_wb_pipe_o.csr_wdata      <= 32'h00000000;
@@ -302,7 +301,6 @@ module cv32e40x_ex_stage import cv32e40x_pkg::*;
 
         // Update signals for CSR access in WB
         ex_wb_pipe_o.csr_en     <= id_ex_pipe_i.csr_en;
-        ex_wb_pipe_o.csr_access <= id_ex_pipe_i.csr_access; // TODO:OK: May revert to using only csr_en with the new instr_valid qualifier?
         ex_wb_pipe_o.csr_op     <= id_ex_pipe_i.csr_op; // todo: why can csr_op not be in below if-body?
         if (id_ex_pipe_i.csr_en) begin
           ex_wb_pipe_o.csr_addr  <= id_ex_pipe_i.alu_operand_b[11:0];

--- a/rtl/cv32e40x_id_stage.sv
+++ b/rtl/cv32e40x_id_stage.sv
@@ -471,7 +471,6 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
       id_ex_pipe_o.rf_we                  <= 1'b0;
       id_ex_pipe_o.rf_waddr               <= '0;
 
-      id_ex_pipe_o.csr_access             <= 1'b0;
       id_ex_pipe_o.csr_en                 <= 1'b0;
       id_ex_pipe_o.csr_op                 <= CSR_OP_READ;
 
@@ -550,7 +549,6 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
             id_ex_pipe_o.rf_waddr             <= rf_waddr_o;
           end
 
-          id_ex_pipe_o.csr_access             <= csr_en;
           id_ex_pipe_o.csr_en                 <= csr_en;
           id_ex_pipe_o.csr_op                 <= csr_op;
 
@@ -601,11 +599,6 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
         // so we set all instr_valid to 0 (stage will use this to locally gate *enables)
         id_ex_pipe_o.instr_valid            <= 1'b0;
         
-      end else if (id_ex_pipe_o.csr_access) begin // TODO: We should get rid of this special case
-       //In the EX stage there was a CSR access. To avoid multiple
-       //writes to the RF, disable csr_access (cs_registers will keep it's rdata as it was when csr_access was 1'b1).
-       //Not doing it can overwrite the RF file with the currennt CSR value rather than the old one
-       id_ex_pipe_o.csr_access              <= 1'b0;
       end
     end
   end

--- a/rtl/include/cv32e40x_pkg.sv
+++ b/rtl/include/cv32e40x_pkg.sv
@@ -932,7 +932,6 @@ typedef struct packed {
 
   // CSR
   logic         csr_en;
-  logic         csr_access;
   csr_opcode_e  csr_op;
 
   // LSU
@@ -973,7 +972,6 @@ typedef struct packed {
 
   // CSR
   logic         csr_en;
-  logic         csr_access;
   csr_opcode_e  csr_op;
   logic [11:0]  csr_addr;
   logic [31:0]  csr_wdata;

--- a/sva/cv32e40x_cs_registers_sva.sv
+++ b/sva/cv32e40x_cs_registers_sva.sv
@@ -33,22 +33,6 @@ module cv32e40x_cs_registers_sva
    input logic [31:0] csr_rdata_o
    );
 
-   // Store last valid rdata output
-   logic [31:0] csr_rdata_last;
 
-   always_ff @(posedge clk or negedge rst_n) begin
-    if (!rst_n) begin
-      csr_rdata_last <= 32'h0;
-    end else if (id_ex_pipe_i.csr_access) begin
-      csr_rdata_last <= csr_rdata_o;
-    end
-  end
-
-
-  // Check that read data is stable when csr_access is low
-  a_stable_rdata: assert property (@(posedge clk) disable iff (!rst_n)
-                                  (!id_ex_pipe_i.csr_access) |-> (csr_rdata_o == csr_rdata_last))
-
-    else `uvm_error("cs_registers", "csr_rdata_o not stable while csr_access is low")
 endmodule // cv32e40x_cs_registers_sva
 


### PR DESCRIPTION
CSR will be read for every cycle a CSR insn is in EX.
Using ex_wb_pipe.rf_wdata in CSR read-modify-write, as this was
using the flopped rdata which does not exist anymore (and was wrong).

Purposely not SEC clean.
Passes ci_check (with ISS disabled)

Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>