### PR TITLE
edit assertion to avoid goto operator in antecedent which could cause…

### DIFF
--- a/sva/cv32e40x_core_sva.sv
+++ b/sva/cv32e40x_core_sva.sv
@@ -268,7 +268,7 @@ always_ff @(posedge clk , negedge rst_ni)
   // before entering debug mode
   a_single_step_with_irq :
     assert property (@(posedge clk) disable iff (!rst_ni)
-                      (inst_taken && debug_single_step && !ctrl_fsm.debug_mode && interrupt_taken) [->1:2]
+                      (inst_taken && debug_single_step && !ctrl_fsm.debug_mode && interrupt_taken) [*1:2]
                       ##1 inst_taken [->1]
                       |-> (ctrl_fsm.debug_mode && debug_single_step))
       else `uvm_error("core", "Assertion a_single_step_with_irq failed")


### PR DESCRIPTION
… performance issues

Signed-off-by: Steve Richmond <Steve.Richmond@silabs.com>

Note this may not be ideal fix for assertion, but we cannot have goto operators as first clause of an assertion.  Non-optimized simulators such as Questa and DSIM will spawn separate threads every single cycle in this case.
