### PR TITLE
Bugfixes for kill_wb during debug mode and flops using wrong clock

### DIFF
--- a/rtl/cv32e40x_controller_fsm.sv
+++ b/rtl/cv32e40x_controller_fsm.sv
@@ -560,6 +560,8 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
           // Ebreak that causes debug entry should not be killed, otherwise RVFI will skip it
           // Trigger match should also be signalled as not killed (all write enables are suppressed in ID), otherwise RVFI/ISS will not attempt to execute and detect trigger
           // Ebreak during debug_mode restarts from dm_halt_addr, without CSR updates. Not killing ebreak due to the same RVFI/ISS reasons.
+          // Neither ebreak nor trigger match have any state updates in WB. For trigger match, all write enables are suppressed in the ID stage.
+          //   Thus this change is not visible to core state, only for RVFI use.
           // todo: Move some logic to RVFI instead?
           ctrl_fsm_o.kill_wb = !((debug_cause_q == DBG_CAUSE_EBREAK) || (debug_cause_q == DBG_CAUSE_TRIGGER) ||
                                 (debug_mode_q && ebreak_in_wb));


### PR DESCRIPTION
Bugfix: Some flip flops in the controller were using the ungated clock by mistake.

Bugfix: kill_wb during DEBUG_TAKEN would kill regular ebreaks (withouth dcsr.ebreakm)
if debug was caused by an external request. Ebreaks were also killed during debug mode.
This fix does not affect RTL, but affects RVFI/RVVI.

Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>