### PR TITLE
Minstret updates to make clean ci_check

### DIFF
--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -358,9 +358,9 @@ bind cv32e40x_sleep_unit:
          .csr_dscratch1_q_i        ( core_i.cs_registers_i.dscratch1_q                                    ),
          .csr_dscratch1_n_i        ( core_i.cs_registers_i.dscratch1_n                                    ),
          .csr_dscratch1_we_i       ( core_i.cs_registers_i.dscratch1_we                                   ),
-         .csr_mhpmcounter_n_i      ( '0                               /* TODO:Connect when implemented */ ),
+         .csr_mhpmcounter_n_i      ( core_i.cs_registers_i.mhpmcounter_n                                  ),
          .csr_mhpmcounter_q_i      ( core_i.cs_registers_i.mhpmcounter_q                                  ),
-         .csr_mhpmcounter_we_i     ( '0                               /* TODO:Connect when implemented */ ),
+         .csr_mhpmcounter_we_i     ( core_i.cs_registers_i.mhpmcounter_we                                 ),
          .csr_mvendorid_i          ( {MVENDORID_BANK, MVENDORID_OFFSET}                                   ),
          .csr_marchid_i            ( MARCHID                                                              ),
          .csr_mhartid_i            ( core_i.cs_registers_i.hart_id_i                                      )

--- a/rtl/cv32e40x_controller.sv
+++ b/rtl/cv32e40x_controller.sv
@@ -75,22 +75,26 @@ module cv32e40x_controller import cv32e40x_pkg::*;
   input  logic         debug_trigger_match_id_i,
 
   // Regfile target
-  input  logic           regfile_alu_we_id_i,        // currently decoded we enable
+  input  logic         regfile_alu_we_id_i,        // currently decoded we enable
 
   // Forwarding signals from regfile
-  input  logic           rf_we_ex_i,            // Register file write enable from EX stage
-  input  logic           rf_we_wb_i,            // Register file write enable from WB stage
+  input  logic         rf_we_ex_i,            // Register file write enable from EX stage
+  input  logic         rf_we_wb_i,            // Register file write enable from WB stage
 
-  input rf_addr_t  rf_waddr_ex_i,
-  input rf_addr_t  rf_waddr_wb_i,
+  // CSR raddr in ex
+  input  csr_num_e     csr_raddr_ex_i,
+
+  input rf_addr_t      rf_waddr_ex_i,
+  input rf_addr_t      rf_waddr_wb_i,
 
   input logic [REGFILE_NUM_READ_PORTS-1:0]         rf_re_i,
-  input rf_addr_t  rf_raddr_i[REGFILE_NUM_READ_PORTS],
-  input rf_addr_t  rf_waddr_i,
+  input rf_addr_t     rf_raddr_i[REGFILE_NUM_READ_PORTS],
+  input rf_addr_t     rf_waddr_i,
 
   input  logic        id_ready_i,               // ID stage is ready
   input  logic        ex_valid_i,               // EX stage is done
   input  logic        wb_ready_i,               // WB stage is ready
+  input  logic        wb_valid_i,                // WB stage is done
 
   input  logic        lsu_en_wb_i,              // LSU data is written back in WB
   input  logic        obi_data_req_i,           // OBI bus data request (EX) // todo: Should look at 'trans' (goal (please check if true) it to not break a multicycle LSU instruction or already committed load/store; that cannot be judged by only looking at the OBI signals)
@@ -135,6 +139,7 @@ module cv32e40x_controller import cv32e40x_pkg::*;
     .lsu_addr_wb_i               ( lsu_addr_wb_i            ),
     .lsu_en_wb_i                 ( lsu_en_wb_i              ),
     .wb_ready_i                  ( wb_ready_i               ),
+    .wb_valid_i                  ( wb_valid_i               ),
 
     // Interrupt Controller Signals
     .irq_req_ctrl_i              ( irq_req_ctrl_i           ),
@@ -179,6 +184,7 @@ module cv32e40x_controller import cv32e40x_pkg::*;
     // From EX
     .rf_we_ex_i                 ( rf_we_ex_i               ),
     .rf_waddr_ex_i              ( rf_waddr_ex_i            ),
+    .csr_raddr_ex_i             ( csr_raddr_ex_i           ),
 
     // From WB
     .rf_we_wb_i                 ( rf_we_wb_i               ),

--- a/rtl/cv32e40x_controller_bypass.sv
+++ b/rtl/cv32e40x_controller_bypass.sv
@@ -48,6 +48,7 @@ module cv32e40x_controller_bypass import cv32e40x_pkg::*;
   input  logic        dret_id_i,                  // dret in ID
   input  logic        csr_en_id_i,                // CSR in ID
   input  csr_opcode_e csr_op_id_i,                // CSR opcode (ID)
+  input  csr_num_e    csr_raddr_ex_i,             // CSR read address (EX)
   input  logic        debug_trigger_match_id_i,         // Trigger match in ID
   // From EX
   input  logic        rf_we_ex_i,                 // Register file write enable from EX stage
@@ -76,8 +77,13 @@ module cv32e40x_controller_bypass import cv32e40x_pkg::*;
   logic                              rf_wr_ex_hz;
   logic                              rf_wr_wb_hz;
 
+  // Detect CSR read in ID (implicit and explicit)
   logic csr_read_in_id;
+  // Detect CSR write in EX or WB (implicit and explicit)
   logic csr_write_in_ex_wb;
+
+  // Detect minstret/minstreth read in EX.
+  logic minstret_read_in_ex;
 
   /////////////////////////////////////////////////////////////
   //  ____  _        _ _    ____            _             _  //
@@ -90,6 +96,7 @@ module cv32e40x_controller_bypass import cv32e40x_pkg::*;
 
   //TODO:OK:low This CSR stall check is very restrictive
   //         Should only check EX vs WB, and also CSR/rd addr
+  //         Also consider whether ID or EX should be stalled
   // Detect when a CSR insn is in ID
   // Note that hazard detection uses the registered instr_valid signals. Usage of the local
   // instr_valid signals would lead to a combinatorial loop via the halt signal.
@@ -102,6 +109,11 @@ module cv32e40x_controller_bypass import cv32e40x_pkg::*;
   assign csr_write_in_ex_wb = ((id_ex_pipe_i.instr_valid && id_ex_pipe_i.csr_en) ||
                               (ex_wb_pipe_i.csr_en || ex_wb_pipe_i.mret_insn || ex_wb_pipe_i.dret_insn) &&
                               ex_wb_pipe_i.instr_valid);
+
+  // minstret/minstreh is read in EX
+  assign minstret_read_in_ex =  ((id_ex_pipe_i.instr_valid && id_ex_pipe_i.csr_en) &&
+                                ((csr_raddr_ex_i  == CSR_MINSTRET) || (csr_raddr_ex_i == CSR_MINSTRETH)));
+
 
   // Stall ID when WFI is active in EX.
   // Used to create an interruptible bubble after WFI // todo:low only needed for load/store following WFI; should actually halt EX when WFI in WB
@@ -139,6 +151,7 @@ module cv32e40x_controller_bypass import cv32e40x_pkg::*;
     ctrl_byp_o.deassert_we         = 1'b0;
     ctrl_byp_o.deassert_we_special = 1'b0;
     ctrl_byp_o.csr_stall           = 1'b0;
+    ctrl_byp_o.minstret_stall      = 1'b0;
 
     // deassert WE when the core has an exception in ID (ins converted to nop and propagated to WB)
     // Also deassert for trigger match, as with dcsr.timing==0 we do not execute before entering debug mode
@@ -178,6 +191,11 @@ module cv32e40x_controller_bypass import cv32e40x_pkg::*;
     // Stall because of CSR read (direct or implied) in ID while CSR (implied or direct) is written in EX/WB
     if (csr_read_in_id && csr_write_in_ex_wb) begin
       ctrl_byp_o.csr_stall = 1'b1;
+    end
+
+    // Stall (EX) due to minstret read
+    if (minstret_read_in_ex && ex_wb_pipe_i.instr_valid) begin
+      ctrl_byp_o.minstret_stall = 1'b1;
     end
   end
 

--- a/rtl/cv32e40x_core.sv
+++ b/rtl/cv32e40x_core.sv
@@ -185,6 +185,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
   // Stage valid signals
   logic        if_valid;
   logic        ex_valid;
+  logic        wb_valid;
 
   // Interrupts
   logic        m_irq_enable; // interrupt_controller
@@ -214,6 +215,8 @@ module cv32e40x_core import cv32e40x_pkg::*;
  
   logic        csr_en_id;
   csr_opcode_e csr_op_id;
+
+  csr_num_e    csr_raddr_ex;
 
   // irq signals
   // TODO:AB Should find a proper suffix for signals from interrupt_controller
@@ -555,7 +558,8 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .lsu_ready_i                ( lsu_ready_1                  ),
   
     // Valid/ready
-    .wb_ready_o                 ( wb_ready                     )
+    .wb_ready_o                 ( wb_ready                     ),
+    .wb_valid_o                 ( wb_valid                     )
   );
 
   //////////////////////////////////////
@@ -605,6 +609,9 @@ module cv32e40x_core import cv32e40x_pkg::*;
     // Interface to CSRs (SRAM like)
     .csr_rdata_o                ( csr_rdata              ),
 
+    // Raddr from first stage (EX)
+    .csr_raddr_o                ( csr_raddr_ex           ),
+
     // Interrupt related control signals
     .mie_o                      ( mie                    ),
     .mip_i                      ( mip                    ),
@@ -640,6 +647,8 @@ module cv32e40x_core import cv32e40x_pkg::*;
 
     // From ID/EX pipeline
     .id_ex_pipe_i                   ( id_ex_pipe             ),
+
+    .csr_raddr_ex_i                 ( csr_raddr_ex           ),
 
     // From EX/WB pipeline
     .ex_wb_pipe_i                   ( ex_wb_pipe             ),
@@ -695,6 +704,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .id_ready_i                     ( id_ready               ),
     .ex_valid_i                     ( ex_valid               ),
     .wb_ready_i                     ( wb_ready               ),
+    .wb_valid_i                     ( wb_valid               ),
 
     .obi_data_req_i                 ( data_req_o             ),
 

--- a/rtl/cv32e40x_cs_registers.sv
+++ b/rtl/cv32e40x_cs_registers.sv
@@ -60,6 +60,9 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
 
   // From controller FSM
   input  ctrl_fsm_t       ctrl_fsm_i,
+
+  // To controller bypass logic
+  output csr_num_e        csr_raddr_o,
  
   // Interface to registers (SRAM like)
   output logic [31:0]     csr_rdata_o,
@@ -151,6 +154,8 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
 
   // Performance Counter Signals
   logic [31:0] [MHPMCOUNTER_WIDTH-1:0] mhpmcounter_q;                    // performance counters
+  logic [31:0] [MHPMCOUNTER_WIDTH-1:0] mhpmcounter_n;                    // performance counters next value
+  logic [31:0] [1:0]                   mhpmcounter_we;                   // performance counters write enable
   logic [31:0] [31:0]                  mhpmevent_q, mhpmevent_n;         // event enable
   logic [31:0]                         mcountinhibit_q, mcountinhibit_n; // performance counter enable
   logic [NUM_HPM_EVENTS-1:0]           hpm_events;                       // events for performance counters
@@ -168,6 +173,7 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
   //  CSR access. Read in EX, write in WB
   // Setting csr_raddr to zero in case of unused csr to save power (alu_operand_b toggles a lot)
   assign csr_raddr = csr_num_e'((id_ex_pipe_i.csr_en && id_ex_pipe_i.instr_valid) ? id_ex_pipe_i.alu_operand_b[11:0] : 12'b0);
