### PR TITLE
Path cleanup for bypass module 

### DIFF
--- a/rtl/cv32e40x_controller.sv
+++ b/rtl/cv32e40x_controller.sv
@@ -77,10 +77,6 @@ module cv32e40x_controller import cv32e40x_pkg::*;
   // Regfile target
   input  logic         regfile_alu_we_id_i,        // currently decoded we enable
 
-  // Forwarding signals from regfile
-  input  logic         rf_we_ex_i,            // Register file write enable from EX stage
-  input  logic         rf_we_wb_i,            // Register file write enable from WB stage
-
   // CSR raddr in ex
   input  csr_num_e     csr_raddr_ex_i,
 
@@ -96,7 +92,6 @@ module cv32e40x_controller import cv32e40x_pkg::*;
   input  logic        wb_ready_i,               // WB stage is ready
   input  logic        wb_valid_i,                // WB stage is done
 
-  input  logic        lsu_en_wb_i,              // LSU data is written back in WB
   input  logic        obi_data_req_i,           // OBI bus data request (EX) // todo: Should look at 'trans' (goal (please check if true) it to not break a multicycle LSU instruction or already committed load/store; that cannot be judged by only looking at the OBI signals)
 
   // Outputs
@@ -181,15 +176,12 @@ module cv32e40x_controller import cv32e40x_pkg::*;
     .debug_trigger_match_id_i   ( debug_trigger_match_id_i ),
 
     // From EX
-    .rf_we_ex_i                 ( rf_we_ex_i               ),
     .rf_waddr_ex_i              ( rf_waddr_ex_i            ),
     .csr_raddr_ex_i             ( csr_raddr_ex_i           ),
 
     // From WB
-    .rf_we_wb_i                 ( rf_we_wb_i               ),
     .rf_waddr_wb_i              ( rf_waddr_wb_i            ),
     .wb_ready_i                 ( wb_ready_i               ),
-    .lsu_en_wb_i                ( lsu_en_wb_i              ),
 
     // From LSU
     .lsu_misaligned_i           ( lsu_misaligned_i         ),

--- a/rtl/cv32e40x_controller.sv
+++ b/rtl/cv32e40x_controller.sv
@@ -80,9 +80,6 @@ module cv32e40x_controller import cv32e40x_pkg::*;
   // CSR raddr in ex
   input  csr_num_e     csr_raddr_ex_i,
 
-  input rf_addr_t      rf_waddr_ex_i,
-  input rf_addr_t      rf_waddr_wb_i,
-
   input logic [REGFILE_NUM_READ_PORTS-1:0]         rf_re_i,
   input rf_addr_t     rf_raddr_i[REGFILE_NUM_READ_PORTS],
   input rf_addr_t     rf_waddr_i,
@@ -176,11 +173,9 @@ module cv32e40x_controller import cv32e40x_pkg::*;
     .debug_trigger_match_id_i   ( debug_trigger_match_id_i ),
 
     // From EX
-    .rf_waddr_ex_i              ( rf_waddr_ex_i            ),
     .csr_raddr_ex_i             ( csr_raddr_ex_i           ),
 
     // From WB
-    .rf_waddr_wb_i              ( rf_waddr_wb_i            ),
     .wb_ready_i                 ( wb_ready_i               ),
 
     // From LSU

--- a/rtl/cv32e40x_controller.sv
+++ b/rtl/cv32e40x_controller.sv
@@ -137,7 +137,6 @@ module cv32e40x_controller import cv32e40x_pkg::*;
     // From WB stage
     .lsu_err_wb_i                ( lsu_err_wb_i             ),
     .lsu_addr_wb_i               ( lsu_addr_wb_i            ),
-    .lsu_en_wb_i                 ( lsu_en_wb_i              ),
     .wb_ready_i                  ( wb_ready_i               ),
     .wb_valid_i                  ( wb_valid_i               ),
 

--- a/rtl/cv32e40x_controller_fsm.sv
+++ b/rtl/cv32e40x_controller_fsm.sv
@@ -59,7 +59,6 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
   // From WB stage
   input  logic        lsu_err_wb_i,               // LSU caused bus_error in WB stage
   input  logic [31:0] lsu_addr_wb_i,              // LSU address in WB stage
-  input  logic        lsu_en_wb_i,                // LSU data is written back in WB
 
   // Interrupt Controller Signals
   input  logic        irq_req_ctrl_i,             // irq requst

--- a/rtl/cv32e40x_core.sv
+++ b/rtl/cv32e40x_core.sv
@@ -132,7 +132,6 @@ module cv32e40x_core import cv32e40x_pkg::*;
   logic [31:0] rf_wdata_wb;
 
   // Forwarding RF from EX
