### PR TITLE
Bugfix: Events in shadow of interrupt/debug pending was not guaranteed to be handled

### DIFF
--- a/rtl/cv32e40x_controller_fsm.sv
+++ b/rtl/cv32e40x_controller_fsm.sv
@@ -332,7 +332,7 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
     // to avoid more than one instructions passing down the pipe.
     ctrl_fsm_o.halt_if = single_step_halt_if_q;
     // ID stage is halted for regular stalls (i.e. stalls for which the instruction
-    // currently in ID is not ready to be issued yet). Also halted it interruptor debug pending
+    // currently in ID is not ready to be issued yet). Also halted if interrupt or debug pending
     // but not allowed to be taken. This is to create an interruptible bubble in WB.
     ctrl_fsm_o.halt_id = ctrl_byp_i.jr_stall || ctrl_byp_i.load_stall || ctrl_byp_i.csr_stall || ctrl_byp_i.wfi_stall ||
                          (pending_interrupt && !interrupt_allowed) ||


### PR DESCRIPTION
In case of pending interrupt or debug, but not allowed to take interrupt/debug, the controller would halt ID to create an interruptible bubble later. This was done in a way that blocked any events happening in EX or WB while halting ID. Branches in EX could end up not being taken, and exceptions in WB would not be handled.

This PR addreses this issue and will enable events in EX/WB to be handled while ID stage is halted.

Passes ci_check, but is non-SEC due to the nature of the bug.

Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>