+  assign csr_raddr_o = csr_raddr;
 
   // Not suppressing csr_waddr to zero when unused since its source are dedicated flipflops and would not save power as for raddr
   assign csr_waddr = csr_num_e'(ex_wb_pipe_i.csr_addr);
@@ -856,6 +862,38 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
 
   // ------------------------
   // HPM Registers
+  // next value
+  genvar nxt_gidx;
+  generate
+    for (nxt_gidx = 0; nxt_gidx < 32; nxt_gidx++) begin : gen_mhpmcounter_nextvalue
+      // mcyclce  is located at index 0
+      // there is no counter at index 1
+      // minstret is located at index 2
+      // Programable HPM counters start at index 3
+      if( (nxt_gidx == 1) ||
+          (nxt_gidx >= (NUM_MHPMCOUNTERS+3) ) )
+        begin : gen_non_implemented
+          assign mhpmcounter_n[nxt_gidx]  = 'b0;
+          assign mhpmcounter_we[nxt_gidx] = 2'b0;
+      end
+      else begin : gen_implemented_nextvalue
+        always_comb begin
+          mhpmcounter_we[nxt_gidx] = 2'b0;
+          mhpmcounter_n[nxt_gidx]  = mhpmcounter_q[nxt_gidx];
+          if (mhpmcounter_write_lower[nxt_gidx]) begin
+            mhpmcounter_n[nxt_gidx][31:0] = csr_wdata_int;
+            mhpmcounter_we[nxt_gidx][0] = 1'b1;
+          end else if (mhpmcounter_write_upper[nxt_gidx]) begin
+            mhpmcounter_n[nxt_gidx][63:32] = csr_wdata_int;
+            mhpmcounter_we[nxt_gidx][1] = 1'b1;
+          end else if (mhpmcounter_write_increment[nxt_gidx]) begin
+            mhpmcounter_we[nxt_gidx] = 2'b1;
+            mhpmcounter_n[nxt_gidx] = mhpmcounter_increment[nxt_gidx];
+          end
+        end // always_comb
+      end
+    end
+  endgenerate
   //  Counter Registers: mhpcounter_q[]
   genvar cnt_gidx;
   generate