-  rf_addr_t    rf_waddr_ex;
   logic [31:0] rf_wdata_ex;
 
   // Register file signals from ID/decoder to controller
@@ -396,7 +395,6 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .debug_trigger_match_id_i     ( debug_trigger_match_id    ),       // from cs_registers (ID timing)
 
     // Register file write back and forwards
-    .rf_waddr_ex_i                ( rf_waddr_ex               ),
     .rf_wdata_ex_i                ( rf_wdata_ex               ),
     .rf_wdata_wb_i                ( rf_wdata_wb               ),
 
@@ -453,7 +451,6 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .branch_target_o            ( branch_target_ex             ),
 
     // Register file forwarding
-    .rf_waddr_o                 ( rf_waddr_ex                  ),
     .rf_wdata_o                 ( rf_wdata_ex                  ),
 
     // LSU interface
@@ -685,8 +682,6 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .rf_re_i                        ( rf_re_id               ),       
     .rf_raddr_i                     ( rf_raddr_id            ),
     .rf_waddr_i                     ( rf_waddr_id            ),
-    .rf_waddr_ex_i                  ( rf_waddr_ex            ),
-    .rf_waddr_wb_i                  ( rf_waddr_wb            ),
 
     // Write targets from ID
     .regfile_alu_we_id_i            ( regfile_alu_we_id      ),

--- a/rtl/cv32e40x_core.sv
+++ b/rtl/cv32e40x_core.sv
@@ -128,6 +128,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
   
   // Register File Write Back
   logic        rf_we_wb;
+  logic        rf_we_wb_raw; // Unaffected by kill/halt
   rf_addr_t    rf_waddr_wb;
   logic [31:0] rf_wdata_wb;
 
@@ -405,8 +406,6 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .rf_wdata_ex_i                ( rf_wdata_ex               ),
     .rf_wdata_wb_i                ( rf_wdata_wb               ),
 
-    .lsu_en_wb_i                  ( lsu_en_wb                 ),
-
     .mret_insn_o                  ( mret_insn_id              ),
     .dret_insn_o                  ( dret_insn_id              ),
 
@@ -548,6 +547,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
 
     // Write back to register file
     .rf_we_wb_o                 ( rf_we_wb                     ),
+    .rf_we_wb_raw_o             ( rf_we_wb_raw                 ),
     .rf_waddr_wb_o              ( rf_waddr_wb                  ),
     .rf_wdata_wb_o              ( rf_wdata_wb                  ),
 
@@ -697,7 +697,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .rf_waddr_i                     ( rf_waddr_id            ),
     .rf_we_ex_i                     ( rf_we_ex               ),
     .rf_waddr_ex_i                  ( rf_waddr_ex            ),
-    .rf_we_wb_i                     ( rf_we_wb               ),
+    .rf_we_wb_i                     ( rf_we_wb_raw           ),
     .rf_waddr_wb_i                  ( rf_waddr_wb            ),
 
     // Write targets from ID

--- a/rtl/cv32e40x_core.sv
+++ b/rtl/cv32e40x_core.sv
@@ -128,12 +128,10 @@ module cv32e40x_core import cv32e40x_pkg::*;
   
   // Register File Write Back
   logic        rf_we_wb;
-  logic        rf_we_wb_raw; // Unaffected by kill/halt
   rf_addr_t    rf_waddr_wb;
   logic [31:0] rf_wdata_wb;
 
   // Forwarding RF from EX
-  logic        rf_we_ex;
   rf_addr_t    rf_waddr_ex;
   logic [31:0] rf_wdata_ex;
 
@@ -204,9 +202,6 @@ module cv32e40x_core import cv32e40x_pkg::*;
 
   // trigger match detected in cs_registers (using ID timing)
   logic        debug_trigger_match_id;
-
-  // WB is writing back a LSU result
-  logic        lsu_en_wb;
 
   // Controller <-> decoder 
   logic       mret_insn_id;
@@ -401,7 +396,6 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .debug_trigger_match_id_i     ( debug_trigger_match_id    ),       // from cs_registers (ID timing)
 
     // Register file write back and forwards
-    .rf_we_ex_i                   ( rf_we_ex                  ),
     .rf_waddr_ex_i                ( rf_waddr_ex               ),
     .rf_wdata_ex_i                ( rf_wdata_ex               ),
     .rf_wdata_wb_i                ( rf_wdata_wb               ),
@@ -459,7 +453,6 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .branch_target_o            ( branch_target_ex             ),
 
     // Register file forwarding
