### PR TITLE
Moved autonomously updated registers to EX stage

### DIFF
--- a/bhv/cv32e40x_rvfi.sv
+++ b/bhv/cv32e40x_rvfi.sv
@@ -86,11 +86,12 @@ module cv32e40x_rvfi
    input logic [31:0]                         mepc_target_wb_i,
 
    //// CSR Probes ////
-   input                                      csr_num_e csr_raddr_i,
    input                                      Status_t csr_mstatus_n_i,
    input                                      Status_t csr_mstatus_q_i,
    input logic                                csr_mstatus_we_i,
-   input logic [31:0]                         csr_misa_i,
+   input logic [31:0]                         csr_misa_n_i,
+   input logic [31:0]                         csr_misa_q_i,
+   input logic                                csr_misa_we_i,
    input logic [31:0]                         csr_mie_n_i,
    input logic [31:0]                         csr_mie_q_i,
    input logic                                csr_mie_we_i,
@@ -112,14 +113,18 @@ module cv32e40x_rvfi
    input                                      Mcause_t csr_mcause_n_i,
    input                                      Mcause_t csr_mcause_q_i,
    input logic                                csr_mcause_we_i,
-   input logic [31:0]                         csr_mip_i,
+   input logic [31:0]                         csr_mip_n_i,
+   input logic [31:0]                         csr_mip_q_i,
+   input logic                                csr_mip_we_i,
    input logic [31:0]                         csr_tdata1_n_i,
    input logic [31:0]                         csr_tdata1_q_i,
    input logic                                csr_tdata1_we_i,
    input logic [31:0]                         csr_tdata2_n_i,
    input logic [31:0]                         csr_tdata2_q_i,
    input logic                                csr_tdata2_we_i,
-   input logic [15:0]                         csr_tinfo_i,
+   input logic [31:0]                         csr_tinfo_n_i,
+   input logic [31:0]                         csr_tinfo_q_i,
+   input logic                                csr_tinfo_we_i,
    input                                      Dcsr_t csr_dcsr_n_i,
    input                                      Dcsr_t csr_dcsr_q_i,
    input logic                                csr_dcsr_we_i,
@@ -137,7 +142,9 @@ module cv32e40x_rvfi
    // performance counters
    //  cycle,  instret,  hpcounter,  cycleh,  instreth,  hpcounterh
    // mcycle, minstret, mhpcounter, mcycleh, minstreth, mhpcounterh
+   input logic [31:0] [MHPMCOUNTER_WIDTH-1:0] csr_mhpmcounter_n_i,
    input logic [31:0] [MHPMCOUNTER_WIDTH-1:0] csr_mhpmcounter_q_i,
+   input logic [31:0] [MHPMCOUNTER_WORDS-1:0] csr_mhpmcounter_we_i,
 
    input logic [31:0]                         csr_mvendorid_i,
    input logic [31:0]                         csr_marchid_i,
@@ -339,21 +346,26 @@ module cv32e40x_rvfi
 
   // CSR inputs in struct format
   rvfi_csr_map_t rvfi_csr_rdata_d;
-  rvfi_csr_map_t rvfi_csr_rmask_d;
   rvfi_csr_map_t rvfi_csr_wdata_d;
   rvfi_csr_map_t rvfi_csr_wmask_d;
 
   rvfi_csr_map_t rvfi_csr_rdata;
-  rvfi_csr_map_t rvfi_csr_rmask;
   rvfi_csr_map_t rvfi_csr_wdata;
   rvfi_csr_map_t rvfi_csr_wmask;
 
+  // Reads from autonomous registers propagate from EX stage
+  rvfi_auto_csr_map_t ex_csr_rdata;
+  rvfi_auto_csr_map_t ex_csr_rdata_d;
+
+  logic [31:0][31:0] csr_mhpmcounter_n_l;
+  logic [31:0][31:0] csr_mhpmcounter_n_h;
   logic [31:0][31:0] csr_mhpmcounter_q_l;
   logic [31:0][31:0] csr_mhpmcounter_q_h;
+  logic [31:0][31:0] csr_mhpmcounter_we_l;
+  logic [31:0][31:0] csr_mhpmcounter_we_h;
 
   logic [63:0] lsu_wdata_ror; // Intermediate rotate signal, as direct part-select not supported in all tools
 
-  logic         wb_valid;
   logic         intr_d;
 
   logic         is_debug_entry_if;
@@ -428,8 +440,6 @@ module cv32e40x_rvfi
                   ((rvfi_order - instr_q.order) == 1) && // Is latest instruction
                   (rvfi_pc_rdata != instr_q.pc_wdata);   // Is first part of trap handler
 
-  assign wb_valid = wb_valid_i;
-
 
   // Pipeline stage model //
 
@@ -446,6 +456,7 @@ module cv32e40x_rvfi
       mem_wmask          <= '0;
       ex_mem_addr        <= '0;
       ex_mem_wdata       <= '0;
+      ex_csr_rdata  <= '0;
 
       is_exception_wb_q  <= 1'b0;
       is_exception_wb_qq <= 1'b0;
@@ -460,7 +471,6 @@ module cv32e40x_rvfi
       rvfi_rd_addr       <= '0;
       rvfi_rd_wdata      <= '0;
       rvfi_csr_rdata     <= '0;
-      rvfi_csr_rmask     <= '0;
       rvfi_csr_wdata     <= '0;
       rvfi_csr_wmask     <= '0;
       rvfi_rs1_addr      <= '0;
@@ -505,12 +515,16 @@ module cv32e40x_rvfi
         // Keep values when misaligned
         ex_mem_addr         <= (lsu_misaligned_ex_i) ? ex_mem_addr  : rvfi_mem_addr_d;
         ex_mem_wdata        <= (lsu_misaligned_ex_i) ? ex_mem_wdata : rvfi_mem_wdata_d;
+
+        // Read autonomuos CSRs from EX perspective
+        ex_csr_rdata        <= ex_csr_rdata_d;
+
       end
 
 
       //// WB Stage ////
-      rvfi_valid      <= wb_valid;
-      if (wb_valid) begin
+      rvfi_valid      <= wb_valid_i;
+      if (wb_valid_i) begin
         rvfi_order      <= rvfi_order + 64'b1;
         rvfi_dbg        <= debug[STAGE_EX];
         rvfi_pc_rdata   <= pc_wb_i;
@@ -522,9 +536,8 @@ module cv32e40x_rvfi
         rvfi_rd_addr    <= rvfi_rd_addr_d;
         rvfi_rd_wdata   <= rvfi_rd_wdata_d;
 
-        // Store CSRs
+        // Read/Write CSRs
         rvfi_csr_rdata  <= rvfi_csr_rdata_d;
-        rvfi_csr_rmask  <= rvfi_csr_rmask_d;
         rvfi_csr_wdata  <= rvfi_csr_wdata_d;
         rvfi_csr_wmask  <= rvfi_csr_wmask_d;
 