@@ -874,15 +912,12 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
           if (!rst_n) begin
             mhpmcounter_q[cnt_gidx] <= 'b0;
           end else begin
-            
-            if (mhpmcounter_write_lower[cnt_gidx]) begin
-              mhpmcounter_q[cnt_gidx][31:0] <= csr_wdata_int;
-            end else if (mhpmcounter_write_upper[cnt_gidx]) begin
-              mhpmcounter_q[cnt_gidx][63:32] <= csr_wdata_int;
-            end else if (mhpmcounter_write_increment[cnt_gidx]) begin
-              mhpmcounter_q[cnt_gidx] <= mhpmcounter_increment[cnt_gidx];
+            if (mhpmcounter_we[cnt_gidx][0]) begin
+              mhpmcounter_q[cnt_gidx][31:0] <= mhpmcounter_n[cnt_gidx][31:0];
             end
-            
+            if (mhpmcounter_we[cnt_gidx][1]) begin
+              mhpmcounter_q[cnt_gidx][63:32] <= mhpmcounter_n[cnt_gidx][63:32];
+            end
           end
       end
     end

--- a/rtl/cv32e40x_wb_stage.sv
+++ b/rtl/cv32e40x_wb_stage.sv
@@ -60,7 +60,8 @@ module cv32e40x_wb_stage import cv32e40x_pkg::*;
   input  logic          lsu_ready_i,
 
   // Stage ready/valid