-    .rf_we_o                    ( rf_we_ex                     ),
     .rf_waddr_o                 ( rf_waddr_ex                  ),
     .rf_wdata_o                 ( rf_wdata_ex                  ),
 
@@ -540,14 +533,12 @@ module cv32e40x_core import cv32e40x_pkg::*;
 
     // Controller
     .ctrl_fsm_i                 ( ctrl_fsm                     ),
-    .lsu_en_wb_o                ( lsu_en_wb                    ),
 
     // LSU
     .lsu_rdata_i                ( lsu_rdata_wb                 ),
 
     // Write back to register file
     .rf_we_wb_o                 ( rf_we_wb                     ),
-    .rf_we_wb_raw_o             ( rf_we_wb_raw                 ),
     .rf_waddr_wb_o              ( rf_waddr_wb                  ),
     .rf_wdata_wb_o              ( rf_wdata_wb                  ),
 
@@ -668,7 +659,6 @@ module cv32e40x_core import cv32e40x_pkg::*;
     // LSU
     .lsu_misaligned_i               ( lsu_misaligned_ex      ),
     .lsu_addr_wb_i                  ( lsu_addr_wb            ),
-    .lsu_en_wb_i                    ( lsu_en_wb              ),
     .lsu_err_wb_i                   ( lsu_err_wb             ),
   
     // jump/branch control
@@ -695,9 +685,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .rf_re_i                        ( rf_re_id               ),       
     .rf_raddr_i                     ( rf_raddr_id            ),
     .rf_waddr_i                     ( rf_waddr_id            ),
-    .rf_we_ex_i                     ( rf_we_ex               ),
     .rf_waddr_ex_i                  ( rf_waddr_ex            ),
-    .rf_we_wb_i                     ( rf_we_wb_raw           ),
     .rf_waddr_wb_i                  ( rf_waddr_wb            ),
 
     // Write targets from ID

--- a/rtl/cv32e40x_cs_registers.sv
+++ b/rtl/cv32e40x_cs_registers.sv
@@ -770,6 +770,7 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
   // Breakpoint matching
   // We match against the next address, as the breakpoint must be taken before execution
   // Matching is disabled when ctrl_fsm_i.debug_mode == 1'b1
+  // todo: Need to explain why this does not require hazard detection (ie csr write to tdata2 before the matched instruction)
   assign debug_trigger_match_o = tmatch_control_q[2] && !ctrl_fsm_i.debug_mode &&
                                  (if_id_pipe_i.pc[31:0] == tmatch_value_q[31:0]);
 

--- a/rtl/cv32e40x_ex_stage.sv
+++ b/rtl/cv32e40x_ex_stage.sv
@@ -48,8 +48,6 @@ module cv32e40x_ex_stage import cv32e40x_pkg::*;
   input  ctrl_fsm_t   ctrl_fsm_i,
 
   // Register file forwarding signals (to ID)
-  output logic        rf_we_o,
-  output rf_addr_t    rf_waddr_o,
   output logic [31:0] rf_wdata_o,
 
   // To IF: Jump and branch target and decision
@@ -108,12 +106,6 @@ module cv32e40x_ex_stage import cv32e40x_pkg::*;
   assign div_en_gated = id_ex_pipe_i.div_en && instr_valid; // Factoring in instr_valid to kill div instructions on kill/halt
   assign lsu_en_gated = id_ex_pipe_i.lsu_en && instr_valid; // Factoring in instr_valid to suppress bus transactions on kill/halt
 
-  // Local rf_we only used in bypass module to detect hazards
-  // Not using local instr_valid to keep stall situations constant while halted
-  // Not gating off with !csr_illegal_i
-  //   Younger instructions will be killed before they reach WB anyway
-  //   Prevents one extra gate in the bypass paths
-  assign rf_we        = id_ex_pipe_i.rf_we  && id_ex_pipe_i.instr_valid;
 
   // Exception happened during IF or ID, or trigger match in ID (converted to NOP).
   // signal needed for ex_valid to go high in such cases
@@ -126,9 +118,6 @@ module cv32e40x_ex_stage import cv32e40x_pkg::*;
   // ALU write port mux
   always_comb
   begin
