### PR TITLE
B ext zbs in result mux

### DIFF
--- a/rtl/cv32e40x_alu.sv
+++ b/rtl/cv32e40x_alu.sv
@@ -409,6 +409,11 @@ module cv32e40x_alu import cv32e40x_pkg::*;
       ALU_B_SEXT_B:         result_o = {{(24){operand_a_i[ 7]}}, operand_a_i[ 7:0]};
       ALU_B_SEXT_H:         result_o = {{(16){operand_a_i[15]}}, operand_a_i[15:0]};
 
+      // Zbs
+      ALU_B_BSET:           result_o = shifter_result;
+      ALU_B_BCLR:           result_o = shifter_result;
+      ALU_B_BINV:           result_o = shifter_result;
+      ALU_B_BEXT:           result_o = shifter_result;
 
       default: ; // default case to suppress unique warning
     endcase

--- a/rtl/cv32e40x_b_decoder.sv
+++ b/rtl/cv32e40x_b_decoder.sv
@@ -156,7 +156,7 @@ module cv32e40x_b_decoder import cv32e40x_pkg::*;
               decoder_ctrl_o.alu_operator = ALU_B_BINV;
             end
           end
-          {7'b0100100, 3'b001}: begin // Extract bit from rs1 at index specified by rs2 (bext)
+          {7'b0100100, 3'b101}: begin // Extract bit from rs1 at index specified by rs2 (bext)
             if (RV32B_ZBS) begin
               decoder_ctrl_o.illegal_insn = 1'b0;
               decoder_ctrl_o.alu_operator = ALU_B_BEXT;
@@ -250,7 +250,7 @@ module cv32e40x_b_decoder import cv32e40x_pkg::*;
               decoder_ctrl_o.alu_op_b_mux_sel = OP_B_IMM;
             end
           end
-          {7'b0100100, 5'b?_????, 3'b001}: begin // Extract bit from rs1 at index specified by immediate (bexti)
+          {7'b0100100, 5'b?_????, 3'b101}: begin // Extract bit from rs1 at index specified by immediate (bexti)
             if (RV32B_ZBS) begin
               decoder_ctrl_o.illegal_insn     = 1'b0;
               decoder_ctrl_o.alu_operator     = ALU_B_BEXT;


### PR DESCRIPTION
Added Zbs instructions to result mux and fixed typo in instruction decoding after creating a new sanity check.

SEC Clean with B_EXT parameter == NONE.
