### PR TITLE
Made mulh_a/mulh_b independenf of valid_i.

### DIFF
--- a/rtl/cv32e40x_mult.sv
+++ b/rtl/cv32e40x_mult.sv
@@ -139,11 +139,11 @@ module cv32e40x_mult import cv32e40x_pkg::*;
           ready_o         = 1'b1;
           valid_o         = 1'b0;
         end else begin
-          mulh_a           = mulh_al;
-          mulh_b           = mulh_bh;
           mulh_acc_next    = mulh_acc_res;
           mulh_state_next  = MUL_AHBL;
         end
+        mulh_a           = mulh_al;
+        mulh_b           = mulh_bh;
       end
 
       MUL_AHBL: begin
@@ -152,12 +152,12 @@ module cv32e40x_mult import cv32e40x_pkg::*;
           ready_o         = 1'b1;
           valid_o         = 1'b0;
         end else begin
-          mulh_shift       = 1'b1;
-          mulh_a           = mulh_ah;
-          mulh_b           = mulh_bl;
           mulh_acc_next    = mulh_acc_res;
           mulh_state_next  = MUL_AHBH;
         end
+        mulh_shift       = 1'b1;
+        mulh_a           = mulh_ah;
+        mulh_b           = mulh_bl;
       end
 
       MUL_AHBH: begin
@@ -167,8 +167,6 @@ module cv32e40x_mult import cv32e40x_pkg::*;
           valid_o = 1'b0;
           mulh_acc_next = '0;
         end else begin  
-          mulh_a            = mulh_ah;
-          mulh_b            = mulh_bh;
           valid_o           = 1'b1;
           mulh_acc_next     = mulh_acc;
           if (ready_i) begin
@@ -177,6 +175,8 @@ module cv32e40x_mult import cv32e40x_pkg::*;
             mulh_acc_next   = '0;
           end
         end
+        mulh_a            = mulh_ah;
+        mulh_b            = mulh_bh;
       end
       default: ;
     endcase

--- a/rtl/cv32e40x_mult.sv
+++ b/rtl/cv32e40x_mult.sv
@@ -118,18 +118,16 @@ module cv32e40x_mult import cv32e40x_pkg::*;
     case (mulh_state)
       MUL_ALBL: begin
         ready_o = 1'b1;
-        if (valid_i) begin
-          if (operator_i == MUL_H) begin
-            // Multicycle multiplication
-            mulh_shift      = 1'b1;
-            ready_o         = 1'b0;
-            mulh_state_next = MUL_ALBH;
-          end
-          else begin
-            // Single cycle multiplication
-            valid_o         = 1'b1;
-            mulh_acc_next   = '0;
-          end
+        if (operator_i == MUL_H) begin
+          // Multicycle multiplication
+          mulh_shift      = 1'b1;
+          ready_o         = 1'b0;
+          mulh_state_next = MUL_ALBH;
+        end
+        else begin
+          // Single cycle multiplication
+          valid_o         = 1'b1;
+          mulh_acc_next   = '0;
         end
       end
 
@@ -169,7 +167,6 @@ module cv32e40x_mult import cv32e40x_pkg::*;
     end
   end // always_comb
 
-  //TODO:medium Area increased after introducing killable mult (valid_i -> !valid_i during mult), investigate why and fix.
   always_ff @(posedge clk, negedge rst_n) begin
     if (~rst_n) begin
       mulh_acc   <=  '0;


### PR DESCRIPTION
Not SEC clean, fails on cutpoint on multiplier results when
being killed.

Reduces area.

Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>