### PR TITLE
Fix for i->o path, and ID stage assertions

### DIFF
--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -20,7 +20,7 @@
   `include "cv32e40x_decoder_sva.sv"
   `include "cv32e40x_div_sva.sv"
   `include "cv32e40x_if_stage_sva.sv"
-//  `include "cv32e40x_id_stage_sva.sv" // todo: why is this excluded (there is no instance of these assertions)
+  `include "cv32e40x_id_stage_sva.sv"
   `include "cv32e40x_ex_stage_sva.sv"
   `include "cv32e40x_wb_stage_sva.sv"
   `include "cv32e40x_load_store_unit_sva.sv"
@@ -120,14 +120,13 @@ module cv32e40x_wrapper
       .*
     );
 
-/* todo: re-enable ID stage assertions
 
   bind cv32e40x_id_stage:
     core_i.id_stage_i cv32e40x_id_stage_sva id_stage_sva
     (
       .*
     );
-*/
+
 
   bind cv32e40x_ex_stage:
     core_i.ex_stage_i cv32e40x_ex_stage_sva ex_stage_sva

--- a/rtl/cv32e40x_controller_bypass.sv
+++ b/rtl/cv32e40x_controller_bypass.sv
@@ -135,14 +135,15 @@ module cv32e40x_controller_bypass import cv32e40x_pkg::*;
 
   always_comb
   begin
-    ctrl_byp_o.load_stall  = 1'b0;
-    ctrl_byp_o.deassert_we = 1'b0;
-    ctrl_byp_o.csr_stall   = 1'b0;
+    ctrl_byp_o.load_stall          = 1'b0;
+    ctrl_byp_o.deassert_we         = 1'b0;
+    ctrl_byp_o.deassert_we_special = 1'b0;
+    ctrl_byp_o.csr_stall           = 1'b0;
 
     // deassert WE when the core has an exception in ID (ins converted to nop and propagated to WB)
     // Also deassert for trigger match, as with dcsr.timing==0 we do not execute before entering debug mode
     if (if_id_pipe_i.instr.bus_resp.err || !(if_id_pipe_i.instr.mpu_status == MPU_OK) || debug_trigger_match_id_i) begin
-      ctrl_byp_o.deassert_we = 1'b1;
+      ctrl_byp_o.deassert_we_special = 1'b1;
     end
 
     // Stall because of load operation

