### PR TITLE
Updated RVFI branch probe

### DIFF
--- a/bhv/cv32e40x_rvfi.sv
+++ b/bhv/cv32e40x_rvfi.sv
@@ -46,7 +46,7 @@ module cv32e40x_rvfi
    input logic [31:0]                         rs2_rdata_id_i,
 
    //// EX probes ////
-   input logic                                branch_taken_ex_i,
+   input logic                                branch_in_ex_i,
    // LSU
    input logic                                lsu_en_ex_i,
 
@@ -488,7 +488,7 @@ module cv32e40x_rvfi
 
       //// EX Stage ////
       if (instr_ex_valid_i && wb_ready_i) begin
-        pc_wdata [STAGE_EX] <= branch_taken_ex_i    ? branch_target_ex_i :
+        pc_wdata [STAGE_EX] <= branch_in_ex_i       ? branch_target_ex_i :
                                !lsu_misaligned_ex_i ? pc_wdata[STAGE_ID] :
                                pc_wdata[STAGE_EX];
         debug    [STAGE_EX] <= debug    [STAGE_ID];

--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -290,7 +290,7 @@ bind cv32e40x_sleep_unit:
          .lsu_type_id_i            ( core_i.id_stage_i.lsu_type                                           ),
          .lsu_we_id_i              ( core_i.id_stage_i.lsu_we                                             ),
 
-         .branch_taken_ex_i        ( core_i.controller_i.controller_fsm_i.branch_taken_ex                 ),
+         .branch_taken_ex_i        ( core_i.controller_i.controller_fsm_i.branch_in_ex                    ),
          .lsu_en_ex_i              ( core_i.ex_stage_i.id_ex_pipe_i.lsu_en                                ),
 
          .instr_ex_ready_i         ( core_i.ex_stage_i.ex_ready_o                                         ),

--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -290,7 +290,7 @@ bind cv32e40x_sleep_unit:
          .lsu_type_id_i            ( core_i.id_stage_i.lsu_type                                           ),
          .lsu_we_id_i              ( core_i.id_stage_i.lsu_we                                             ),
 
-         .branch_taken_ex_i        ( core_i.controller_i.controller_fsm_i.branch_in_ex                    ),
+         .branch_in_ex_i           ( core_i.controller_i.controller_fsm_i.branch_in_ex                    ),
          .lsu_en_ex_i              ( core_i.ex_stage_i.id_ex_pipe_i.lsu_en                                ),
 
          .instr_ex_ready_i         ( core_i.ex_stage_i.ex_ready_o                                         ),


### PR DESCRIPTION
Updated RVFI branch probe to handle the jump-once update in the controller.

This fixes an issue where pc_wdata would not be set correctly (leading to rvfi_intr getting set) when a branch was taken during a bus stall.

Signed-off-by: Halfdan Bechmann <halfdan.bechmann@silabs.com>