### PR TITLE
Jumps and branches will only be active for one cycle.

### DIFF
--- a/rtl/cv32e40x_controller_fsm.sv
+++ b/rtl/cv32e40x_controller_fsm.sv
@@ -183,8 +183,8 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
                               ex_wb_pipe_i.ecall_insn                 ? EXC_CAUSE_ECALL_MMODE     :
                               EXC_CAUSE_BREAKPOINT;
 
-  // wfi in wb, if debug_mode we treat it as a NOP
-  assign wfi_in_wb = ex_wb_pipe_i.wfi_insn && ex_wb_pipe_i.instr_valid && !debug_mode_q;
+  // wfi in wb
+  assign wfi_in_wb = ex_wb_pipe_i.wfi_insn && ex_wb_pipe_i.instr_valid;
 
   // fencei in wb
   assign fencei_in_wb = ex_wb_pipe_i.fencei_insn && ex_wb_pipe_i.instr_valid;

--- a/rtl/cv32e40x_i_decoder.sv
+++ b/rtl/cv32e40x_i_decoder.sv
@@ -322,15 +322,15 @@ module cv32e40x_i_decoder import cv32e40x_pkg::*;
 
               12'h105:  // wfi
               begin
-                decoder_ctrl_o.wfi_insn = 1'b1;
-                if (ctrl_fsm_i.debug_wfi_no_sleep) begin
-                  // Treat as NOP (do not cause sleep mode entry)
-                  // Using decoding similar to ADDI, but without register reads/writes, i.e.
-                  // keep rf_we = 0, rf_re[0] = 0
-                  decoder_ctrl_o.alu_op_b_mux_sel = OP_B_IMM;
-                  decoder_ctrl_o.imm_b_mux_sel    = IMMB_I;
-                  decoder_ctrl_o.alu_operator     = ALU_ADD;
-                end
+                // Treat as NOP
+                // Using decoding similar to ADDI, but without register reads/writes, i.e.
+                // keep rf_we = 0, rf_re[0] = 0
+                // Suppressing wfi_insn bit in case of ctrl_fsm_i.debug_wfi_no_sleep to prevent
+                // sleeping when not allowed to.
+                decoder_ctrl_o.wfi_insn = ctrl_fsm_i.debug_wfi_no_sleep ? 1'b0 : 1'b1;
+                decoder_ctrl_o.alu_op_b_mux_sel = OP_B_IMM;
+                decoder_ctrl_o.imm_b_mux_sel    = IMMB_I;
+                decoder_ctrl_o.alu_operator     = ALU_ADD;
               end
 
               default:


### PR DESCRIPTION
This will allow IF (and ID) to fill up with the jump/branch
target while EX stage may be stalled. Slightly improves performance.

Bugfix to debug entry killing of stages.

Requires an update to RVFI to properly detect jumps in ID (and possibly branches in EX)

Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>