### PR TITLE
Moved evaluation of debug single step.

### DIFF
--- a/rtl/cv32e40x_controller_fsm.sv
+++ b/rtl/cv32e40x_controller_fsm.sv
@@ -525,16 +525,17 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
           if (mret_in_wb && !ctrl_fsm_o.kill_wb) begin
             ctrl_fsm_o.csr_restore_mret  = !debug_mode_q;
           end
-
-          // Single step debug entry
-          // Need to be after exception/interrupt handling
-          // to ensure mepc and if_pc set correctly for use in dpc
-          if (pending_single_step) begin
-            if (single_step_allowed) begin
-              ctrl_fsm_ns = DEBUG_TAKEN;
-            end
-          end
         end // !debug or interrupts
+
+        // Single step debug entry
+          // Need to be after (in parallell with) exception/interrupt handling
+          // to ensure mepc and if_pc set correctly for use in dpc,
+          // and to ensure only one instruction can retire during single step
+        if (pending_single_step) begin
+          if (single_step_allowed) begin
+            ctrl_fsm_ns = DEBUG_TAKEN;
+          end
+        end
       end
       SLEEP: begin
         ctrl_fsm_o.ctrl_busy = 1'b0;


### PR DESCRIPTION
Single_step_pending would not be evaluated in case of a pending interrupt,
possibly leading to executing two instructions in a step.

Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>