### PR TITLE
Shifter cleanup

### DIFF
--- a/rtl/cv32e40x_alu.sv
+++ b/rtl/cv32e40x_alu.sv
@@ -50,7 +50,7 @@ module cv32e40x_alu import cv32e40x_pkg::*;
   input  logic              clk,
   input  logic              rst_n,
   input  alu_opcode_e       operator_i,
-  input  Alu_shifter_t      shifter_i,
+  input  alu_shifter_t      shifter_i,
   input  logic [31:0]       operand_a_i,
   input  logic [31:0]       operand_b_i,
 
@@ -127,8 +127,8 @@ module cv32e40x_alu import cv32e40x_pkg::*;
 
   logic        shifter_rotate;
   logic        shifter_rshift;
-  logic        shifter_operand_tieoff;
   logic        shifter_arithmetic;
+  logic        shifter_operand_tieoff; // Ties shifter oprand a to 1 and b to 0. Used for some single bit operations.
 
   logic [31:0] shifter_bext_result;
   logic [31:0] shifter_bset_result;
@@ -150,7 +150,7 @@ module cv32e40x_alu import cv32e40x_pkg::*;
   assign div_op_a_shifted_o = shifter_result;
   always_comb begin
     shifter_shamt = div_shift_en_i ? {1'b0, div_shift_amt_i[4:0]} : {1'b0, operand_b_i[4:0]};
-    shifter_aa = shifter_operand_tieoff ? 1 : operand_a_i;
+    shifter_aa = shifter_operand_tieoff ? 32'h1 : operand_a_i;
 
     if (shifter_rshift) begin
       // Treat right shifts as left shifts with corrected shift amount
@@ -159,7 +159,7 @@ module cv32e40x_alu import cv32e40x_pkg::*;
 
 
     if (shifter_operand_tieoff) begin
-      shifter_bb = 0;
+      shifter_bb = 32'h0;
     end else if (shifter_arithmetic) begin
       shifter_bb = shifter_rotate ? operand_a_i : {32{operand_a_i[31]}};
     end else begin
@@ -180,7 +180,7 @@ module cv32e40x_alu import cv32e40x_pkg::*;
 
   assign shifter_result      = shifter_tmp[31:0];
 
-  assign shifter_bext_result =           1 &  shifter_result;
+  assign shifter_bext_result =       32'h1 &  shifter_result;
   assign shifter_bset_result = operand_a_i |  shifter_result;
   assign shifter_bclr_result = operand_a_i & ~shifter_result;
   assign shifter_binv_result = operand_a_i ^  shifter_result;

--- a/rtl/cv32e40x_b_decoder.sv
+++ b/rtl/cv32e40x_b_decoder.sv
@@ -126,40 +126,54 @@ module cv32e40x_b_decoder import cv32e40x_pkg::*;
           end
           {7'b0110000, 3'b001}: begin // Rotate Left (rol)
             if (RV32B_ZBB) begin
-              decoder_ctrl_o.illegal_insn = 1'b0;
-              decoder_ctrl_o.alu_operator = ALU_B_ROL;
+              decoder_ctrl_o.illegal_insn               = 1'b0;
+              decoder_ctrl_o.alu_operator               = ALU_B_ROL;
+              decoder_ctrl_o.alu_shifter.rotate         = 1'b1;
+              decoder_ctrl_o.alu_shifter.arithmetic     = 1'b1;
             end
           end
           {7'b0110000, 3'b101}: begin // Rotate Right (ror)
             if (RV32B_ZBB) begin
-              decoder_ctrl_o.illegal_insn = 1'b0;
-              decoder_ctrl_o.alu_operator = ALU_B_ROR;
+              decoder_ctrl_o.illegal_insn               = 1'b0;
+              decoder_ctrl_o.alu_operator               = ALU_B_ROR;
+              decoder_ctrl_o.alu_shifter.rotate         = 1'b1;
+              decoder_ctrl_o.alu_shifter.rshift         = 1'b1;
+              decoder_ctrl_o.alu_shifter.arithmetic     = 1'b1;
             end
           end
 
           // RVB Zbs
           {7'b0010100, 3'b001}: begin // Set bit in rs1 at index specified by rs2 (bset)
             if (RV32B_ZBS) begin