-  output logic          wb_ready_o
+  output logic          wb_ready_o,
+  output logic          wb_valid_o
 );
 
   logic                 instr_valid;
@@ -121,5 +122,7 @@ module cv32e40x_wb_stage import cv32e40x_pkg::*;
   assign wb_valid = ((!ex_wb_pipe_i.lsu_en && 1'b1) ||          // Non-LSU instructions always have valid result in WB
                      ( ex_wb_pipe_i.lsu_en && lsu_valid_i)      // LSU instructions have valid result based on data_rvalid_i
                     ) && instr_valid;
+
+  assign wb_valid_o = wb_valid;
   
 endmodule // cv32e40x_wb_stage

--- a/rtl/include/cv32e40x_pkg.sv
+++ b/rtl/include/cv32e40x_pkg.sv
@@ -1019,6 +1019,7 @@ typedef struct packed {
   logic        load_stall;            // Stall due to load operation
   logic        csr_stall;
   logic        wfi_stall;
+  logic        minstret_stall;        // Stall due to minstret/h read in EX
   logic        deassert_we;           // Deassert write enable for next instruction
   logic        deassert_we_special;   // Deassert write enable and special insn bits
 } ctrl_byp_t;


### PR DESCRIPTION
Rewrote performance counters to have proper write enable and next_value. (For use in RVFI)

Added support for minstret. Notethat this uses wb_valid which factors in data_rvalid_i.
Added stall in EX if minstret is READ in EX and any instruction is valid in WB.
Updated RVFI to include dret pc in WB model and not updating EX pc in case of misaligned LSU.

ci_check is clean with one warning during debug_test (comes from verif, not RTL)

Synthesis shows around 450 gates increase compared to last hash.
This is probably due to using wb_valid in counting retired instructions.

Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>