@@ -558,7 +571,7 @@ module cv32e40x_rvfi
         is_exception_wb_qq <= is_exception_wb_q;
         rvfi_csr_wmask.mstatus <= '0;
       end else if (is_exception_wb_qq) begin
-        if (wb_valid || insn_mret_wb_i || (lsu_rvalid_wb_i && lsu_en_wb_i)) begin
+        if (wb_valid_i || insn_mret_wb_i || (lsu_rvalid_wb_i && lsu_en_wb_i)) begin
           is_exception_wb_qq <= 1'b0;
           rvfi_csr_wdata.mstatus <= csr_mstatus_q_i; // Take value already stored in mstatus
           rvfi_csr_wmask.mstatus <= '1;
@@ -606,372 +619,343 @@ module cv32e40x_rvfi
   ////////////////////////////////
 
   // Machine trap setup
-  assign rvfi_csr_wdata_d.mstatus            = csr_mstatus_n_i;
-  assign rvfi_csr_wmask_d.mstatus            = (csr_mstatus_we_i) ? '1 : '0;
   assign rvfi_csr_rdata_d.mstatus            = csr_mstatus_q_i;
-  assign rvfi_csr_rmask_d.mstatus            = '1;
+  assign rvfi_csr_wdata_d.mstatus            = csr_mstatus_n_i;
+  assign rvfi_csr_wmask_d.mstatus            = csr_mstatus_we_i ? '1 : '0;
 
-  assign rvfi_csr_wdata_d.misa               = csr_misa_i; // WARL
-  assign rvfi_csr_wmask_d.misa               = (csr_raddr_i == CSR_MISA) ? '1 : '0;
-  assign rvfi_csr_rdata_d.misa               = csr_misa_i;
-  assign rvfi_csr_rmask_d.misa               = '1;
+  assign rvfi_csr_rdata_d.misa               = csr_misa_n_i;
+  assign rvfi_csr_wdata_d.misa               = csr_misa_q_i;
+  assign rvfi_csr_wmask_d.misa               = csr_misa_we_i    ? '1 : '0;
 
-  assign rvfi_csr_wdata_d.mie                = csr_mie_n_i;
-  assign rvfi_csr_wmask_d.mie                = (csr_mie_we_i) ? '1 : '0;
   assign rvfi_csr_rdata_d.mie                = csr_mie_q_i;
-  assign rvfi_csr_rmask_d.mie                = '1;
+  assign rvfi_csr_wdata_d.mie                = csr_mie_n_i;
+  assign rvfi_csr_wmask_d.mie                = csr_mie_we_i     ? '1 : '0;
 
-  assign rvfi_csr_wdata_d.mtvec              = csr_mtvec_n_i;
-  assign rvfi_csr_wmask_d.mtvec              = (csr_mtvec_we_i) ? '1 : '0;
   assign rvfi_csr_rdata_d.mtvec              = csr_mtvec_q_i;
-  assign rvfi_csr_rmask_d.mtvec              = '1;
+  assign rvfi_csr_wdata_d.mtvec              = csr_mtvec_n_i;
+  assign rvfi_csr_wmask_d.mtvec              = csr_mtvec_we_i   ? '1 : '0;
 
   // Performance counters
+  assign rvfi_csr_rdata_d.mcountinhibit      = csr_mcountinhibit_q_i;
   assign rvfi_csr_wdata_d.mcountinhibit      = csr_mcountinhibit_n_i;
   assign rvfi_csr_wmask_d.mcountinhibit      = csr_mcountinhibit_we_i ? '1 : '0;
-  assign rvfi_csr_rdata_d.mcountinhibit      = csr_mcountinhibit_q_i;
-  assign rvfi_csr_rmask_d.mcountinhibit      = '1;
 
+  assign rvfi_csr_rdata_d.mhpmevent          = csr_mhpmevent_q_i;
   assign rvfi_csr_wdata_d.mhpmevent          = csr_mhpmevent_n_i;
   assign rvfi_csr_mhpmevent_wmask[2:0]       = '0; // No mhpevent0-2 registers
   assign rvfi_csr_mhpmevent_wmask[31:3]      = csr_mhpmevent_we_i ? '1 : '0;
-  assign rvfi_csr_rdata_d.mhpmevent          = csr_mhpmevent_q_i;
-  assign rvfi_csr_mhpmevent_rmask[2:0]       = '0; // No mhpevent0-2 registers
-  assign rvfi_csr_mhpmevent_rmask[31:3]      = '1;
 
   // Machine trap handling
+  assign rvfi_csr_rdata_d.mscratch           = csr_mscratch_q_i;
   assign rvfi_csr_wdata_d.mscratch           = csr_mscratch_n_i;
   assign rvfi_csr_wmask_d.mscratch           = csr_mscratch_we_i ? '1 : '0;
-  assign rvfi_csr_rdata_d.mscratch           = csr_mscratch_q_i;
-  assign rvfi_csr_rmask_d.mscratch           = '1;
 
+  assign rvfi_csr_rdata_d.mepc               = csr_mepc_q_i;
   assign rvfi_csr_wdata_d.mepc               = csr_mepc_n_i;
   assign rvfi_csr_wmask_d.mepc               = csr_mepc_we_i ? '1 : '0;
-  assign rvfi_csr_rdata_d.mepc               = csr_mepc_q_i;
-  assign rvfi_csr_rmask_d.mepc               = '1;
 
+  assign rvfi_csr_rdata_d.mcause             = csr_mcause_q_i;
   assign rvfi_csr_wdata_d.mcause             = csr_mcause_n_i;
   assign rvfi_csr_wmask_d.mcause             = csr_mcause_we_i ? '1 : '0;
-  assign rvfi_csr_rdata_d.mcause             = csr_mcause_q_i;
-  assign rvfi_csr_rmask_d.mcause             = '1;
 
+  assign rvfi_csr_rdata_d.mtval              = '0;
   assign rvfi_csr_wdata_d.mtval              = '0; // Not implemented, read 0
   assign rvfi_csr_wmask_d.mtval              = '0;
-  assign rvfi_csr_rdata_d.mtval              = '0;
-  assign rvfi_csr_rmask_d.mtval              = '1;
 
-  assign rvfi_csr_wdata_d.mip                = csr_mip_i;
-  assign rvfi_csr_wmask_d.mip                = '1;
-  assign rvfi_csr_rdata_d.mip                = csr_mip_i;
-  assign rvfi_csr_rmask_d.mip                = '1;
+  assign ex_csr_rdata_d.mip                  = csr_mip_q_i;
+  assign rvfi_csr_rdata_d.mip                = ex_csr_rdata.mip;
+  assign rvfi_csr_wdata_d.mip                = csr_mip_n_i;
+  assign rvfi_csr_wmask_d.mip                = csr_mip_we_i ? '1 : '0;
 
   // Trigger
+  assign rvfi_csr_rdata_d.tselect            = '0;
   assign rvfi_csr_wdata_d.tselect            = '0; // Not implemented, read 0
   assign rvfi_csr_wmask_d.tselect            = '0;
-  assign rvfi_csr_rdata_d.tselect            = '0;
-  assign rvfi_csr_rmask_d.tselect            = '1;
 
