### PR TITLE
Pma assertions

### DIFF
--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -223,7 +223,8 @@ bind cv32e40x_sleep_unit:
     cv32e40x_mpu_sva
       #(.PMA_NUM_REGIONS(PMA_NUM_REGIONS),
         .PMA_CFG(PMA_CFG))
-  mpu_if_sva(.*);
+  mpu_if_sva(.pma_addr(pma_i.trans_addr_i),
+             .*);
 
   // TODO: Reintroduce once LSU PMA support has been properly implemented in the controller
   /*

--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -221,24 +221,37 @@ bind cv32e40x_sleep_unit:
     core_i.if_stage_i.mpu_i 
     cv32e40x_mpu_sva
       #(.PMA_NUM_REGIONS(PMA_NUM_REGIONS),
-        .PMA_CFG(PMA_CFG))
+        .PMA_CFG(PMA_CFG),
+        .IS_INSTR_SIDE(1))
   mpu_if_sva(.pma_addr(pma_i.trans_addr_i),
-             .pma_cfg(pma_i.pma_cfg),
+             .pma_cfg (pma_i.pma_cfg),
              .instr_memtype_o(core_i.instr_memtype_o),
-             .instr_addr_o(core_i.instr_addr_o),
-             .instr_req_o(core_i.instr_req_o),
-             .instr_gnt_i(core_i.instr_gnt_i),
+             .instr_addr_o   (core_i.instr_addr_o),
+             .instr_req_o    (core_i.instr_req_o),
+             .instr_gnt_i    (core_i.instr_gnt_i),
+             .data_memtype_o('X),
+             .data_addr_o   ('X),
+             .data_req_o    ('X),
+             .data_gnt_i    ('X),
              .*);
 
-  // TODO:low Reintroduce once LSU PMA support has been properly implemented in the controller
-  /*
   bind cv32e40x_mpu:
     core_i.load_store_unit_i.mpu_i
     cv32e40x_mpu_sva
       #(.PMA_NUM_REGIONS(PMA_NUM_REGIONS),
-        .PMA_CFG(PMA_CFG))
-  mpu_lsu_sva(.*);
-  */
+        .PMA_CFG(PMA_CFG),
+        .IS_INSTR_SIDE(0))
+  mpu_lsu_sva(.pma_addr(pma_i.trans_addr_i),
+             .pma_cfg (pma_i.pma_cfg),
+             .instr_memtype_o('X),
+             .instr_addr_o   ('X),
+             .instr_req_o    ('X),
+             .instr_gnt_i    ('X),
+             .data_memtype_o(core_i.data_memtype_o),
+             .data_addr_o   (core_i.data_addr_o),
+             .data_req_o    (core_i.data_req_o),
+             .data_gnt_i    (core_i.data_gnt_i),
+             .*);
 `endif //  `ifndef COREV_ASSERT_OFF
   
     cv32e40x_core_log

--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -226,6 +226,8 @@ bind cv32e40x_sleep_unit:
              .pma_cfg(pma_i.pma_cfg),
              .instr_memtype_o(core_i.instr_memtype_o),
              .instr_addr_o(core_i.instr_addr_o),
+             .instr_req_o(core_i.instr_req_o),
+             .instr_gnt_i(core_i.instr_gnt_i),
              .*);
 
   // TODO:low Reintroduce once LSU PMA support has been properly implemented in the controller

--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -225,6 +225,7 @@ bind cv32e40x_sleep_unit:
   mpu_if_sva(.pma_addr(pma_i.trans_addr_i),
              .pma_cfg(pma_i.pma_cfg),
              .instr_memtype_o(core_i.instr_memtype_o),
+             .instr_addr_o(core_i.instr_addr_o),
              .*);
 
   // TODO:low Reintroduce once LSU PMA support has been properly implemented in the controller

--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -224,6 +224,7 @@ bind cv32e40x_sleep_unit:
       #(.PMA_NUM_REGIONS(PMA_NUM_REGIONS),
         .PMA_CFG(PMA_CFG))
   mpu_if_sva(.pma_addr(pma_i.trans_addr_i),
+             .pma_cfg(pma_i.pma_cfg),
              .*);
 
   // TODO: Reintroduce once LSU PMA support has been properly implemented in the controller

--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -225,14 +225,10 @@ bind cv32e40x_sleep_unit:
         .IS_INSTR_SIDE(1))
   mpu_if_sva(.pma_addr(pma_i.trans_addr_i),
              .pma_cfg (pma_i.pma_cfg),
-             .instr_memtype_o(core_i.instr_memtype_o),
-             .instr_addr_o   (core_i.instr_addr_o),
-             .instr_req_o    (core_i.instr_req_o),
-             .instr_gnt_i    (core_i.instr_gnt_i),
-             .data_memtype_o('X),
-             .data_addr_o   ('X),
-             .data_req_o    ('X),
-             .data_gnt_i    ('X),
+             .obi_memtype(core_i.instr_memtype_o),
+             .obi_addr   (core_i.instr_addr_o),
+             .obi_req    (core_i.instr_req_o),
+             .obi_gnt    (core_i.instr_gnt_i),
              .*);
 
   bind cv32e40x_mpu:
@@ -243,14 +239,10 @@ bind cv32e40x_sleep_unit:
         .IS_INSTR_SIDE(0))
   mpu_lsu_sva(.pma_addr(pma_i.trans_addr_i),
              .pma_cfg (pma_i.pma_cfg),
-             .instr_memtype_o('X),
-             .instr_addr_o   ('X),
-             .instr_req_o    ('X),
-             .instr_gnt_i    ('X),
-             .data_memtype_o(core_i.data_memtype_o),
-             .data_addr_o   (core_i.data_addr_o),
-             .data_req_o    (core_i.data_req_o),
-             .data_gnt_i    (core_i.data_gnt_i),
+             .obi_memtype(core_i.data_memtype_o),
+             .obi_addr   (core_i.data_addr_o),
+             .obi_req    (core_i.data_req_o),
+             .obi_gnt    (core_i.data_gnt_i),
              .*);
 `endif //  `ifndef COREV_ASSERT_OFF
   

--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -225,6 +225,7 @@ bind cv32e40x_sleep_unit:
         .PMA_CFG(PMA_CFG))
   mpu_if_sva(.pma_addr(pma_i.trans_addr_i),
              .pma_cfg(pma_i.pma_cfg),
+             .instr_memtype_o(core_i.instr_memtype_o),
              .*);
 
   // TODO: Reintroduce once LSU PMA support has been properly implemented in the controller

--- a/sva/cv32e40x_mpu_sva.sv
+++ b/sva/cv32e40x_mpu_sva.sv
@@ -112,9 +112,11 @@ module cv32e40x_mpu_sva import cv32e40x_pkg::*; import uvm_pkg::*;
       end
     end
   end
-  cov_pma_matchnone : cover property (@(posedge clk) disable iff (!rst_n) (!is_pma_matched));
-  cov_pma_matchfirst : cover property (@(posedge clk) disable iff (!rst_n) (is_pma_matched && (pma_match_num == 0)));
-  cov_pma_matchother : cover property (@(posedge clk) disable iff (!rst_n) (is_pma_matched && (pma_match_num > 0)));
+  `ifndef FORMAL
+    cov_pma_matchnone : cover property (@(posedge clk) disable iff (!rst_n) (!is_pma_matched));
+    cov_pma_matchfirst : cover property (@(posedge clk) disable iff (!rst_n) (is_pma_matched && (pma_match_num == 0)));
+    cov_pma_matchother : cover property (@(posedge clk) disable iff (!rst_n) (is_pma_matched && (pma_match_num > 0)));
+  `endif
 
 
   // Checks for illegal PMA region configuration
@@ -213,11 +215,15 @@ module cv32e40x_mpu_sva import cv32e40x_pkg::*; import uvm_pkg::*;
     x_err_cacheable: cross cp_err, cp_cacheable;
     x_err_atomic: cross cp_err, cp_atomic;
   endgroup
-  cg_pma cgpma = new;
+  `ifndef FORMAL
+    cg_pma cgpma = new;
+  `endif
 
-  cov_pma_nondefault :
-    cover property (@(posedge clk) disable iff (!rst_n)
-      (pma_cfg != PMA_R_DEFAULT) && bus_trans_valid_o);
+  `ifndef FORMAL
+    cov_pma_nondefault :
+      cover property (@(posedge clk) disable iff (!rst_n)
+        (pma_cfg != PMA_R_DEFAULT) && bus_trans_valid_o);
+  `endif
 
 
   // Should only give MPU error response during mpu_err_trans_valid

--- a/sva/cv32e40x_mpu_sva.sv
+++ b/sva/cv32e40x_mpu_sva.sv
@@ -216,18 +216,20 @@ module cv32e40x_mpu_sva import cv32e40x_pkg::*; import uvm_pkg::*;
   covergroup cg_pma @(posedge clk);
     cp_err: coverpoint pma_err;
     cp_exec: coverpoint execute_access_i;
-    //TODO "cp_speculative"?
     cp_bufferable: coverpoint bus_trans_bufferable;
     cp_cacheable: coverpoint bus_trans_cacheable;
     cp_atomic: coverpoint atomic_access_i;
-    cp_addr: coverpoint pma_addr[31:2] {  // TODO check if spec justifies this
+    cp_addr: coverpoint pma_addr[31:2] {
       bins min = {0};
       bins max = {30'h 3FFF_FFFF};
       bins range[3] = {[1 : 30'h 3FFF_FFFe]};
       illegal_bins il = default;
       }
 
-    //TODO crosses
+    x_err_exec: cross cp_err, cp_exec;
+    x_err_bufferable: cross cp_err, cp_bufferable;
+    x_err_cacheable: cross cp_err, cp_cacheable;
+    x_err_atomic: cross cp_err, cp_atomic;
   endgroup
   cg_pma cgpma = new;
 

--- a/sva/cv32e40x_mpu_sva.sv
+++ b/sva/cv32e40x_mpu_sva.sv
@@ -193,11 +193,11 @@ module cv32e40x_mpu_sva import cv32e40x_pkg::*; import uvm_pkg::*;
   assign obibuf_excuse = IS_INSTR_SIDE && bus_trans_bufferable && (was_obi_reqnognt && !was_obi_memtype[0]);
   a_pma_obi_bufon :
     assert property (@(posedge clk) disable iff (!rst_n)
-                     obibuf_expected |-> (obi_memtype[0] || obibuf_excuse))
+                     obi_memtype[0] |-> obibuf_expected && !obibuf_excuse)
       else `uvm_error("mpu", "obi should have had bufferable flag")
   a_pma_obi_bufoff :
     assert property (@(posedge clk) disable iff (!rst_n)
-                     !obibuf_expected |-> !(obi_memtype[0] || obibuf_excuse))
+                     !obi_memtype[0] |-> !(obibuf_expected && !obibuf_excuse))
       else `uvm_error("mpu", "obi should not have had bufferable flag")
 
   // Cacheable
@@ -207,11 +207,11 @@ module cv32e40x_mpu_sva import cv32e40x_pkg::*; import uvm_pkg::*;
   assign obicache_excuse = IS_INSTR_SIDE && bus_trans_cacheable && (was_obi_reqnognt && !was_obi_memtype[1]);
   a_pma_obi_cacheon :
     assert property (@(posedge clk) disable iff (!rst_n)
-                     obicache_expected |-> (obi_memtype[1] || obicache_excuse))
+                     obi_memtype[1] |-> obicache_expected && !obicache_excuse)
       else `uvm_error("mpu", "obi should have had cacheable flag")
   a_pma_obi_cacheoff :
     assert property (@(posedge clk) disable iff (!rst_n)
-                     !obicache_expected |-> !(obi_memtype[1] || obicache_excuse))
+                     !obi_memtype[1] |-> !(obicache_expected && !obicache_excuse))
       else `uvm_error("mpu", "obi should not have had cacheable flag")
 
   // OBI req vs PMA err

--- a/sva/cv32e40x_mpu_sva.sv
+++ b/sva/cv32e40x_mpu_sva.sv
@@ -185,24 +185,24 @@ module cv32e40x_mpu_sva import cv32e40x_pkg::*; import uvm_pkg::*;
   a_pma_obi_bufon :
     assert property (@(posedge clk) disable iff (!rst_n)
                      bus_trans_bufferable
-                     |-> obi_memtype[0] ^ (!obi_memtype[0] && was_obi_waiting && !$past(obi_memtype[0])))
+                     |-> obi_memtype[0] ^ (!obi_memtype[0] && was_obi_waiting && !$past(obi_memtype[0]) && IS_INSTR_SIDE))
       else `uvm_error("mpu", "obi should have had bufferable flag")
   a_pma_obi_bufoff :
     assert property (@(posedge clk) disable iff (!rst_n)
                      !bus_trans_bufferable
-                     |-> !obi_memtype[0] ^ (obi_memtype[0] && was_obi_waiting && $past(obi_memtype[0])))
+                     |-> !obi_memtype[0] ^ (obi_memtype[0] && was_obi_waiting && $past(obi_memtype[0]) && IS_INSTR_SIDE))
       else `uvm_error("mpu", "obi should not have had bufferable flag")
 
   // Cacheable
   a_pma_obi_cacheon :
     assert property (@(posedge clk) disable iff (!rst_n)
                      bus_trans_cacheable
-                     |-> obi_memtype[1] ^ (!obi_memtype[1] && was_obi_waiting && !$past(obi_memtype[1])))
+                     |-> obi_memtype[1] ^ (!obi_memtype[1] && was_obi_waiting && !$past(obi_memtype[1]) && IS_INSTR_SIDE))
       else `uvm_error("mpu", "obi should have had cacheable flag")
   a_pma_obi_cacheoff :
     assert property (@(posedge clk) disable iff (!rst_n)
                      !bus_trans_cacheable
-                     |-> !obi_memtype[1] ^ (obi_memtype[1] && was_obi_waiting && $past(obi_memtype[1])))
+                     |-> !obi_memtype[1] ^ (obi_memtype[1] && was_obi_waiting && $past(obi_memtype[1]) && IS_INSTR_SIDE))
       else `uvm_error("mpu", "obi should not have had cacheable flag")
 
   // OBI req vs PMA err

--- a/sva/cv32e40x_mpu_sva.sv
+++ b/sva/cv32e40x_mpu_sva.sv
@@ -157,27 +157,27 @@ module cv32e40x_mpu_sva import cv32e40x_pkg::*; import uvm_pkg::*;
       else `uvm_error("mpu", "illegal cfg index")
 
   // Bufferable
-  a_pma_obi_bufrequired :
+  a_pma_obi_bufon :
     assert property (@(posedge clk) disable iff (!rst_n)
                      bus_trans_bufferable
                      |-> obi_memtype[0] ^ (!obi_memtype[0] && was_obi_waiting && !$past(obi_memtype[0])))
       else `uvm_error("mpu", "obi should have had bufferable flag")
-  a_pma_obi_bufallowed :
+  a_pma_obi_bufoff :
     assert property (@(posedge clk) disable iff (!rst_n)
-                     obi_memtype[0]
-                     |-> bus_trans_bufferable ^ (!bus_trans_bufferable && was_obi_waiting && $past(obi_memtype[0])))
+                     !bus_trans_bufferable
+                     |-> !obi_memtype[0] ^ (obi_memtype[0] && was_obi_waiting && $past(obi_memtype[0])))
       else `uvm_error("mpu", "obi should not have had bufferable flag")
 
   // Cacheable
-  a_pma_obi_cacherequired :
+  a_pma_obi_cacheon :
     assert property (@(posedge clk) disable iff (!rst_n)
                      bus_trans_cacheable
                      |-> obi_memtype[1] ^ (!obi_memtype[1] && was_obi_waiting && !$past(obi_memtype[1])))
       else `uvm_error("mpu", "obi should have had cacheable flag")
-  a_pma_obi_cacheallowed :
+  a_pma_obi_cacheoff :
     assert property (@(posedge clk) disable iff (!rst_n)
-                     obi_memtype[1]
-                     |-> bus_trans_cacheable ^ (!bus_trans_cacheable && was_obi_waiting && $past(obi_memtype[1])))
+                     !bus_trans_cacheable
+                     |-> !obi_memtype[1] ^ (obi_memtype[1] && was_obi_waiting && $past(obi_memtype[1])))
       else `uvm_error("mpu", "obi should not have had cacheable flag")
 
   // OBI req vs PMA err

--- a/sva/cv32e40x_mpu_sva.sv
+++ b/sva/cv32e40x_mpu_sva.sv
@@ -201,8 +201,8 @@ module cv32e40x_mpu_sva import cv32e40x_pkg::*; import uvm_pkg::*;
     assert property (@(posedge clk)
                      obi_req
                      |->
-                     (!was_obi_waiting && !pma_err && is_addr_match)  // TODO should be "naturally disjoint"?
-                     ^ (was_obi_waiting && $past(obi_req)))
+                     (!pma_err && is_addr_match)
+                     ^ (!is_addr_match && was_obi_waiting && $past(obi_req)))
       else `uvm_error("mpu", "obi made request to pma-forbidden region")
   a_pma_obi_reqdenied :
     assert property (@(posedge clk)

--- a/sva/cv32e40x_mpu_sva.sv
+++ b/sva/cv32e40x_mpu_sva.sv
@@ -52,10 +52,11 @@ module cv32e40x_mpu_sva import cv32e40x_pkg::*; import uvm_pkg::*;
    input              mpu_state_e state_q,
    input logic        mpu_err
    );
-  
-  // Checks for illegal PMA region configuration
-  initial begin : p_mpu_assertions
 
+
+  // Checks for illegal PMA region configuration
+
+  initial begin : p_mpu_assertions
     if (PMA_NUM_REGIONS != 0) begin
       assert (PMA_NUM_REGIONS == $size(PMA_CFG)) else `uvm_error("mpu", "PMA_CFG must contain PMA_NUM_REGION entries")
     end
@@ -69,9 +70,14 @@ module cv32e40x_mpu_sva import cv32e40x_pkg::*; import uvm_pkg::*;
         assert (!PMA_CFG[i].cacheable) else `uvm_error("mpu", "PMA regions configured as I/O cannot be defined as cacheable")
       end
     end
-    
   end
-  
+
+  a_pma_valid_num_regions :
+    assert property (@(posedge clk)
+                     (0 <= PMA_NUM_REGIONS) && (PMA_NUM_REGIONS <= 16))
+      else `uvm_error("mpu", "PMA number of regions is badly configured")
+
+
   // Should only give MPU error response during mpu_err_trans_valid
   a_mpu_status_no_obi_rvalid :
     assert property (@(posedge clk)

--- a/sva/cv32e40x_mpu_sva.sv
+++ b/sva/cv32e40x_mpu_sva.sv
@@ -43,14 +43,10 @@ module cv32e40x_mpu_sva import cv32e40x_pkg::*; import uvm_pkg::*;
    input pma_region_t pma_cfg,
 
    // Core OBI signals
-   input logic [ 1:0] instr_memtype_o,
-   input logic [31:0] instr_addr_o,
-   input logic        instr_req_o,
-   input logic        instr_gnt_i,
-   input logic [ 1:0] data_memtype_o,
-   input logic [31:0] data_addr_o,
-   input logic        data_req_o,
-   input logic        data_gnt_i,
+   input logic [ 1:0] obi_memtype,
+   input logic [31:0] obi_addr,
+   input logic        obi_req,
+   input logic        obi_gnt,
 
    // Interface towards bus interface
    input logic        bus_trans_ready_i,
@@ -71,27 +67,6 @@ module cv32e40x_mpu_sva import cv32e40x_pkg::*; import uvm_pkg::*;
    input              mpu_state_e state_q,
    input logic        mpu_err
    );
-
-
-  // Assign local signals depending on instr/data side instantiation
-
-  logic [ 1:0] obi_memtype;
-  logic [31:0] obi_addr;
-  logic        obi_req;
-  logic        obi_gnt;
-  generate
-    if (IS_INSTR_SIDE) begin
-      assign obi_memtype = instr_memtype_o;
-      assign obi_addr = instr_addr_o;
-      assign obi_req = instr_req_o;
-      assign obi_gnt = instr_gnt_i;
-    end else begin
-      assign obi_memtype = data_memtype_o;
-      assign obi_addr = data_addr_o;
-      assign obi_req = data_req_o;
-      assign obi_gnt = data_gnt_i;
-    end
-  endgenerate
 
 
   // PMA assertions helper signals


### PR DESCRIPTION
This PR adds assertions for the PMA.

It adds a IS_INSTR_SIDE parameter to the sva module and also a few signals for connecting to the obi bus.
Then it adds the assertions themselves (according to the PMA vPlan) plus some helper logic.
Covers were added to make sure formal isn't overconstrained, to guide simulation testing, and for the insight they provide.

_NB. I did not get anyone else to review the assertions (neither the assertions alone or compared to the vPlan)._

_NB. Formal fails because all coverage is not reachable from all pma configs. I did not figure out a solution to this._