-              decoder_ctrl_o.illegal_insn = 1'b0;
-              decoder_ctrl_o.alu_operator = ALU_B_BSET;
+              decoder_ctrl_o.illegal_insn               = 1'b0;
+              decoder_ctrl_o.alu_operator               = ALU_B_BSET;
+              decoder_ctrl_o.alu_shifter.rotate         = 1'b1;
+              decoder_ctrl_o.alu_shifter.operand_tieoff = 1'b1;
             end
           end
           {7'b0100100, 3'b001}: begin // Clear bit in rs1 at index specified by rs2 (bclr)
             if (RV32B_ZBS) begin
-              decoder_ctrl_o.illegal_insn = 1'b0;
-              decoder_ctrl_o.alu_operator = ALU_B_BCLR;
+              decoder_ctrl_o.illegal_insn               = 1'b0;
+              decoder_ctrl_o.alu_operator               = ALU_B_BCLR;
+              decoder_ctrl_o.alu_shifter.arithmetic     = 1'b1;
+              decoder_ctrl_o.alu_shifter.operand_tieoff = 1'b1;
             end
           end
           {7'b0110100, 3'b001}: begin // Invert bit in rs1 at index specified by rs2 (binv)
             if (RV32B_ZBS) begin
-              decoder_ctrl_o.illegal_insn = 1'b0;
-              decoder_ctrl_o.alu_operator = ALU_B_BINV;
+              decoder_ctrl_o.illegal_insn               = 1'b0;
+              decoder_ctrl_o.alu_operator               = ALU_B_BINV;
+              decoder_ctrl_o.alu_shifter.rotate         = 1'b1;
+              decoder_ctrl_o.alu_shifter.arithmetic     = 1'b1;
+              decoder_ctrl_o.alu_shifter.operand_tieoff = 1'b1;
             end
           end
           {7'b0100100, 3'b101}: begin // Extract bit from rs1 at index specified by rs2 (bext)
             if (RV32B_ZBS) begin
-              decoder_ctrl_o.illegal_insn = 1'b0;
-              decoder_ctrl_o.alu_operator = ALU_B_BEXT;
+              decoder_ctrl_o.illegal_insn               = 1'b0;
+              decoder_ctrl_o.alu_operator               = ALU_B_BEXT;
+              decoder_ctrl_o.alu_shifter.rshift         = 1'b1;
+              decoder_ctrl_o.alu_shifter.arithmetic     = 1'b1;
             end
           end
 