+  assign rvfi_csr_rdata_d.tdata[0]           = 'Z;
   assign rvfi_csr_wdata_d.tdata[0]           = 'Z; // Does not exist
   assign rvfi_csr_wmask_d.tdata[0]           = '0;
-  assign rvfi_csr_rdata_d.tdata[0]           = 'Z;
-  assign rvfi_csr_rmask_d.tdata[0]           = '0;
 
+  assign rvfi_csr_rdata_d.tdata[1]           = csr_tdata1_q_i;
   assign rvfi_csr_wdata_d.tdata[1]           = csr_tdata1_n_i;
   assign rvfi_csr_wmask_d.tdata[1]           = csr_tdata1_we_i ? '1 : '0;
-  assign rvfi_csr_rdata_d.tdata[1]           = csr_tdata1_q_i;
-  assign rvfi_csr_rmask_d.tdata[1]           = '1;
 
+  assign rvfi_csr_rdata_d.tdata[2]           = csr_tdata2_q_i;
   assign rvfi_csr_wdata_d.tdata[2]           = csr_tdata2_n_i;
   assign rvfi_csr_wmask_d.tdata[2]           = csr_tdata2_we_i ? '1 : '0;
-  assign rvfi_csr_rdata_d.tdata[2]           = csr_tdata2_q_i;
-  assign rvfi_csr_rmask_d.tdata[2]           = '1;
 
+  assign rvfi_csr_rdata_d.tdata[3]           = '0;
   assign rvfi_csr_wdata_d.tdata[3]           = '0; // Not implemented, read 0
   assign rvfi_csr_wmask_d.tdata[3]           = '0;
-  assign rvfi_csr_rdata_d.tdata[3]           = '0;
-  assign rvfi_csr_rmask_d.tdata[3]           = '1;
 