-    rf_we_o    = rf_we;
-    rf_waddr_o = id_ex_pipe_i.rf_waddr;
-
     // There is no need to use gated versions of alu_en, mul_en, etc. as rf_wdata_o will be ignored
     // for invalid instructions (as the register file write enable will be suppressed).
     unique case (1'b1)

--- a/rtl/cv32e40x_ex_stage.sv
+++ b/rtl/cv32e40x_ex_stage.sv
@@ -83,7 +83,6 @@ module cv32e40x_ex_stage import cv32e40x_pkg::*;
   logic           mul_en_gated;
   logic           div_en_gated;
   logic           lsu_en_gated;
-  logic           rf_we;
   logic           previous_exception;
 
   // Divider signals

--- a/rtl/cv32e40x_ex_stage.sv
+++ b/rtl/cv32e40x_ex_stage.sv
@@ -85,7 +85,7 @@ module cv32e40x_ex_stage import cv32e40x_pkg::*;
   logic           mul_en_gated;
   logic           div_en_gated;
   logic           lsu_en_gated;
-  logic           rf_we_gated;
+  logic           rf_we;
   logic           previous_exception;
 
   // Divider signals
@@ -104,10 +104,16 @@ module cv32e40x_ex_stage import cv32e40x_pkg::*;
   //assign instr_valid = id_ex_pipe_i.instr_valid && !ctrl_fsm_i.kill_ex; // todo: why does halt_ex not factor in here just like in LSU?
   assign instr_valid = id_ex_pipe_i.instr_valid && !ctrl_fsm_i.kill_ex && !ctrl_fsm_i.halt_ex; // todo: This gives SEC error, explain why this is ok.
  
-  assign mul_en_gated = id_ex_pipe_i.mul_en && instr_valid;
-  assign div_en_gated = id_ex_pipe_i.div_en && instr_valid;
-  assign lsu_en_gated = id_ex_pipe_i.lsu_en && instr_valid;
-  assign rf_we_gated  = id_ex_pipe_i.rf_we  && instr_valid && !csr_illegal_i;
+  assign mul_en_gated = id_ex_pipe_i.mul_en && instr_valid; // Factoring in instr_valid to kill mul instructions on kill/halt
+  assign div_en_gated = id_ex_pipe_i.div_en && instr_valid; // Factoring in instr_valid to kill div instructions on kill/halt
+  assign lsu_en_gated = id_ex_pipe_i.lsu_en && instr_valid; // Factoring in instr_valid to suppress bus transactions on kill/halt
+
+  // Local rf_we only used in bypass module to detect hazards
+  // Not using local instr_valid to keep stall situations constant while halted
+  // Not gating off with !csr_illegal_i
+  //   Younger instructions will be killed before they reach WB anyway
+  //   Prevents one extra gate in the bypass paths
+  assign rf_we        = id_ex_pipe_i.rf_we  && id_ex_pipe_i.instr_valid;
 
   // Exception happened during IF or ID, or trigger match in ID (converted to NOP).
   // signal needed for ex_valid to go high in such cases
@@ -120,7 +126,7 @@ module cv32e40x_ex_stage import cv32e40x_pkg::*;
   // ALU write port mux
   always_comb
   begin
-    rf_we_o    = rf_we_gated;
+    rf_we_o    = rf_we;
     rf_waddr_o = id_ex_pipe_i.rf_waddr;
 
     // There is no need to use gated versions of alu_en, mul_en, etc. as rf_wdata_o will be ignored

--- a/rtl/cv32e40x_id_stage.sv
+++ b/rtl/cv32e40x_id_stage.sv
@@ -62,11 +62,10 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
   // Debug Signal
   input  logic        debug_trigger_match_id_i,
 
-  // Register file write back and forwards
+  // Register file write data from WB stage
   input  logic [31:0]    rf_wdata_wb_i,
 
-  input  logic           rf_we_ex_i,
-  input  rf_addr_t       rf_waddr_ex_i,
+  // Register file write data from EX stage
   input  logic [31:0]    rf_wdata_ex_i,
 
   output logic        mret_insn_o,

--- a/rtl/cv32e40x_id_stage.sv
+++ b/rtl/cv32e40x_id_stage.sv
@@ -69,8 +69,6 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
   input  rf_addr_t       rf_waddr_ex_i,
   input  logic [31:0]    rf_wdata_ex_i,
 
-  input  logic        lsu_en_wb_i,
-
   output logic        mret_insn_o,
   output logic        dret_insn_o,
   // Decoder to controller


### PR DESCRIPTION
-Changed rf_we_o in EX to _not_ factor in halt and kill, as this would
lead to hazards not being detected during halt. Not SEC clean as stalls are affected by this fix.

-Added a rf_we_wb_raw output to the WB stage for use in the bypass module.
-Not including the local instr valid in WB stage lsu_en and lsu_valid_o.

The above two changes are done to prevent timing paths like
controller_fsm -> bypass -> controller_fsm.

Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>