--- a/rtl/cv32e40x_decoder.sv
+++ b/rtl/cv32e40x_decoder.sv
@@ -35,6 +35,7 @@ module cv32e40x_decoder import cv32e40x_pkg::*;
 (
   // singals running to/from controller
   input  logic        deassert_we_i,            // deassert we, we are stalled or not active
+  input  logic        deassert_we_special_i,    // deassert we and special insn (exception in IF)
 
   output logic        illegal_insn_o,           // illegal instruction encountered
   output logic        ebrk_insn_o,              // trap instruction encountered
@@ -202,22 +203,22 @@ module cv32e40x_decoder import cv32e40x_pkg::*;
   assign lsu_prepost_useincr_o          = decoder_ctrl_mux.lsu_prepost_useincr;               
 
   // Suppress control signals
-  assign alu_en_o             = deassert_we_i ? 1'b0        : alu_en;
-  assign mul_en_o             = deassert_we_i ? 1'b0        : mul_en;
-  assign div_en_o             = deassert_we_i ? 1'b0        : div_en;
-  assign lsu_en_o             = deassert_we_i ? 1'b0        : lsu_en;
-  assign csr_op_o             = deassert_we_i ? CSR_OP_READ : csr_op;
-  assign rf_we_o              = deassert_we_i ? 1'b0        : rf_we;
-  assign ctrl_transfer_insn_o = deassert_we_i ? BRANCH_NONE : ctrl_transfer_insn;
+  assign alu_en_o             = deassert_we_i || deassert_we_special_i ? 1'b0        : alu_en;
+  assign mul_en_o             = deassert_we_i || deassert_we_special_i ? 1'b0        : mul_en;
+  assign div_en_o             = deassert_we_i || deassert_we_special_i ? 1'b0        : div_en;
+  assign lsu_en_o             = deassert_we_i || deassert_we_special_i ? 1'b0        : lsu_en;
+  assign csr_op_o             = deassert_we_i || deassert_we_special_i ? CSR_OP_READ : csr_op;
+  assign rf_we_o              = deassert_we_i || deassert_we_special_i ? 1'b0        : rf_we;
+  assign ctrl_transfer_insn_o = deassert_we_i || deassert_we_special_i ? BRANCH_NONE : ctrl_transfer_insn;
 
   // Suppress special instruction/illegal instruction bits
-  assign mret_insn_o          = deassert_we_i ? 1'b0 : decoder_ctrl_mux.mret_insn;
-  assign dret_insn_o          = deassert_we_i ? 1'b0 : decoder_ctrl_mux.dret_insn;
-  assign ebrk_insn_o          = deassert_we_i ? 1'b0 : decoder_ctrl_mux.ebrk_insn;
-  assign ecall_insn_o         = deassert_we_i ? 1'b0 : decoder_ctrl_mux.ecall_insn;
-  assign wfi_insn_o           = deassert_we_i ? 1'b0 : decoder_ctrl_mux.wfi_insn;
-  assign fencei_insn_o        = deassert_we_i ? 1'b0 : decoder_ctrl_mux.fencei_insn;
-  assign illegal_insn_o       = deassert_we_i ? 1'b0 : decoder_ctrl_mux.illegal_insn;
+  assign mret_insn_o          = deassert_we_special_i ? 1'b0 : decoder_ctrl_mux.mret_insn;
+  assign dret_insn_o          = deassert_we_special_i ? 1'b0 : decoder_ctrl_mux.dret_insn;
+  assign ebrk_insn_o          = deassert_we_special_i ? 1'b0 : decoder_ctrl_mux.ebrk_insn;
+  assign ecall_insn_o         = deassert_we_special_i ? 1'b0 : decoder_ctrl_mux.ecall_insn;
+  assign wfi_insn_o           = deassert_we_special_i ? 1'b0 : decoder_ctrl_mux.wfi_insn;
+  assign fencei_insn_o        = deassert_we_special_i ? 1'b0 : decoder_ctrl_mux.fencei_insn;
+  assign illegal_insn_o       = deassert_we_special_i ? 1'b0 : decoder_ctrl_mux.illegal_insn;
 
 
   assign ctrl_transfer_insn_raw_o = ctrl_transfer_insn;

--- a/rtl/cv32e40x_id_stage.sv
+++ b/rtl/cv32e40x_id_stage.sv
@@ -373,7 +373,8 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
   decoder_i
   (
     // controller related signals
-    .deassert_we_i                   ( ctrl_byp_i.deassert_we    ),
+    .deassert_we_i                   ( ctrl_byp_i.deassert_we         ),
+    .deassert_we_special_i           ( ctrl_byp_i.deassert_we_special ),
 
     .illegal_insn_o                  ( illegal_insn              ),
     .ebrk_insn_o                     ( ebrk_insn                 ),

--- a/rtl/include/cv32e40x_pkg.sv
+++ b/rtl/include/cv32e40x_pkg.sv
@@ -1020,6 +1020,7 @@ typedef struct packed {
   logic        csr_stall;
   logic        wfi_stall;
   logic        deassert_we;           // Deassert write enable for next instruction
+  logic        deassert_we_special;   // Deassert write enable and special insn bits
 } ctrl_byp_t;
 
 // Controller FSM outputs

--- a/sva/cv32e40x_controller_fsm_sva.sv
+++ b/sva/cv32e40x_controller_fsm_sva.sv
@@ -35,6 +35,7 @@ module cv32e40x_controller_fsm_sva
   input ctrl_fsm_t      ctrl_fsm_o,
   input logic           jump_taken_id,
   input logic           branch_taken_ex,
+  input logic           branch_decision_ex_i,
   input ctrl_state_e    ctrl_fsm_cs,
   input ctrl_state_e    ctrl_fsm_ns,
   input logic [1:0]     lsu_outstanding_cnt,
@@ -57,7 +58,27 @@ module cv32e40x_controller_fsm_sva
     assert property (@(posedge clk)
                      (jump_taken_id) |=> (!jump_taken_id))
       else `uvm_error("controller", "Two jumps back-to-back are taken")
-*/  
+*/
+
+
+
+  // Check that xret does not coincide with CSR write (to avoid using wrong return address)
+  // This check is more strict than really needed; a CSR instruction would be allowed in EX as long
+  // as its write action happens before the xret CSR usage
+  property p_xret_csr;
+    @(posedge clk) disable iff (!rst_n)
+      (ctrl_fsm_o.pc_set && ((ctrl_fsm_o.pc_mux == PC_MRET) || (ctrl_fsm_o.pc_mux == PC_DRET))) |->
+                                (!(ex_wb_pipe_i.instr_valid && ex_wb_pipe_i.csr_en && (ex_wb_pipe_i.csr_op != CSR_OP_READ)));
+  endproperty
+
+  a_xret_csr : assert property(p_xret_csr) else `uvm_error("controller", "Assertion a_xret_csr failed")
+
+  // make sure that branch decision is valid when jumping
+  a_br_decision :
+    assert property (@(posedge clk)
+                     (id_ex_pipe_i.branch_in_ex) |-> (branch_decision_ex_i !== 1'bx) )
+      else begin `uvm_warning("controller", $sformatf("%t, Branch decision is X in module %m", $time)); end
+
   // Ensure that debug state outputs are one-hot
   a_debug_state_onehot :
     assert property (@(posedge clk)


### PR DESCRIPTION
Suppressing *_insn bits in the decoder using deassert_we caused a path from data_rvalid_i and to the instr_ interface, breaking timing.

Added a separate deassert signal for use when IF stage has
PMA/PMP/bus_error, and uses this to deassert both write enables
and the *_special bits in the decoder. This removes the timing path
from the previous solution.

Also brought back in ID stage assertions. Work-in-progress to
reenable them and/or move them to appropriate sva files.

Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>