### PR TITLE
Bugfix

### DIFF
--- a/rtl/cv32e40x_cs_registers.sv
+++ b/rtl/cv32e40x_cs_registers.sv
@@ -727,7 +727,8 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
 
   // Breakpoint matching
   // We match against the next address, as the breakpoint must be taken before execution
-  assign debug_trigger_match_o = tmatch_control_q[2] &
+  // Matching is disabled when ctrl_fsm_i.debug_mode == 1'b1
+  assign debug_trigger_match_o = tmatch_control_q[2] && !ctrl_fsm_i.debug_mode &&
                                  (if_id_pipe_i.pc[31:0] == tmatch_value_q[31:0]);
 
 

--- a/sva/cv32e40x_controller_fsm_sva.sv
+++ b/sva/cv32e40x_controller_fsm_sva.sv
@@ -45,7 +45,8 @@ module cv32e40x_controller_fsm_sva
   input ex_wb_pipe_t    ex_wb_pipe_i,
   input logic           rf_we_wb_i,
   input csr_opcode_e    csr_op_i,
-  input logic           pending_single_step
+  input logic           pending_single_step,
+  input logic           trigger_match_in_wb
 );
 
 
@@ -158,5 +159,11 @@ module cv32e40x_controller_fsm_sva
     assert property (@(posedge clk)
             (pending_single_step && (ctrl_fsm_ns == DEBUG_TAKEN)) |-> (!id_ex_pipe_i.instr_valid && !if_id_pipe_i.instr_valid))
       else `uvm_error("controller", "ID and EX not empty when when single step is taken")
+
+  // Check trigger match never happens during debug_mode
+  a_trigger_match_in_debug :
+    assert property (@(posedge clk)
+            ctrl_fsm_o.debug_mode |-> !trigger_match_in_wb)
+      else `uvm_error("controller", "Trigger match during debug mode")
 endmodule // cv32e40x_controller_fsm_sva
 


### PR DESCRIPTION
Trigger match during debug would deassert all special instructions bits (include dret_insn) while in ID stage.
This would mask the dret and the core would not exit debug mode.
Moved qualification with ctrl_fsm.debug_mode from controller to match logic inside cs_registers.

Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>