@@ -222,39 +236,51 @@ module cv32e40x_b_decoder import cv32e40x_pkg::*;
           end
           {7'b0110000, 5'b?_????, 3'b101}: begin // Rotate Right immediate (rori)
             if (RV32B_ZBB) begin
-              decoder_ctrl_o.illegal_insn     = 1'b0;
-              decoder_ctrl_o.alu_operator     = ALU_B_ROR;
-              decoder_ctrl_o.alu_op_b_mux_sel = OP_B_IMM;
+              decoder_ctrl_o.illegal_insn           = 1'b0;
+              decoder_ctrl_o.alu_operator           = ALU_B_ROR;
+              decoder_ctrl_o.alu_op_b_mux_sel       = OP_B_IMM;
+              decoder_ctrl_o.alu_shifter.rotate     = 1'b1;
+              decoder_ctrl_o.alu_shifter.rshift     = 1'b1;
+              decoder_ctrl_o.alu_shifter.arithmetic = 1'b1;
             end
           end
 
           // RVB Zbs immediate
           {7'b0010100, 5'b?_????, 3'b001}: begin // Set bit in rs1 at index specified by immediate (bseti)
             if (RV32B_ZBS) begin
-              decoder_ctrl_o.illegal_insn     = 1'b0;
-              decoder_ctrl_o.alu_operator     = ALU_B_BSET;
-              decoder_ctrl_o.alu_op_b_mux_sel = OP_B_IMM;
+              decoder_ctrl_o.illegal_insn               = 1'b0;
+              decoder_ctrl_o.alu_operator               = ALU_B_BSET;
+              decoder_ctrl_o.alu_op_b_mux_sel           = OP_B_IMM;
+              decoder_ctrl_o.alu_shifter.rotate         = 1'b1;
+              decoder_ctrl_o.alu_shifter.operand_tieoff = 1'b1;
             end
           end
           {7'b0100100, 5'b?_????, 3'b001}: begin // Clear bit in rs1 at index specified by immediate (bclri)
             if (RV32B_ZBS) begin
-              decoder_ctrl_o.illegal_insn     = 1'b0;
-              decoder_ctrl_o.alu_operator     = ALU_B_BCLR;
-              decoder_ctrl_o.alu_op_b_mux_sel = OP_B_IMM;
+              decoder_ctrl_o.illegal_insn               = 1'b0;
+              decoder_ctrl_o.alu_operator               = ALU_B_BCLR;
+              decoder_ctrl_o.alu_op_b_mux_sel           = OP_B_IMM;
+              decoder_ctrl_o.alu_shifter.arithmetic     = 1'b1;
+              decoder_ctrl_o.alu_shifter.operand_tieoff = 1'b1;
             end
           end
           {7'b0110100, 5'b?_????, 3'b001}: begin // Invert bit in rs1 at index specified by immediate (binvi)
             if (RV32B_ZBS) begin
-              decoder_ctrl_o.illegal_insn     = 1'b0;
-              decoder_ctrl_o.alu_operator     = ALU_B_BINV;
-              decoder_ctrl_o.alu_op_b_mux_sel = OP_B_IMM;
+              decoder_ctrl_o.illegal_insn               = 1'b0;
+              decoder_ctrl_o.alu_operator               = ALU_B_BINV;
+              decoder_ctrl_o.alu_op_b_mux_sel           = OP_B_IMM;
+              decoder_ctrl_o.alu_shifter.rotate         = 1'b1;
+              decoder_ctrl_o.alu_shifter.arithmetic     = 1'b1;
+              decoder_ctrl_o.alu_shifter.operand_tieoff = 1'b1;
             end
           end
           {7'b0100100, 5'b?_????, 3'b101}: begin // Extract bit from rs1 at index specified by immediate (bexti)
             if (RV32B_ZBS) begin
-              decoder_ctrl_o.illegal_insn     = 1'b0;
-              decoder_ctrl_o.alu_operator     = ALU_B_BEXT;
-              decoder_ctrl_o.alu_op_b_mux_sel = OP_B_IMM;
+              decoder_ctrl_o.illegal_insn           = 1'b0;
+              decoder_ctrl_o.alu_operator           = ALU_B_BEXT;
+              decoder_ctrl_o.alu_op_b_mux_sel       = OP_B_IMM;
+              decoder_ctrl_o.alu_shifter.rshift     = 1'b1;
+              decoder_ctrl_o.alu_shifter.arithmetic = 1'b1;
             end
           end
 

--- a/rtl/cv32e40x_decoder.sv
+++ b/rtl/cv32e40x_decoder.sv
@@ -55,7 +55,7 @@ module cv32e40x_decoder import cv32e40x_pkg::*;
   // ALU signals
   output logic        alu_en_o,                 // ALU enable
   output alu_opcode_e alu_operator_o, // ALU operation selection
-  output Alu_shifter_t  alu_shifter_o,          // ALU Shifter control
+  output alu_shifter_t  alu_shifter_o,          // ALU Shifter control
   output alu_op_a_mux_e alu_op_a_mux_sel_o,     // operand a selection: reg value, PC, immediate or zero
   output alu_op_b_mux_e alu_op_b_mux_sel_o,     // operand b selection: reg value or immediate
   output op_c_mux_e     op_c_mux_sel_o,         // operand c selection: reg value or jump target

--- a/rtl/cv32e40x_decoder.sv
+++ b/rtl/cv32e40x_decoder.sv
@@ -55,6 +55,7 @@ module cv32e40x_decoder import cv32e40x_pkg::*;
   // ALU signals
   output logic        alu_en_o,                 // ALU enable
   output alu_opcode_e alu_operator_o, // ALU operation selection
+  output Alu_shifter_t  alu_shifter_o,          // ALU Shifter control
   output alu_op_a_mux_e alu_op_a_mux_sel_o,     // operand a selection: reg value, PC, immediate or zero
   output alu_op_b_mux_e alu_op_b_mux_sel_o,     // operand b selection: reg value or immediate
   output op_c_mux_e     op_c_mux_sel_o,         // operand c selection: reg value or jump target
@@ -180,6 +181,7 @@ module cv32e40x_decoder import cv32e40x_pkg::*;
   assign ctrl_transfer_target_mux_sel_o = decoder_ctrl_mux.ctrl_transfer_target_mux_sel;
   assign alu_en                         = decoder_ctrl_mux.alu_en;
   assign alu_operator_o                 = decoder_ctrl_mux.alu_operator;                  
+  assign alu_shifter_o                  = decoder_ctrl_mux.alu_shifter;
   assign alu_op_a_mux_sel_o             = decoder_ctrl_mux.alu_op_a_mux_sel;              
   assign alu_op_b_mux_sel_o             = decoder_ctrl_mux.alu_op_b_mux_sel;              
   assign op_c_mux_sel_o                 = decoder_ctrl_mux.op_c_mux_sel;

--- a/rtl/cv32e40x_ex_stage.sv
+++ b/rtl/cv32e40x_ex_stage.sv
@@ -151,6 +151,7 @@ module cv32e40x_ex_stage import cv32e40x_pkg::*;
     .rst_n               ( rst_n                      ),
 
     .operator_i          ( id_ex_pipe_i.alu_operator  ),
+    .shifter_i           ( id_ex_pipe_i.alu_shifter   ),
     .operand_a_i         ( id_ex_pipe_i.alu_operand_a ),
     .operand_b_i         ( id_ex_pipe_i.alu_operand_b ),
     

--- a/rtl/cv32e40x_i_decoder.sv
+++ b/rtl/cv32e40x_i_decoder.sv
@@ -209,11 +209,14 @@ module cv32e40x_i_decoder import cv32e40x_pkg::*;
           end
 
           3'b101: begin
-            if (instr_rdata_i[31:25] == 7'b0)
-              decoder_ctrl_o.alu_operator = ALU_SRL;  // Shift Right Logical by Immediate
-            else if (instr_rdata_i[31:25] == 7'b010_0000)
-              decoder_ctrl_o.alu_operator = ALU_SRA;  // Shift Right Arithmetically by Immediate
-            else begin
+            if (instr_rdata_i[31:25] == 7'b0) begin
+              decoder_ctrl_o.alu_operator       = ALU_SRL;     // Shift Right Logical by Immediate
+              decoder_ctrl_o.alu_shifter.rshift = 1'b1;
+            end else if (instr_rdata_i[31:25] == 7'b010_0000) begin
+              decoder_ctrl_o.alu_operator           = ALU_SRA; // Shift Right Arithmetically by Immediate
+              decoder_ctrl_o.alu_shifter.rshift     = 1'b1;
+              decoder_ctrl_o.alu_shifter.arithmetic = 1'b1;
+            end else begin
               decoder_ctrl_o = DECODER_CTRL_ILLEGAL_INSN;
             end
           end
@@ -243,9 +246,15 @@ module cv32e40x_i_decoder import cv32e40x_pkg::*;
             {6'b00_0000, 3'b110}: decoder_ctrl_o.alu_operator = ALU_OR;    // Or
             {6'b00_0000, 3'b111}: decoder_ctrl_o.alu_operator = ALU_AND;   // And
             {6'b00_0000, 3'b001}: decoder_ctrl_o.alu_operator = ALU_SLL;   // Shift Left Logical
-            {6'b00_0000, 3'b101}: decoder_ctrl_o.alu_operator = ALU_SRL;   // Shift Right Logical
-            {6'b10_0000, 3'b101}: decoder_ctrl_o.alu_operator = ALU_SRA;   // Shift Right Arithmetic
-
+            {6'b00_0000, 3'b101}: begin
+              decoder_ctrl_o.alu_operator       = ALU_SRL;                 // Shift Right Logical
+              decoder_ctrl_o.alu_shifter.rshift = 1'b1;
+            end
+            {6'b10_0000, 3'b101}: begin
+              decoder_ctrl_o.alu_operator           = ALU_SRA;             // Shift Right Arithmetic
+              decoder_ctrl_o.alu_shifter.rshift     = 1'b1;
+              decoder_ctrl_o.alu_shifter.arithmetic = 1'b1;
+            end
             default: begin
               decoder_ctrl_o = DECODER_CTRL_ILLEGAL_INSN;
             end

--- a/rtl/cv32e40x_id_stage.sv
+++ b/rtl/cv32e40x_id_stage.sv
@@ -128,6 +128,7 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
   // ALU Control
   logic        alu_en;
   alu_opcode_e alu_operator;
+  Alu_shifter_t  alu_shifter;
   alu_op_a_mux_e alu_op_a_mux_sel;
   alu_op_b_mux_e alu_op_b_mux_sel;
 
@@ -391,6 +392,7 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
     // ALU signals
     .alu_en_o                        ( alu_en                    ),
     .alu_operator_o                  ( alu_operator              ),
+    .alu_shifter_o                   ( alu_shifter               ),
     .alu_op_a_mux_sel_o              ( alu_op_a_mux_sel          ),
     .alu_op_b_mux_sel_o              ( alu_op_b_mux_sel          ),
     .imm_a_mux_sel_o                 ( imm_a_mux_sel             ),
@@ -455,6 +457,7 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
       id_ex_pipe_o.instr_valid            <= 1'b0;
       id_ex_pipe_o.alu_en                 <= '0;
       id_ex_pipe_o.alu_operator           <= ALU_SLTU;
+      id_ex_pipe_o.alu_shifter            <= 4'b0000;
       id_ex_pipe_o.alu_operand_a          <= 32'b0; // todo: path from data_rdata_i through WB to id_ex_pipe_o_reg_alu_operand_a seems longer than needed (too many gates in ID)
       id_ex_pipe_o.alu_operand_b          <= 32'b0;
 
@@ -524,6 +527,7 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
           if (alu_en)
           begin
             id_ex_pipe_o.alu_operator         <= alu_operator;
+            id_ex_pipe_o.alu_shifter          <= alu_shifter;
             id_ex_pipe_o.operand_c            <= operand_c;
           end
 

--- a/rtl/cv32e40x_id_stage.sv
+++ b/rtl/cv32e40x_id_stage.sv
@@ -128,7 +128,7 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
   // ALU Control
   logic        alu_en;
   alu_opcode_e alu_operator;
-  Alu_shifter_t  alu_shifter;
+  alu_shifter_t  alu_shifter;
   alu_op_a_mux_e alu_op_a_mux_sel;
   alu_op_b_mux_e alu_op_b_mux_sel;
 

--- a/rtl/cv32e40x_m_decoder.sv
+++ b/rtl/cv32e40x_m_decoder.sv
@@ -80,6 +80,7 @@ module cv32e40x_m_decoder import cv32e40x_pkg::*;
             decoder_ctrl_o.alu_op_b_mux_sel = OP_B_REGA_OR_FWD;
             decoder_ctrl_o.div_en           = 1'b1;
             decoder_ctrl_o.div_operator     = DIV_DIV;
+            decoder_ctrl_o.alu_shifter      = 4'b0000;
           end
           {7'b000_0001, 3'b101}: begin // divu
             decoder_ctrl_o.illegal_insn     = 1'b0;
@@ -87,6 +88,7 @@ module cv32e40x_m_decoder import cv32e40x_pkg::*;
             decoder_ctrl_o.alu_op_b_mux_sel = OP_B_REGA_OR_FWD;
             decoder_ctrl_o.div_en           = 1'b1;
             decoder_ctrl_o.div_operator     = DIV_DIVU;
+            decoder_ctrl_o.alu_shifter      = 4'b0000;
           end
           {7'b000_0001, 3'b110}: begin // rem
             decoder_ctrl_o.illegal_insn     = 1'b0;
@@ -94,6 +96,7 @@ module cv32e40x_m_decoder import cv32e40x_pkg::*;
             decoder_ctrl_o.alu_op_b_mux_sel = OP_B_REGA_OR_FWD;
             decoder_ctrl_o.div_en           = 1'b1;
             decoder_ctrl_o.div_operator     = DIV_REM;
+            decoder_ctrl_o.alu_shifter      = 4'b0000;
           end
           {7'b000_0001, 3'b111}: begin // remu
             decoder_ctrl_o.illegal_insn     = 1'b0;
@@ -101,6 +104,7 @@ module cv32e40x_m_decoder import cv32e40x_pkg::*;
             decoder_ctrl_o.alu_op_b_mux_sel = OP_B_REGA_OR_FWD;
             decoder_ctrl_o.div_en           = 1'b1;
             decoder_ctrl_o.div_operator     = DIV_REMU;
+            decoder_ctrl_o.alu_shifter      = 4'b0000;
           end
 
           default: begin

--- a/rtl/include/cv32e40x_pkg.sv
+++ b/rtl/include/cv32e40x_pkg.sv
@@ -487,7 +487,7 @@ typedef struct packed {
     logic        rshift;
     logic        arithmetic;
     logic        operand_tieoff;
-  } Alu_shifter_t;
+  } alu_shifter_t;
 
 // Debug Cause
 parameter DBG_CAUSE_NONE       = 3'h0;
@@ -705,7 +705,7 @@ typedef struct packed {
   op_c_mux_e                         op_c_mux_sel;
   imm_a_mux_e                        imm_a_mux_sel;
   imm_b_mux_e                        imm_b_mux_sel;
-  Alu_shifter_t                      alu_shifter;
+  alu_shifter_t                      alu_shifter;
   logic                              mul_en;
   mul_opcode_e                       mul_operator;
   logic [1:0]                        mul_signed_mode;
@@ -946,7 +946,7 @@ typedef struct packed {
   // ALU Control
   logic         alu_en;
   alu_opcode_e  alu_operator;
-  Alu_shifter_t alu_shifter;
+  alu_shifter_t alu_shifter;
   logic [31:0]  alu_operand_a;
   logic [31:0]  alu_operand_b;
   logic [31:0]  operand_c; // Gated with alu_en but not used by ALU

--- a/rtl/include/cv32e40x_pkg.sv
+++ b/rtl/include/cv32e40x_pkg.sv
@@ -480,7 +480,15 @@ typedef struct packed {
   logic         uie; // Tie to zero when user mode is not enabled
 
 } Status_t;
-  
+
+
+  typedef struct packed {
+    logic        rotate;
+    logic        rshift;
+    logic        arithmetic;
+    logic        operand_tieoff;
+  } Alu_shifter_t;
+
 // Debug Cause
 parameter DBG_CAUSE_NONE       = 3'h0;
 parameter DBG_CAUSE_EBREAK     = 3'h1;
@@ -697,6 +705,7 @@ typedef struct packed {
   op_c_mux_e                         op_c_mux_sel;
   imm_a_mux_e                        imm_a_mux_sel;
   imm_b_mux_e                        imm_b_mux_sel;
+  Alu_shifter_t                      alu_shifter;
   logic                              mul_en;
   mul_opcode_e                       mul_operator;
   logic [1:0]                        mul_signed_mode;
@@ -731,6 +740,7 @@ typedef struct packed {
                                                           op_c_mux_sel                 : OP_C_FWD,
                                                           imm_a_mux_sel                : IMMA_ZERO,
                                                           imm_b_mux_sel                : IMMB_I,
+                                                          alu_shifter                  : 4'b0000,
                                                           mul_en                       : 1'b0,
                                                           mul_operator                 : MUL_M32,
                                                           mul_signed_mode              : 2'b00,
@@ -936,6 +946,7 @@ typedef struct packed {
   // ALU Control
   logic         alu_en;
   alu_opcode_e  alu_operator;
+  Alu_shifter_t alu_shifter;
   logic [31:0]  alu_operand_a;
   logic [31:0]  alu_operand_b;
   logic [31:0]  operand_c; // Gated with alu_en but not used by ALU


### PR DESCRIPTION
Cleaned up and simplified shifter.

SEC clean both with B_EXT==NONE and with B_EXT==ZBA_ZBB_ZBS.

Slight area decrease with  B_EXT==NONE.
Some area increase with B_EXT==ZBA_ZBB_ZBS.
