### PR TITLE
MULT/DIV cleanup; fixed MULT ready signal; added todos

### DIFF
--- a/rtl/cv32e40x_controller_bypass.sv
+++ b/rtl/cv32e40x_controller_bypass.sv
@@ -55,7 +55,7 @@ module cv32e40x_controller_bypass import cv32e40x_pkg::*;
 
   // From WB
   input  logic        rf_we_wb_i,                 // Register file write enable from WB stage
-  input rf_addr_t     rf_waddr_wb_i,              // write address currently in WB
+  input  rf_addr_t    rf_waddr_wb_i,              // write address currently in WB
   input  logic        wb_ready_i,                 // WB stage is ready
   input  logic        lsu_en_wb_i,                // LSU data is written back in WB
 
@@ -193,19 +193,17 @@ module cv32e40x_controller_bypass import cv32e40x_pkg::*;
     ctrl_byp_o.jalr_fw_mux_sel      = SELJ_REGFILE;
 
     // Forwarding WB -> ID
-    if (rf_we_wb_i)
-    begin
+    if (rf_we_wb_i) begin
       if (rf_rd_wb_match[0]) begin
         ctrl_byp_o.operand_a_fw_mux_sel = SEL_FW_WB;
       end
-      if ( rf_rd_wb_match[1]) begin
+      if (rf_rd_wb_match[1]) begin
         ctrl_byp_o.operand_b_fw_mux_sel = SEL_FW_WB;
       end
     end
 
     // Forwarding EX -> ID (not actually used when there is a load in EX)
-    if (rf_we_ex_i)
-    begin
+    if (rf_we_ex_i) begin
       if (rf_rd_ex_match[0]) begin
         ctrl_byp_o.operand_a_fw_mux_sel = SEL_FW_EX;
       end

--- a/rtl/cv32e40x_controller_fsm.sv
+++ b/rtl/cv32e40x_controller_fsm.sv
@@ -321,7 +321,7 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
 
     ctrl_fsm_o.csr_restore_mret    = 1'b0;
     ctrl_fsm_o.csr_restore_dret    = 1'b0;
-    ctrl_fsm_o.csr_save_if         = 1'b0;
+    ctrl_fsm_o.csr_save_if         = 1'b0; // todo: can we send the correct pc to the CSR module instead of the separate save_* signals? (Keep the save signals local to this file, but move the pc mux from CSR to here)
     ctrl_fsm_o.csr_save_id         = 1'b0;
     ctrl_fsm_o.csr_save_ex         = 1'b0;
     ctrl_fsm_o.csr_save_wb         = 1'b0;
@@ -456,8 +456,8 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
             ctrl_fsm_o.kill_id = 1'b1;
             ctrl_fsm_o.kill_ex = 1'b1;
             
-            ctrl_fsm_o.pc_mux      = PC_DRET;
-            ctrl_fsm_o.pc_set      = 1'b1;
+            ctrl_fsm_o.pc_mux  = PC_DRET;
+            ctrl_fsm_o.pc_set  = 1'b1;
 
             ctrl_fsm_o.csr_restore_dret  = 1'b1;
 
@@ -554,7 +554,7 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
           // Save pc from oldest valid instruction
           if (ex_wb_pipe_i.instr_valid) begin
             ctrl_fsm_o.csr_save_wb = 1'b1;
-          end else if (id_ex_pipe_i.instr_valid && !id_ex_pipe_i.lsu_misaligned) begin
+          end else if (id_ex_pipe_i.instr_valid && !id_ex_pipe_i.lsu_misaligned) begin // todo: this same condition is not used in other places where ctrl_fsm_o.csr_save_ex is set to 1; what is the difference?
             ctrl_fsm_o.csr_save_ex = 1'b1;
           end else if (if_id_pipe_i.instr_valid) begin
             ctrl_fsm_o.csr_save_id = 1'b1;


### PR DESCRIPTION
SEC clean (the multiplier ready_o error did not propagate onto ex_ready as wb_ready_i was ANDed into ex_ready via other paths)
Signed-off-by: Arjan Bink <Arjan.Bink@silabs.com>