### PR TITLE
Fixed rvfi fence instruction issue

### DIFF
--- a/bhv/cv32e40x_rvfi.sv
+++ b/bhv/cv32e40x_rvfi.sv
@@ -544,7 +544,7 @@ module cv32e40x_rvfi
       end
 
       // Set expected next PC, half-word aligned
-      if (insn_ebrk_wb_i || insn_ecall_wb_i || insn_fencei_wb_i) begin //ebreaks, ecall, fence.i
+      if (insn_ebrk_wb_i || insn_ecall_wb_i) begin //ebreaks, ecall
         rvfi_pc_wdata <= exception_target_wb_i & ~32'b1;
       end else if (insn_mret_wb_i) begin // mret
         rvfi_pc_wdata <= mepc_target_wb_i & ~32'b1;


### PR DESCRIPTION
Fixed issue where rvfi would use the exception target address for fencei pc_wdata.

Signed-off-by: Halfdan Bechmann <halfdan.bechmann@silabs.com>