### PR TITLE
Bug fix (when using B extension): Divider relies on ALU operand

### DIFF
--- a/rtl/cv32e40x_id_stage.sv
+++ b/rtl/cv32e40x_id_stage.sv
@@ -526,12 +526,12 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
           id_ex_pipe_o.alu_en                 <= alu_en;
           if (alu_en)
           begin
-            id_ex_pipe_o.alu_operator         <= alu_operator;
             id_ex_pipe_o.alu_shifter          <= alu_shifter;
             id_ex_pipe_o.operand_c            <= operand_c;
           end
 
           if (alu_en || div_en) begin
+            id_ex_pipe_o.alu_operator         <= alu_operator;
             id_ex_pipe_o.alu_operand_a        <= alu_operand_a;
             id_ex_pipe_o.alu_operand_b        <= alu_operand_b;
           end


### PR DESCRIPTION
SEC clean without B extension.
Bug fix for B extension.

Divider operation uses CLZ, which in turn relies on alu_operand to be up to date, see
https://github.com/openhwgroup/cv32e40x/blob/df94dbf0ad36f88d1f65c057bb8f843a7d1692a0/rtl/cv32e40x_alu.sv#L240

Signed-off-by: Arjan Bink <Arjan.Bink@silabs.com>