-  assign rvfi_csr_wdata_d.tinfo              = '0; // Read Only
-  assign rvfi_csr_wmask_d.tinfo              = '0;
-  assign rvfi_csr_rdata_d.tinfo              = {16'h0, csr_tinfo_i};
-  assign rvfi_csr_rmask_d.tinfo              = '1;
+  assign rvfi_csr_rdata_d.tinfo              = csr_tinfo_n_i;
+  assign rvfi_csr_wdata_d.tinfo              = csr_tinfo_q_i;
+  assign rvfi_csr_wmask_d.tinfo              = csr_tinfo_we_i;
 
+  assign rvfi_csr_rdata_d.mcontext           = '0;
   assign rvfi_csr_wdata_d.mcontext           = '0; // Not implemented, read 0
   assign rvfi_csr_wmask_d.mcontext           = '0;
-  assign rvfi_csr_rdata_d.mcontext           = '0;
-  assign rvfi_csr_rmask_d.mcontext           = '1;
 
+  assign rvfi_csr_rdata_d.scontext           = '0;
   assign rvfi_csr_wdata_d.scontext           = '0; // Not implemented, read 0
   assign rvfi_csr_wmask_d.scontext           = '0;
-  assign rvfi_csr_rdata_d.scontext           = '0;
-  assign rvfi_csr_rmask_d.scontext           = '1;
 
   // Debug / Trace
+  assign rvfi_csr_rdata_d.dcsr               = csr_dcsr_q_i;
   assign rvfi_csr_wdata_d.dcsr               = csr_dcsr_n_i;
   assign rvfi_csr_wmask_d.dcsr               = csr_dcsr_we_i ? '1 : '0;
-  assign rvfi_csr_rdata_d.dcsr               = csr_dcsr_q_i;
-  assign rvfi_csr_rmask_d.dcsr               = '1;
 
+  assign rvfi_csr_rdata_d.dpc                = csr_dpc_q_i;
   assign rvfi_csr_wdata_d.dpc                = csr_dpc_n_i;
   assign rvfi_csr_wmask_d.dpc                = csr_dpc_we_i ? '1 : '0;
-  assign rvfi_csr_rdata_d.dpc                = csr_dpc_q_i;
-  assign rvfi_csr_rmask_d.dpc                = '1;
 
+  assign rvfi_csr_rdata_d.dscratch[0]        = csr_dscratch0_q_i;
   assign rvfi_csr_wdata_d.dscratch[0]        = csr_dscratch0_n_i;
   assign rvfi_csr_wmask_d.dscratch[0]        = csr_dscratch0_we_i ? '1 : '0;
-  assign rvfi_csr_rdata_d.dscratch[0]        = csr_dscratch0_q_i;
-  assign rvfi_csr_rmask_d.dscratch[0]        = '1;
 
+  assign rvfi_csr_rdata_d.dscratch[1]        = csr_dscratch1_q_i;
   assign rvfi_csr_wdata_d.dscratch[1]        = csr_dscratch1_n_i;
   assign rvfi_csr_wmask_d.dscratch[1]        = csr_dscratch1_we_i ? '1 : '0;
-  assign rvfi_csr_rdata_d.dscratch[1]        = csr_dscratch1_q_i;
-  assign rvfi_csr_rmask_d.dscratch[1]        = '1;
 
   // Performance Monitors
   generate
     for (genvar i = 0; i < 32; i++) begin
-      assign csr_mhpmcounter_q_l[i] = csr_mhpmcounter_q_i[i][31: 0];
-      assign csr_mhpmcounter_q_h[i] = csr_mhpmcounter_q_i[i][63:32];
+      assign csr_mhpmcounter_n_l[i]  = csr_mhpmcounter_n_i[i][31: 0];
+      assign csr_mhpmcounter_n_h[i]  = csr_mhpmcounter_n_i[i][63:32];
+      assign csr_mhpmcounter_q_l[i]  = csr_mhpmcounter_q_i[i][31: 0];
+      assign csr_mhpmcounter_q_h[i]  = csr_mhpmcounter_q_i[i][63:32];
+      assign csr_mhpmcounter_we_l[i] = csr_mhpmcounter_we_i[i][0] ? '1 : '0;
+      assign csr_mhpmcounter_we_h[i] = csr_mhpmcounter_we_i[i][1] ? '1 : '0;
     end
   endgenerate
 
-  assign rvfi_csr_wdata_d.mcycle             = csr_mhpmcounter_q_l[CSR_MCYCLE & 'hF];
-  assign rvfi_csr_wmask_d.mcycle             = '1;
-  assign rvfi_csr_rdata_d.mcycle             = csr_mhpmcounter_q_l[CSR_MCYCLE & 'hF];
-  assign rvfi_csr_rmask_d.mcycle             = '1;
+  assign ex_csr_rdata_d.mcycle               = csr_mhpmcounter_q_l [CSR_MCYCLE & 'hF];
+  assign rvfi_csr_rdata_d.mcycle             = ex_csr_rdata.mcycle;
+  assign rvfi_csr_wdata_d.mcycle             = csr_mhpmcounter_n_l [CSR_MCYCLE & 'hF];
+  assign rvfi_csr_wmask_d.mcycle             = csr_mhpmcounter_we_l[CSR_MCYCLE & 'hF];
 
-  assign rvfi_csr_wdata_d.minstret           = csr_mhpmcounter_q_l[CSR_MINSTRET & 'hF];
-  assign rvfi_csr_wmask_d.minstret           = '1;
-  assign rvfi_csr_rdata_d.minstret           = csr_mhpmcounter_q_l[CSR_MINSTRET & 'hF];
-  assign rvfi_csr_rmask_d.minstret           = '1;
+  assign rvfi_csr_rdata_d.minstret           = csr_mhpmcounter_q_l [CSR_MINSTRET & 'hF];
+  assign rvfi_csr_wdata_d.minstret           = csr_mhpmcounter_q_l [CSR_MINSTRET & 'hF];
+  assign rvfi_csr_wmask_d.minstret           = csr_mhpmcounter_we_l[CSR_MINSTRET & 'hF];
 
+  assign rvfi_csr_rdata_d.mhpmcounter[ 2:0]  = 'Z;
   assign rvfi_csr_wdata_d.mhpmcounter[ 2:0]  = 'Z; // Does not exist
   assign rvfi_csr_wmask_d.mhpmcounter[ 2:0]  = '0;
-  assign rvfi_csr_rdata_d.mhpmcounter[ 2:0]  = 'Z;
-  assign rvfi_csr_rmask_d.mhpmcounter[ 2:0]  = '0;
-  assign rvfi_csr_wdata_d.mhpmcounter[31:3]  = csr_mhpmcounter_q_l[31:3];
-  assign rvfi_csr_wmask_d.mhpmcounter[31:3]  = '1;
-  assign rvfi_csr_rdata_d.mhpmcounter[31:3]  = csr_mhpmcounter_q_l[31:3];
-  assign rvfi_csr_rmask_d.mhpmcounter[31:3]  = '1;
+  assign rvfi_csr_rdata_d.mhpmcounter[31:3]  = csr_mhpmcounter_q_l [31:3];
+  assign rvfi_csr_wdata_d.mhpmcounter[31:3]  = csr_mhpmcounter_q_l [31:3];
+  assign rvfi_csr_wmask_d.mhpmcounter[31:3]  = csr_mhpmcounter_we_l[31:3];
 
-  assign rvfi_csr_wdata_d.mcycleh            = csr_mhpmcounter_q_h[CSR_MCYCLEH & 'hF];
-  assign rvfi_csr_wmask_d.mcycleh            = '1;
-  assign rvfi_csr_rdata_d.mcycleh            = csr_mhpmcounter_q_h[CSR_MCYCLEH & 'hF];
-  assign rvfi_csr_rmask_d.mcycleh            = '1;
+  assign ex_csr_rdata_d.mcycleh              = csr_mhpmcounter_q_h [CSR_MCYCLEH & 'hF];
+  assign rvfi_csr_rdata_d.mcycleh            = ex_csr_rdata.mcycleh;
+  assign rvfi_csr_wdata_d.mcycleh            = csr_mhpmcounter_n_h [CSR_MCYCLEH & 'hF];
+  assign rvfi_csr_wmask_d.mcycleh            = csr_mhpmcounter_we_h[CSR_MCYCLEH & 'hF];
 
-  assign rvfi_csr_wdata_d.minstreth          = csr_mhpmcounter_q_h[CSR_MINSTRETH & 'hF];
-  assign rvfi_csr_wmask_d.minstreth          = '1;
-  assign rvfi_csr_rdata_d.minstreth          = csr_mhpmcounter_q_h[CSR_MINSTRETH & 'hF];
-  assign rvfi_csr_rmask_d.minstreth          = '1;
+  assign rvfi_csr_rdata_d.minstreth          = csr_mhpmcounter_q_h [CSR_MINSTRETH & 'hF];
+  assign rvfi_csr_wdata_d.minstreth          = csr_mhpmcounter_n_h [CSR_MINSTRETH & 'hF];
+  assign rvfi_csr_wmask_d.minstreth          = csr_mhpmcounter_we_h[CSR_MINSTRETH & 'hF];
 
+  assign rvfi_csr_rdata_d.mhpmcounterh[ 2:0] = 'Z;
   assign rvfi_csr_wdata_d.mhpmcounterh[ 2:0] = 'Z;  // Does not exist
   assign rvfi_csr_wmask_d.mhpmcounterh[ 2:0] = '0;
-  assign rvfi_csr_rdata_d.mhpmcounterh[ 2:0] = 'Z;
-  assign rvfi_csr_rmask_d.mhpmcounterh[ 2:0] = '0;
-  assign rvfi_csr_wdata_d.mhpmcounterh[31:3] = csr_mhpmcounter_q_h[31:3];
-  assign rvfi_csr_wmask_d.mhpmcounterh[31:3] = '1;
-  assign rvfi_csr_rdata_d.mhpmcounterh[31:3] = csr_mhpmcounter_q_h[31:3];
-  assign rvfi_csr_rmask_d.mhpmcounterh[31:3] = '1;
+  assign rvfi_csr_rdata_d.mhpmcounterh[31:3] = csr_mhpmcounter_q_h [31:3];
+  assign rvfi_csr_wdata_d.mhpmcounterh[31:3] = csr_mhpmcounter_n_h [31:3];
+  assign rvfi_csr_wmask_d.mhpmcounterh[31:3] = csr_mhpmcounter_we_h[31:3];
 
-  assign rvfi_csr_wdata_d.cycle              = csr_mhpmcounter_q_l[CSR_CYCLE & 'hF];
-  assign rvfi_csr_wmask_d.cycle              = '1;
-  assign rvfi_csr_rdata_d.cycle              = csr_mhpmcounter_q_l[CSR_CYCLE & 'hF];
-  assign rvfi_csr_rmask_d.cycle              = '1;
+  assign ex_csr_rdata_d.cycle                = csr_mhpmcounter_q_l [CSR_CYCLE & 'hF];
+  assign rvfi_csr_rdata_d.cycle              = ex_csr_rdata.cycle;
+  assign rvfi_csr_wdata_d.cycle              = csr_mhpmcounter_n_l [CSR_CYCLE & 'hF];
+  assign rvfi_csr_wmask_d.cycle              = csr_mhpmcounter_we_l[CSR_CYCLE & 'hF];
 
-  assign rvfi_csr_wdata_d.instret            = csr_mhpmcounter_q_l[CSR_INSTRET & 'hF];
-  assign rvfi_csr_wmask_d.instret            = '1;
-  assign rvfi_csr_rdata_d.instret            = csr_mhpmcounter_q_l[CSR_INSTRET & 'hF];
-  assign rvfi_csr_rmask_d.instret            = '1;
+  assign rvfi_csr_rdata_d.instret            = csr_mhpmcounter_q_l [CSR_INSTRET & 'hF];
+  assign rvfi_csr_wdata_d.instret            = csr_mhpmcounter_n_l [CSR_INSTRET & 'hF];
+  assign rvfi_csr_wmask_d.instret            = csr_mhpmcounter_we_l[CSR_INSTRET & 'hF];
 
+  assign rvfi_csr_rdata_d.hpmcounter[ 2:0]   = 'Z;
   assign rvfi_csr_wdata_d.hpmcounter[ 2:0]   = 'Z;  // Does not exist
   assign rvfi_csr_wmask_d.hpmcounter[ 2:0]   = '0;
-  assign rvfi_csr_rdata_d.hpmcounter[ 2:0]   = 'Z;
-  assign rvfi_csr_rmask_d.hpmcounter[ 2:0]   = '0;
-  assign rvfi_csr_wdata_d.hpmcounter[31:3]   = csr_mhpmcounter_q_l[31:3];
-  assign rvfi_csr_wmask_d.hpmcounter[31:3]   = '1;
-  assign rvfi_csr_rdata_d.hpmcounter[31:3]   = csr_mhpmcounter_q_l[31:3];
-  assign rvfi_csr_rmask_d.hpmcounter[31:3]   = '1;
+  assign rvfi_csr_rdata_d.hpmcounter[31:3]   = csr_mhpmcounter_q_l [31:3];
+  assign rvfi_csr_wdata_d.hpmcounter[31:3]   = csr_mhpmcounter_n_l [31:3];
+  assign rvfi_csr_wmask_d.hpmcounter[31:3]   = csr_mhpmcounter_we_l[31:3];
 
-  assign rvfi_csr_wdata_d.cycleh             = csr_mhpmcounter_q_h[CSR_CYCLEH & 'hF];
-  assign rvfi_csr_wmask_d.cycleh             = '1;
-  assign rvfi_csr_rdata_d.cycleh             = csr_mhpmcounter_q_h[CSR_CYCLEH & 'hF];
-  assign rvfi_csr_rmask_d.cycleh             = '1;
+  assign ex_csr_rdata_d.cycleh               = csr_mhpmcounter_q_h [CSR_CYCLEH & 'hF];
+  assign rvfi_csr_rdata_d.cycleh             = ex_csr_rdata.cycleh;
+  assign rvfi_csr_wdata_d.cycleh             = csr_mhpmcounter_n_h [CSR_CYCLEH & 'hF];
+  assign rvfi_csr_wmask_d.cycleh             = csr_mhpmcounter_we_h[CSR_CYCLEH & 'hF];
 
-  assign rvfi_csr_wdata_d.instreth           = csr_mhpmcounter_q_h[CSR_INSTRETH & 'hF];
-  assign rvfi_csr_wmask_d.instreth           = '1;
-  assign rvfi_csr_rdata_d.instreth           = csr_mhpmcounter_q_h[CSR_INSTRETH & 'hF];
-  assign rvfi_csr_rmask_d.instreth           = '1;
+  assign rvfi_csr_rdata_d.instreth           = csr_mhpmcounter_q_h [CSR_INSTRETH & 'hF];
+  assign rvfi_csr_wdata_d.instreth           = csr_mhpmcounter_n_h [CSR_INSTRETH & 'hF];
+  assign rvfi_csr_wmask_d.instreth           = csr_mhpmcounter_we_h[CSR_INSTRETH & 'hF];
 
+  assign rvfi_csr_rdata_d.hpmcounterh[ 2:0]  = 'Z;
   assign rvfi_csr_wdata_d.hpmcounterh[ 2:0]  = 'Z; // Does not exist
   assign rvfi_csr_wmask_d.hpmcounterh[ 2:0]  = '0;
-  assign rvfi_csr_rdata_d.hpmcounterh[ 2:0]  = 'Z;
-  assign rvfi_csr_rmask_d.hpmcounterh[ 2:0]  = '0;
-  assign rvfi_csr_wdata_d.hpmcounterh[31:3]  = csr_mhpmcounter_q_h[31:3];
-  assign rvfi_csr_wmask_d.hpmcounterh[31:3]  = '1;
-  assign rvfi_csr_rdata_d.hpmcounterh[31:3]  = csr_mhpmcounter_q_h[31:3];
-  assign rvfi_csr_rmask_d.hpmcounterh[31:3]  = '1;
+  assign rvfi_csr_rdata_d.hpmcounterh[31:3]  = csr_mhpmcounter_q_h [31:3];
+  assign rvfi_csr_wdata_d.hpmcounterh[31:3]  = csr_mhpmcounter_n_h [31:3];
+  assign rvfi_csr_wmask_d.hpmcounterh[31:3]  = csr_mhpmcounter_we_h[31:3];
 
   // Machine info
+  assign rvfi_csr_rdata_d.mvendorid          = csr_mvendorid_i;
   assign rvfi_csr_wdata_d.mvendorid          = '0; // Read Only
   assign rvfi_csr_wmask_d.mvendorid          = '0;
-  assign rvfi_csr_rdata_d.mvendorid          = csr_mvendorid_i;
-  assign rvfi_csr_rmask_d.mvendorid          = '1;
 
   assign rvfi_csr_wdata_d.marchid            = '0; // Read Only
   assign rvfi_csr_wmask_d.marchid            = '0;
   assign rvfi_csr_rdata_d.marchid            = csr_marchid_i;
-  assign rvfi_csr_rmask_d.marchid            = '1;
 
   assign rvfi_csr_wdata_d.mimpid             = '0; // Not implemented, read 0
   assign rvfi_csr_wmask_d.mimpid             = '0;
   assign rvfi_csr_rdata_d.mimpid             = '0;
-  assign rvfi_csr_rmask_d.mimpid             = '1;
 
   assign rvfi_csr_wdata_d.mhartid            = '0; // Read Only
   assign rvfi_csr_wmask_d.mhartid            = '0;
   assign rvfi_csr_rdata_d.mhartid            = csr_mhartid_i;
-  assign rvfi_csr_rmask_d.mhartid            = '1;
 
 
   // CSR outputs //
   assign rvfi_csr_mstatus_rdata           = rvfi_csr_rdata.mstatus;
-  assign rvfi_csr_mstatus_rmask           = rvfi_csr_rmask.mstatus;
+  assign rvfi_csr_mstatus_rmask           = '1;
   assign rvfi_csr_mstatus_wdata           = rvfi_csr_wdata.mstatus;
   assign rvfi_csr_mstatus_wmask           = rvfi_csr_wmask.mstatus;
   assign rvfi_csr_misa_rdata              = rvfi_csr_rdata.misa;
-  assign rvfi_csr_misa_rmask              = rvfi_csr_rmask.misa;
+  assign rvfi_csr_misa_rmask              = '1;
   assign rvfi_csr_misa_wdata              = rvfi_csr_wdata.misa;
   assign rvfi_csr_misa_wmask              = rvfi_csr_wmask.misa;
   assign rvfi_csr_mie_rdata               = rvfi_csr_rdata.mie;
-  assign rvfi_csr_mie_rmask               = rvfi_csr_rmask.mie;
+  assign rvfi_csr_mie_rmask               = '1;
   assign rvfi_csr_mie_wdata               = rvfi_csr_wdata.mie;
   assign rvfi_csr_mie_wmask               = rvfi_csr_wmask.mie;
   assign rvfi_csr_mtvec_rdata             = rvfi_csr_rdata.mtvec;
-  assign rvfi_csr_mtvec_rmask             = rvfi_csr_rmask.mtvec;
+  assign rvfi_csr_mtvec_rmask             = '1;
   assign rvfi_csr_mtvec_wdata             = rvfi_csr_wdata.mtvec;
   assign rvfi_csr_mtvec_wmask             = rvfi_csr_wmask.mtvec;
   assign rvfi_csr_mcountinhibit_rdata     = rvfi_csr_rdata.mcountinhibit;
-  assign rvfi_csr_mcountinhibit_rmask     = rvfi_csr_rmask.mcountinhibit;
+  assign rvfi_csr_mcountinhibit_rmask     = '1;
   assign rvfi_csr_mcountinhibit_wdata     = rvfi_csr_wdata.mcountinhibit;
   assign rvfi_csr_mcountinhibit_wmask     = rvfi_csr_wmask.mcountinhibit;
   assign rvfi_csr_mhpmevent_rdata         = rvfi_csr_rdata.mhpmevent;
-  assign rvfi_csr_mhpmevent_rmask         = rvfi_csr_rmask.mhpmevent;
+  assign rvfi_csr_mhpmevent_rmask[ 2:0]   = '1;
+  assign rvfi_csr_mhpmevent_rmask[31:3]   = '1;
   assign rvfi_csr_mhpmevent_wdata         = rvfi_csr_wdata.mhpmevent;
   assign rvfi_csr_mhpmevent_wmask         = rvfi_csr_wmask.mhpmevent;
   assign rvfi_csr_mscratch_rdata          = rvfi_csr_rdata.mscratch;
-  assign rvfi_csr_mscratch_rmask          = rvfi_csr_rmask.mscratch;
+  assign rvfi_csr_mscratch_rmask          = '1;
   assign rvfi_csr_mscratch_wdata          = rvfi_csr_wdata.mscratch;
   assign rvfi_csr_mscratch_wmask          = rvfi_csr_wmask.mscratch;
   assign rvfi_csr_mepc_rdata              = rvfi_csr_rdata.mepc;
-  assign rvfi_csr_mepc_rmask              = rvfi_csr_rmask.mepc;
+  assign rvfi_csr_mepc_rmask              = '1;
   assign rvfi_csr_mepc_wdata              = rvfi_csr_wdata.mepc;
   assign rvfi_csr_mepc_wmask              = rvfi_csr_wmask.mepc;
   assign rvfi_csr_mcause_rdata            = rvfi_csr_rdata.mcause;
-  assign rvfi_csr_mcause_rmask            = rvfi_csr_rmask.mcause;
+  assign rvfi_csr_mcause_rmask            = '1;
   assign rvfi_csr_mcause_wdata            = rvfi_csr_wdata.mcause;
   assign rvfi_csr_mcause_wmask            = rvfi_csr_wmask.mcause;
   assign rvfi_csr_mtval_rdata             = rvfi_csr_rdata.mtval;
-  assign rvfi_csr_mtval_rmask             = rvfi_csr_rmask.mtval;
+  assign rvfi_csr_mtval_rmask             = '1;
   assign rvfi_csr_mtval_wdata             = rvfi_csr_wdata.mtval;
   assign rvfi_csr_mtval_wmask             = rvfi_csr_wmask.mtval;
   assign rvfi_csr_mip_rdata               = rvfi_csr_rdata.mip;
-  assign rvfi_csr_mip_rmask               = rvfi_csr_rmask.mip;
+  assign rvfi_csr_mip_rmask               = '1;
   assign rvfi_csr_mip_wdata               = rvfi_csr_wdata.mip;
   assign rvfi_csr_mip_wmask               = rvfi_csr_wmask.mip;
   assign rvfi_csr_tselect_rdata           = rvfi_csr_rdata.tselect;
-  assign rvfi_csr_tselect_rmask           = rvfi_csr_rmask.tselect;
+  assign rvfi_csr_tselect_rmask           = '1;
   assign rvfi_csr_tselect_wdata           = rvfi_csr_wdata.tselect;
   assign rvfi_csr_tselect_wmask           = rvfi_csr_wmask.tselect;
   assign rvfi_csr_tdata_rdata             = rvfi_csr_rdata.tdata;
-  assign rvfi_csr_tdata_rmask             = rvfi_csr_rmask.tdata;
+  assign rvfi_csr_tdata_rmask[0]          = '0; // Does not exist
+  assign rvfi_csr_tdata_rmask[3:1]        = '1;
   assign rvfi_csr_tdata_wdata             = rvfi_csr_wdata.tdata;
   assign rvfi_csr_tdata_wmask             = rvfi_csr_wmask.tdata;
   assign rvfi_csr_tinfo_rdata             = rvfi_csr_rdata.tinfo;
-  assign rvfi_csr_tinfo_rmask             = rvfi_csr_rmask.tinfo;
+  assign rvfi_csr_tinfo_rmask             = '1;
   assign rvfi_csr_tinfo_wdata             = rvfi_csr_wdata.tinfo;
   assign rvfi_csr_tinfo_wmask             = rvfi_csr_wmask.tinfo;
   assign rvfi_csr_mcontext_rdata          = rvfi_csr_rdata.mcontext;
-  assign rvfi_csr_mcontext_rmask          = rvfi_csr_rmask.mcontext;
+  assign rvfi_csr_mcontext_rmask          = '1;
   assign rvfi_csr_mcontext_wdata          = rvfi_csr_wdata.mcontext;
   assign rvfi_csr_mcontext_wmask          = rvfi_csr_wmask.mcontext;
   assign rvfi_csr_scontext_rdata          = rvfi_csr_rdata.scontext;
-  assign rvfi_csr_scontext_rmask          = rvfi_csr_rmask.scontext;
+  assign rvfi_csr_scontext_rmask          = '1;
   assign rvfi_csr_scontext_wdata          = rvfi_csr_wdata.scontext;
   assign rvfi_csr_scontext_wmask          = rvfi_csr_wmask.scontext;
   assign rvfi_csr_dcsr_rdata              = rvfi_csr_rdata.dcsr;
-  assign rvfi_csr_dcsr_rmask              = rvfi_csr_rmask.dcsr;
+  assign rvfi_csr_dcsr_rmask              = '1;
   assign rvfi_csr_dcsr_wdata              = rvfi_csr_wdata.dcsr;
   assign rvfi_csr_dcsr_wmask              = rvfi_csr_wmask.dcsr;
   assign rvfi_csr_dpc_rdata               = rvfi_csr_rdata.dpc;
-  assign rvfi_csr_dpc_rmask               = rvfi_csr_rmask.dpc;
+  assign rvfi_csr_dpc_rmask               = '1;
   assign rvfi_csr_dpc_wdata               = rvfi_csr_wdata.dpc;
   assign rvfi_csr_dpc_wmask               = rvfi_csr_wmask.dpc;
   assign rvfi_csr_dscratch_rdata          = rvfi_csr_rdata.dscratch;
-  assign rvfi_csr_dscratch_rmask          = rvfi_csr_rmask.dscratch;
+  assign rvfi_csr_dscratch_rmask          = '1;
   assign rvfi_csr_dscratch_wdata          = rvfi_csr_wdata.dscratch;
   assign rvfi_csr_dscratch_wmask          = rvfi_csr_wmask.dscratch;
   assign rvfi_csr_mcycle_rdata            = rvfi_csr_rdata.mcycle;
-  assign rvfi_csr_mcycle_rmask            = rvfi_csr_rmask.mcycle;
+  assign rvfi_csr_mcycle_rmask            = '1;
   assign rvfi_csr_mcycle_wdata            = rvfi_csr_wdata.mcycle;
   assign rvfi_csr_mcycle_wmask            = rvfi_csr_wmask.mcycle;
   assign rvfi_csr_minstret_rdata          = rvfi_csr_rdata.minstret;
-  assign rvfi_csr_minstret_rmask          = rvfi_csr_rmask.minstret;
+  assign rvfi_csr_minstret_rmask          = '1;
   assign rvfi_csr_minstret_wdata          = rvfi_csr_wdata.minstret;
   assign rvfi_csr_minstret_wmask          = rvfi_csr_wmask.minstret;
   assign rvfi_csr_mhpmcounter_rdata       = rvfi_csr_rdata.mhpmcounter;
-  assign rvfi_csr_mhpmcounter_rmask       = rvfi_csr_rmask.mhpmcounter;
+  assign rvfi_csr_mhpmcounter_rmask[ 2:0] = '0;
+  assign rvfi_csr_mhpmcounter_rmask[31:3] = '1;
   assign rvfi_csr_mhpmcounter_wdata       = rvfi_csr_wdata.mhpmcounter;
   assign rvfi_csr_mhpmcounter_wmask       = rvfi_csr_wmask.mhpmcounter;
   assign rvfi_csr_mcycleh_rdata           = rvfi_csr_rdata.mcycleh;
-  assign rvfi_csr_mcycleh_rmask           = rvfi_csr_rmask.mcycleh;
+  assign rvfi_csr_mcycleh_rmask           = '1;
   assign rvfi_csr_mcycleh_wdata           = rvfi_csr_wdata.mcycleh;
   assign rvfi_csr_mcycleh_wmask           = rvfi_csr_wmask.mcycleh;
   assign rvfi_csr_minstreth_rdata         = rvfi_csr_rdata.minstreth;
-  assign rvfi_csr_minstreth_rmask         = rvfi_csr_rmask.minstreth;
+  assign rvfi_csr_minstreth_rmask         = '1;
   assign rvfi_csr_minstreth_wdata         = rvfi_csr_wdata.minstreth;
   assign rvfi_csr_minstreth_wmask         = rvfi_csr_wmask.minstreth;
   assign rvfi_csr_mhpmcounterh_rdata      = rvfi_csr_rdata.mhpmcounterh;
-  assign rvfi_csr_mhpmcounterh_rmask      = rvfi_csr_rmask.mhpmcounterh;
+  assign rvfi_csr_mhpmcounterh_rmask[ 2:0] = '0;
+  assign rvfi_csr_mhpmcounterh_rmask[31:3] = '1;
   assign rvfi_csr_mhpmcounterh_wdata      = rvfi_csr_wdata.mhpmcounterh;
   assign rvfi_csr_mhpmcounterh_wmask      = rvfi_csr_wmask.mhpmcounterh;
   assign rvfi_csr_mvendorid_rdata         = rvfi_csr_rdata.mvendorid;
-  assign rvfi_csr_mvendorid_rmask         = rvfi_csr_rmask.mvendorid;
+  assign rvfi_csr_mvendorid_rmask         = '1;
   assign rvfi_csr_mvendorid_wdata         = rvfi_csr_wdata.mvendorid;
   assign rvfi_csr_mvendorid_wmask         = rvfi_csr_wmask.mvendorid;
   assign rvfi_csr_marchid_rdata           = rvfi_csr_rdata.marchid;
-  assign rvfi_csr_marchid_rmask           = rvfi_csr_rmask.marchid;
+  assign rvfi_csr_marchid_rmask           = '1;
   assign rvfi_csr_marchid_wdata           = rvfi_csr_wdata.marchid;
   assign rvfi_csr_marchid_wmask           = rvfi_csr_wmask.marchid;
   assign rvfi_csr_mimpid_rdata            = rvfi_csr_rdata.mimpid;
-  assign rvfi_csr_mimpid_rmask            = rvfi_csr_rmask.mimpid;
+  assign rvfi_csr_mimpid_rmask            = '1;
   assign rvfi_csr_mimpid_wdata            = rvfi_csr_wdata.mimpid;
   assign rvfi_csr_mimpid_wmask            = rvfi_csr_wmask.mimpid;
   assign rvfi_csr_mhartid_rdata           = rvfi_csr_rdata.mhartid;
-  assign rvfi_csr_mhartid_rmask           = rvfi_csr_rmask.mhartid;
+  assign rvfi_csr_mhartid_rmask           = '1;
   assign rvfi_csr_mhartid_wdata           = rvfi_csr_wdata.mhartid;
   assign rvfi_csr_mhartid_wmask           = rvfi_csr_wmask.mhartid;
   assign rvfi_csr_cycle_rdata             = rvfi_csr_rdata.cycle;
-  assign rvfi_csr_cycle_rmask             = rvfi_csr_rmask.cycle;
+  assign rvfi_csr_cycle_rmask             = '1;
   assign rvfi_csr_cycle_wdata             = rvfi_csr_wdata.cycle;
   assign rvfi_csr_cycle_wmask             = rvfi_csr_wmask.cycle;
   assign rvfi_csr_instret_rdata           = rvfi_csr_rdata.instret;
-  assign rvfi_csr_instret_rmask           = rvfi_csr_rmask.instret;
+  assign rvfi_csr_instret_rmask           = '1;
   assign rvfi_csr_instret_wdata           = rvfi_csr_wdata.instret;
   assign rvfi_csr_instret_wmask           = rvfi_csr_wmask.instret;
   assign rvfi_csr_hpmcounter_rdata        = rvfi_csr_rdata.hpmcounter;
-  assign rvfi_csr_hpmcounter_rmask        = rvfi_csr_rmask.hpmcounter;
+  assign rvfi_csr_hpmcounter_rmask[ 2:0]  = '0;
+  assign rvfi_csr_hpmcounter_rmask[31:3]  = '1;
   assign rvfi_csr_hpmcounter_wdata        = rvfi_csr_wdata.hpmcounter;
   assign rvfi_csr_hpmcounter_wmask        = rvfi_csr_wmask.hpmcounter;
   assign rvfi_csr_cycleh_rdata            = rvfi_csr_rdata.cycleh;
-  assign rvfi_csr_cycleh_rmask            = rvfi_csr_rmask.cycleh;
+  assign rvfi_csr_cycleh_rmask            = '1;
   assign rvfi_csr_cycleh_wdata            = rvfi_csr_wdata.cycleh;
   assign rvfi_csr_cycleh_wmask            = rvfi_csr_wmask.cycleh;
   assign rvfi_csr_instreth_rdata          = rvfi_csr_rdata.instreth;
-  assign rvfi_csr_instreth_rmask          = rvfi_csr_rmask.instreth;
+  assign rvfi_csr_instreth_rmask          = '1;
   assign rvfi_csr_instreth_wdata          = rvfi_csr_wdata.instreth;
   assign rvfi_csr_instreth_wmask          = rvfi_csr_wmask.instreth;
   assign rvfi_csr_hpmcounterh_rdata       = rvfi_csr_rdata.hpmcounterh;
-  assign rvfi_csr_hpmcounterh_rmask       = rvfi_csr_rmask.hpmcounterh;
+  assign rvfi_csr_hpmcounterh_rmask[ 2:0] = '0;
+  assign rvfi_csr_hpmcounterh_rmask[31:3] = '1;
   assign rvfi_csr_hpmcounterh_wdata       = rvfi_csr_wdata.hpmcounterh;
   assign rvfi_csr_hpmcounterh_wmask       = rvfi_csr_wmask.hpmcounterh;
 

--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -309,11 +309,13 @@ bind cv32e40x_sleep_unit:
          .mepc_target_wb_i         ( core_i.if_stage_i.mepc_i                                             ),
 
          // CSRs
-         .csr_raddr_i              ( core_i.cs_registers_i.csr_raddr                                      ),
          .csr_mstatus_n_i          ( core_i.cs_registers_i.mstatus_n                                      ),
          .csr_mstatus_q_i          ( core_i.cs_registers_i.mstatus_q                                      ),
          .csr_mstatus_we_i         ( core_i.cs_registers_i.mstatus_we                                     ),
-         .csr_misa_i               ( core_i.cs_registers_i.MISA_VALUE                                     ),
+         .csr_misa_n_i             ( core_i.cs_registers_i.MISA_VALUE                                     ), // WARL
+         .csr_misa_q_i             ( core_i.cs_registers_i.MISA_VALUE                                     ),
+         .csr_misa_we_i            ( core_i.cs_registers_i.csr_we_int &&
+                                     (core_i.cs_registers_i.csr_waddr == CSR_MISA)                        ),
          .csr_mie_q_i              ( core_i.cs_registers_i.mie_q                                          ),
          .csr_mie_n_i              ( core_i.cs_registers_i.mie_n                                          ),
          .csr_mie_we_i             ( core_i.cs_registers_i.mie_we                                         ),
@@ -335,14 +337,20 @@ bind cv32e40x_sleep_unit:
          .csr_mcause_q_i           ( core_i.cs_registers_i.mcause_q                                       ),
          .csr_mcause_n_i           ( core_i.cs_registers_i.mcause_n                                       ),
          .csr_mcause_we_i          ( core_i.cs_registers_i.mcause_we                                      ),
-         .csr_mip_i                ( core_i.cs_registers_i.mip_i                                          ),
+         .csr_mip_n_i              ( core_i.cs_registers_i.mip_i                                          ),
+         .csr_mip_q_i              ( core_i.cs_registers_i.mip_i                                          ),
+         .csr_mip_we_i             ( core_i.cs_registers_i.csr_we_int &&
+                                     (core_i.cs_registers_i.csr_waddr == CSR_MIP)                         ),
          .csr_tdata1_n_i           ( core_i.cs_registers_i.tmatch_control_n                               ),
          .csr_tdata1_q_i           ( core_i.cs_registers_i.tmatch_control_q                               ),
          .csr_tdata1_we_i          ( core_i.cs_registers_i.tmatch_control_we                              ),
          .csr_tdata2_n_i           ( core_i.cs_registers_i.tmatch_value_n                                 ),
          .csr_tdata2_q_i           ( core_i.cs_registers_i.tmatch_value_q                                 ),
          .csr_tdata2_we_i          ( core_i.cs_registers_i.tmatch_value_we                                ),
-         .csr_tinfo_i              ( core_i.cs_registers_i.tinfo_types                                    ),
+         .csr_tinfo_n_i            ( {16'h0, core_i.cs_registers_i.tinfo_types}                           ),
+         .csr_tinfo_q_i            ( {16'h0, core_i.cs_registers_i.tinfo_types}                           ),
+         .csr_tinfo_we_i           ( core_i.cs_registers_i.csr_we_int &&
+                                     (core_i.cs_registers_i.csr_waddr == CSR_TINFO)                       ),
          .csr_dcsr_q_i             ( core_i.cs_registers_i.dcsr_q                                         ),
          .csr_dcsr_n_i             ( core_i.cs_registers_i.dcsr_n                                         ),
          .csr_dcsr_we_i            ( core_i.cs_registers_i.dcsr_we                                        ),
@@ -356,7 +364,9 @@ bind cv32e40x_sleep_unit:
          .csr_dscratch1_q_i        ( core_i.cs_registers_i.dscratch1_q                                    ),
          .csr_dscratch1_n_i        ( core_i.cs_registers_i.dscratch1_n                                    ),
          .csr_dscratch1_we_i       ( core_i.cs_registers_i.dscratch1_we                                   ),
+         .csr_mhpmcounter_n_i      ( '0                               /* TODO:Connect when implemented */ ),
          .csr_mhpmcounter_q_i      ( core_i.cs_registers_i.mhpmcounter_q                                  ),
+         .csr_mhpmcounter_we_i     ( '0                               /* TODO:Connect when implemented */ ),
          .csr_mvendorid_i          ( {MVENDORID_BANK, MVENDORID_OFFSET}                                   ),
          .csr_marchid_i            ( MARCHID                                                              ),
          .csr_mhartid_i            ( core_i.cs_registers_i.hart_id_i                                      )

--- a/bhv/include/cv32e40x_rvfi_pkg.sv
+++ b/bhv/include/cv32e40x_rvfi_pkg.sv
@@ -19,6 +19,18 @@
 //               Halfdan Bechmann <halfdan.bechmann@silabs.com>
 
 package cv32e40x_rvfi_pkg;
+  import cv32e40x_pkg::*;
+
+  // RVFI only supports MHPMCOUNTER_WIDTH == 64
+  parameter MHPMCOUNTER_WORDS  = MHPMCOUNTER_WIDTH/32;
+
+  typedef struct packed { // Autonomously updated CSRs
+    logic [31:0] mcycle;
+    logic [31:0] mcycleh;
+    logic [31:0] cycle;
+    logic [31:0] cycleh;
+    logic [31:0] mip;
+  } rvfi_auto_csr_map_t;
 
   typedef struct packed {
     logic        [31:0] mstatus;


### PR DESCRIPTION
Moved RVFI register reads for autonomously updated registers to the EX stage in the pipe modelling. #101 
Added _n and _we  signals. #100 

Signed-off-by: Halfdan Bechmann <halfdan.bechmann@silabs.com>