### PR TITLE
Changed minstret to (hopefully) correctly count retired instructions.

### DIFF
--- a/bhv/cv32e40x_rvfi.sv
+++ b/bhv/cv32e40x_rvfi.sv
@@ -693,8 +693,8 @@ module cv32e40x_rvfi
   assign rvfi_csr_wdata_d.mcycle             = csr_mhpmcounter_n_l [CSR_MCYCLE & 'hF];
   assign rvfi_csr_wmask_d.mcycle             = csr_mhpmcounter_we_l[CSR_MCYCLE & 'hF];
 
-  assign rvfi_csr_rdata_d.minstret           = csr_mhpmcounter_q_l [CSR_MINSTRET & 'hF];
-  assign rvfi_csr_wdata_d.minstret           = csr_mhpmcounter_q_l [CSR_MINSTRET & 'hF];
+  assign rvfi_csr_rdata_d.minstret           = csr_mhpmcounter_q_l [CSR_MINSTRET & 'hF]; // not compliant to RVFI spec
+  assign rvfi_csr_wdata_d.minstret           = csr_mhpmcounter_n_l [CSR_MINSTRET & 'hF]; // not compliant to RVFI spec
   assign rvfi_csr_wmask_d.minstret           = csr_mhpmcounter_we_l[CSR_MINSTRET & 'hF];
 
   assign rvfi_csr_rdata_d.mhpmcounter[ 2:0]  = 'Z;

--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -358,9 +358,9 @@ bind cv32e40x_sleep_unit:
          .csr_dscratch1_q_i        ( core_i.cs_registers_i.dscratch1_q                                    ),
          .csr_dscratch1_n_i        ( core_i.cs_registers_i.dscratch1_n                                    ),
          .csr_dscratch1_we_i       ( core_i.cs_registers_i.dscratch1_we                                   ),
-         .csr_mhpmcounter_n_i      ( '0                               /* TODO:Connect when implemented */ ),
+         .csr_mhpmcounter_n_i      ( core_i.cs_registers_i.mhpmcounter_n                                  ),
          .csr_mhpmcounter_q_i      ( core_i.cs_registers_i.mhpmcounter_q                                  ),
-         .csr_mhpmcounter_we_i     ( '0                               /* TODO:Connect when implemented */ ),
+         .csr_mhpmcounter_we_i     ( core_i.cs_registers_i.mhpmcounter_we                                 ),
          .csr_mvendorid_i          ( {MVENDORID_BANK, MVENDORID_OFFSET}                                   ),
          .csr_marchid_i            ( MARCHID                                                              ),
          .csr_mhartid_i            ( core_i.cs_registers_i.hart_id_i                                      )

--- a/rtl/cv32e40x_controller.sv
+++ b/rtl/cv32e40x_controller.sv
@@ -46,6 +46,7 @@ module cv32e40x_controller import cv32e40x_pkg::*;
   input  logic        dret_id_i,
   input  logic        csr_en_id_i,
   input  csr_opcode_e csr_op_id_i,
+  input  csr_num_e    csr_raddr_ex_i,
 
   input  id_ex_pipe_t id_ex_pipe_i,
   input  ex_wb_pipe_t ex_wb_pipe_i,
@@ -174,6 +175,7 @@ module cv32e40x_controller import cv32e40x_pkg::*;
     .dret_id_i                  ( dret_id_i                ),
     .csr_en_id_i                ( csr_en_id_i              ),
     .csr_op_id_i                ( csr_op_id_i              ),
+    .csr_raddr_ex_i             ( csr_raddr_ex_i           ),
     .debug_trigger_match_id_i   ( debug_trigger_match_id_i ),
 
     // From EX

--- a/rtl/cv32e40x_controller_bypass.sv
+++ b/rtl/cv32e40x_controller_bypass.sv
@@ -48,7 +48,7 @@ module cv32e40x_controller_bypass import cv32e40x_pkg::*;
   input  logic        dret_id_i,                  // dret in ID
   input  logic        csr_en_id_i,                // CSR in ID
   input  csr_opcode_e csr_op_id_i,                // CSR opcode (ID)
-  input  csr_num_e    csr_raddr_ex_i,             // CSR read address (ID)
+  input  csr_num_e    csr_raddr_ex_i,             // CSR read address (EX)
   input  logic        debug_trigger_match_id_i,         // Trigger match in ID
   // From EX
   input  logic        rf_we_ex_i,                 // Register file write enable from EX stage

--- a/rtl/cv32e40x_controller_fsm.sv
+++ b/rtl/cv32e40x_controller_fsm.sv
@@ -243,7 +243,7 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
                               !id_ex_pipe_i.lsu_misaligned)) && !debug_mode_q;
                                
   // Performance counter events
-  assign ctrl_fsm_o.mhpmevent.minstret = ex_wb_pipe_i.instr_valid; // todo:low Not correct; just put something here such that minstret counter will not get optimized away (and did not use wb_valid to avoid long timing path)
+  assign ctrl_fsm_o.mhpmevent.minstret = ex_wb_pipe_i.instr_valid && !exception_in_wb && !ctrl_fsm_o.kill_wb && !ctrl_fsm_o.halt_wb; // todo: Should maybe use wb_stage local instr_valid, as the current code remakes that here.
   assign ctrl_fsm_o.mhpmevent.load = 1'b0; // todo:low
   assign ctrl_fsm_o.mhpmevent.store = 1'b0; // todo:low
   assign ctrl_fsm_o.mhpmevent.jump = 1'b0; // todo:low
@@ -322,7 +322,8 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
     // ID stage is halted for regular stalls (i.e. stalls for which the instruction
     // currently in ID is not ready to be issued yet)
     ctrl_fsm_o.halt_id = ctrl_byp_i.jr_stall || ctrl_byp_i.load_stall || ctrl_byp_i.csr_stall || ctrl_byp_i.wfi_stall;
-    ctrl_fsm_o.halt_ex = 1'b0;
+    // EX stage is halted when minstret/h is read
+    ctrl_fsm_o.halt_ex = ctrl_byp_i.minstret_stall;
     ctrl_fsm_o.halt_wb = 1'b0;
 
     // By default no stages are killed

--- a/rtl/cv32e40x_core.sv
+++ b/rtl/cv32e40x_core.sv
@@ -214,6 +214,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
  
   logic        csr_en_id;
   csr_opcode_e csr_op_id;
+  csr_num_e    csr_raddr_ex;
 
   // irq signals
   // TODO:AB Should find a proper suffix for signals from interrupt_controller
@@ -602,6 +603,8 @@ module cv32e40x_core import cv32e40x_pkg::*;
     // From controller FSM
     .ctrl_fsm_i                 ( ctrl_fsm               ),
 
+    .csr_raddr_o                ( csr_raddr_ex           ),
+
     // Interface to CSRs (SRAM like)
     .csr_rdata_o                ( csr_rdata              ),
 
@@ -653,6 +656,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .dret_id_i                      ( dret_insn_id           ),
     .csr_en_id_i                    ( csr_en_id              ),
     .csr_op_id_i                    ( csr_op_id              ),
+    .csr_raddr_ex_i                 ( csr_raddr_ex           ),
                                                                  
     // LSU
     .lsu_misaligned_i               ( lsu_misaligned_ex      ),

--- a/rtl/cv32e40x_cs_registers.sv
+++ b/rtl/cv32e40x_cs_registers.sv
@@ -860,7 +860,7 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
     end
   endgenerate
 
-    // ------------------------
+  // ------------------------
   // HPM Registers
   // next value
   genvar nxt_gidx;

--- a/rtl/cv32e40x_ex_stage.sv
+++ b/rtl/cv32e40x_ex_stage.sv
@@ -340,6 +340,6 @@ module cv32e40x_ex_stage import cv32e40x_pkg::*;
                        (id_ex_pipe_i.div_en && div_valid) ||
                        (id_ex_pipe_i.csr_en && csr_valid) ||
                        previous_exception // todo:ab:remove
-                      ) && instr_valid;
+                      ) && instr_valid && !ctrl_fsm_i.halt_ex;
 
 endmodule // cv32e40x_ex_stage

--- a/rtl/include/cv32e40x_pkg.sv
+++ b/rtl/include/cv32e40x_pkg.sv
@@ -1019,6 +1019,7 @@ typedef struct packed {
   logic        load_stall;            // Stall due to load operation
   logic        csr_stall;
   logic        wfi_stall;
+  logic        minstret_stall;        // Stall due to minstret/h read in EX
   logic        deassert_we;           // Deassert write enable for next instruction
   logic        deassert_we_special;   // Deassert write enable and special insn bits
 } ctrl_byp_t;


### PR DESCRIPTION
Halting EX stage in case of minstret/h read in EX and any valid instruction in WB.
Halting to get correct value for reading minstret to GPR.

No errors for CSR minstret checks in ci_check.

Not SEC clean

Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>