### PR TITLE
LSU PMA support

### DIFF
--- a/rtl/cv32e40x_controller.sv
+++ b/rtl/cv32e40x_controller.sv
@@ -51,7 +51,8 @@ module cv32e40x_controller import cv32e40x_pkg::*;
   input  ex_wb_pipe_t ex_wb_pipe_i,
 
   // LSU
-  input  logic        lsu_misaligned_i, // todo:ab proper postfix
+  input  logic        lsu_misaligned_i,           // todo:ab proper postfix
+  input  mpu_status_e lsu_mpu_status_i,           // MPU status (WB stage)
   input  logic        lsu_err_wb_i,               // LSU bus error in WB stage
   input  logic [31:0] lsu_addr_wb_i,              // LSU address in WB stage
 
@@ -131,6 +132,9 @@ module cv32e40x_controller import cv32e40x_pkg::*;
     .lsu_addr_wb_i               ( lsu_addr_wb_i            ),
     .wb_ready_i                  ( wb_ready_i               ),
     .wb_valid_i                  ( wb_valid_i               ),
+
+    // From LSU
+    .lsu_mpu_status_i            ( lsu_mpu_status_i         ),
 
     // Interrupt Controller Signals
     .irq_req_ctrl_i              ( irq_req_ctrl_i           ),

--- a/rtl/cv32e40x_controller.sv
+++ b/rtl/cv32e40x_controller.sv
@@ -51,8 +51,8 @@ module cv32e40x_controller import cv32e40x_pkg::*;
   input  ex_wb_pipe_t ex_wb_pipe_i,
 
   // LSU
-  input  logic        lsu_misaligned_i,           // todo:ab proper postfix
-  input  mpu_status_e lsu_mpu_status_i,           // MPU status (WB stage)
+  input  logic        lsu_misaligned_ex_i,        // LSU is misaligned
+  input  mpu_status_e lsu_mpu_status_wb_i,        // MPU status (WB stage)
   input  logic        lsu_err_wb_i,               // LSU bus error in WB stage
   input  logic [31:0] lsu_addr_wb_i,              // LSU address in WB stage
 
@@ -130,11 +130,9 @@ module cv32e40x_controller import cv32e40x_pkg::*;
     // From WB stage
     .lsu_err_wb_i                ( lsu_err_wb_i             ),
     .lsu_addr_wb_i               ( lsu_addr_wb_i            ),
+    .lsu_mpu_status_wb_i         ( lsu_mpu_status_wb_i      ),
     .wb_ready_i                  ( wb_ready_i               ),
     .wb_valid_i                  ( wb_valid_i               ),
-
-    // From LSU
-    .lsu_mpu_status_i            ( lsu_mpu_status_i         ),
 
     // Interrupt Controller Signals
     .irq_req_ctrl_i              ( irq_req_ctrl_i           ),
@@ -183,7 +181,7 @@ module cv32e40x_controller import cv32e40x_pkg::*;
     .wb_ready_i                 ( wb_ready_i               ),
 
     // From LSU
-    .lsu_misaligned_i           ( lsu_misaligned_i         ),
+    .lsu_misaligned_ex_i        ( lsu_misaligned_ex_i      ),
 
     // Outputs
     .ctrl_byp_o                 ( ctrl_byp_o               )

--- a/rtl/cv32e40x_controller_bypass.sv
+++ b/rtl/cv32e40x_controller_bypass.sv
@@ -60,7 +60,7 @@ module cv32e40x_controller_bypass import cv32e40x_pkg::*;
   input  logic        wb_ready_i,                 // WB stage is ready
 
   // From LSU
-  input  logic        lsu_misaligned_i,           // LSU detected a misaligned load/store instruction
+  input  logic        lsu_misaligned_ex_i,           // LSU detected a misaligned load/store instruction
 
   // Controller Bypass outputs
   output ctrl_byp_t     ctrl_byp_o
@@ -184,8 +184,8 @@ module cv32e40x_controller_bypass import cv32e40x_pkg::*;
     if (
         (id_ex_pipe_i.lsu_en && rf_we_ex && |rf_rd_ex_hz) || // load-use hazard (EX)
         (!wb_ready_i         && rf_we_wb && |rf_rd_wb_hz) || // load-use hazard (WB during wait-state)
-        (id_ex_pipe_i.lsu_en && rf_we_ex && !lsu_misaligned_i && rf_wr_ex_hz) ||  // TODO: remove?
-        (!wb_ready_i         && rf_we_wb && !lsu_misaligned_i && rf_wr_wb_hz)     // TODO: remove? Probably SEC fail
+        (id_ex_pipe_i.lsu_en && rf_we_ex && !lsu_misaligned_ex_i && rf_wr_ex_hz) ||  // TODO: remove?
+        (!wb_ready_i         && rf_we_wb && !lsu_misaligned_ex_i && rf_wr_wb_hz)     // TODO: remove? Probably SEC fail
        )
     begin
       ctrl_byp_o.deassert_we = 1'b1;
@@ -221,7 +221,7 @@ module cv32e40x_controller_bypass import cv32e40x_pkg::*;
   end
 
   // stall because of misaligned data access
-  assign ctrl_byp_o.misaligned_stall = lsu_misaligned_i;
+  assign ctrl_byp_o.misaligned_stall = lsu_misaligned_ex_i;
 
   // Forwarding control unit
   always_comb
@@ -260,7 +260,7 @@ module cv32e40x_controller_bypass import cv32e40x_pkg::*;
     end
 
     // for misaligned memory accesses
-    if (lsu_misaligned_i)
+    if (lsu_misaligned_ex_i)
     begin
       ctrl_byp_o.operand_a_fw_mux_sel = SEL_FW_EX;
       ctrl_byp_o.operand_b_fw_mux_sel = SEL_REGFILE;

--- a/rtl/cv32e40x_controller_fsm.sv
+++ b/rtl/cv32e40x_controller_fsm.sv
@@ -61,7 +61,7 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
   input  logic [31:0] lsu_addr_wb_i,              // LSU address in WB stage
 
   // From LSU (WB)
-  input  mpu_status_e lsu_mpu_status_i,           // MPU status (WB timing)
+  input  mpu_status_e lsu_mpu_status_wb_i,        // MPU status (WB timing)
 
   // Interrupt Controller Signals
   input  logic        irq_req_ctrl_i,             // irq requst
@@ -182,7 +182,7 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
                             ex_wb_pipe_i.illegal_insn                 ||
                             ex_wb_pipe_i.ecall_insn                   ||
                             ex_wb_pipe_i.ebrk_insn                    ||
-                            (lsu_mpu_status_i != MPU_OK))             && ex_wb_pipe_i.instr_valid;
+                            (lsu_mpu_status_wb_i != MPU_OK))          && ex_wb_pipe_i.instr_valid;
 
   // Set exception cause
   assign exception_cause_wb = ex_wb_pipe_i.instr.mpu_status != MPU_OK       ? EXC_CAUSE_INSTR_FAULT     :
@@ -190,8 +190,8 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
                               ex_wb_pipe_i.illegal_insn                     ? EXC_CAUSE_ILLEGAL_INSN    :
                               ex_wb_pipe_i.ecall_insn                       ? EXC_CAUSE_ECALL_MMODE     :
                               ex_wb_pipe_i.ebrk_insn                        ? EXC_CAUSE_BREAKPOINT      :
-                              (lsu_mpu_status_i == MPU_WR_FAULT)            ? EXC_CAUSE_STORE_FAULT     :
-                              (lsu_mpu_status_i == MPU_RE_FAULT)            ? EXC_CAUSE_LOAD_FAULT      :
+                              (lsu_mpu_status_wb_i == MPU_WR_FAULT)         ? EXC_CAUSE_STORE_FAULT     :
+                              (lsu_mpu_status_wb_i == MPU_RE_FAULT)         ? EXC_CAUSE_LOAD_FAULT      :
                               'h0; // todo:ok: could default to EXC_CAUSE_LOAD_FAULT instead
 
   // wfi in wb

--- a/rtl/cv32e40x_controller_fsm.sv
+++ b/rtl/cv32e40x_controller_fsm.sv
@@ -178,14 +178,18 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
                             ex_wb_pipe_i.instr.bus_resp.err           ||
                             ex_wb_pipe_i.illegal_insn                 ||
                             ex_wb_pipe_i.ecall_insn                   ||
-                            ex_wb_pipe_i.ebrk_insn) && ex_wb_pipe_i.instr_valid;
+                            ex_wb_pipe_i.ebrk_insn                    ||
+                            (ex_wb_pipe_i.lsu_mpu_status != MPU_OK))  && ex_wb_pipe_i.instr_valid;
 
   // Set exception cause
-  assign exception_cause_wb = ex_wb_pipe_i.instr.mpu_status != MPU_OK ? EXC_CAUSE_INSTR_FAULT     :
-                              ex_wb_pipe_i.instr.bus_resp.err         ? EXC_CAUSE_INSTR_BUS_FAULT :
-                              ex_wb_pipe_i.illegal_insn               ? EXC_CAUSE_ILLEGAL_INSN    :
-                              ex_wb_pipe_i.ecall_insn                 ? EXC_CAUSE_ECALL_MMODE     :
-                              EXC_CAUSE_BREAKPOINT;
+  assign exception_cause_wb = ex_wb_pipe_i.instr.mpu_status != MPU_OK       ? EXC_CAUSE_INSTR_FAULT     :
+                              ex_wb_pipe_i.instr.bus_resp.err               ? EXC_CAUSE_INSTR_BUS_FAULT :
+                              ex_wb_pipe_i.illegal_insn                     ? EXC_CAUSE_ILLEGAL_INSN    :
+                              ex_wb_pipe_i.ecall_insn                       ? EXC_CAUSE_ECALL_MMODE     :
+                              ex_wb_pipe_i.ebrk_insn                        ? EXC_CAUSE_BREAKPOINT      :
+                              (ex_wb_pipe_i.lsu_mpu_status == MPU_WR_FAULT) ? EXC_CAUSE_STORE_FAULT     :
+                              (ex_wb_pipe_i.lsu_mpu_status == MPU_RE_FAULT) ? EXC_CAUSE_LOAD_FAULT      :
+                              'h0; // todo:ok: could default to EXC_CAUSE_LOAD_FAULT instead
 
   // wfi in wb
   assign wfi_in_wb = ex_wb_pipe_i.wfi_insn && ex_wb_pipe_i.instr_valid;

--- a/rtl/cv32e40x_controller_fsm.sv
+++ b/rtl/cv32e40x_controller_fsm.sv
@@ -60,6 +60,9 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
   input  logic        lsu_err_wb_i,               // LSU caused bus_error in WB stage
   input  logic [31:0] lsu_addr_wb_i,              // LSU address in WB stage
 
+  // From LSU (WB)
+  input  mpu_status_e lsu_mpu_status_i,           // MPU status (WB timing)
+
   // Interrupt Controller Signals
   input  logic        irq_req_ctrl_i,             // irq requst
   input  logic [4:0]  irq_id_ctrl_i,              // irq id
@@ -179,7 +182,7 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
                             ex_wb_pipe_i.illegal_insn                 ||
                             ex_wb_pipe_i.ecall_insn                   ||
                             ex_wb_pipe_i.ebrk_insn                    ||
-                            (ex_wb_pipe_i.lsu_mpu_status != MPU_OK))  && ex_wb_pipe_i.instr_valid;
+                            (lsu_mpu_status_i != MPU_OK))             && ex_wb_pipe_i.instr_valid;
 
   // Set exception cause
   assign exception_cause_wb = ex_wb_pipe_i.instr.mpu_status != MPU_OK       ? EXC_CAUSE_INSTR_FAULT     :
@@ -187,8 +190,8 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
                               ex_wb_pipe_i.illegal_insn                     ? EXC_CAUSE_ILLEGAL_INSN    :
                               ex_wb_pipe_i.ecall_insn                       ? EXC_CAUSE_ECALL_MMODE     :
                               ex_wb_pipe_i.ebrk_insn                        ? EXC_CAUSE_BREAKPOINT      :
-                              (ex_wb_pipe_i.lsu_mpu_status == MPU_WR_FAULT) ? EXC_CAUSE_STORE_FAULT     :
-                              (ex_wb_pipe_i.lsu_mpu_status == MPU_RE_FAULT) ? EXC_CAUSE_LOAD_FAULT      :
+                              (lsu_mpu_status_i == MPU_WR_FAULT)            ? EXC_CAUSE_STORE_FAULT     :
+                              (lsu_mpu_status_i == MPU_RE_FAULT)            ? EXC_CAUSE_LOAD_FAULT      :
                               'h0; // todo:ok: could default to EXC_CAUSE_LOAD_FAULT instead
 
   // wfi in wb

--- a/rtl/cv32e40x_core.sv
+++ b/rtl/cv32e40x_core.sv
@@ -158,7 +158,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
 
   // LSU
   logic        lsu_misaligned_ex;
-  mpu_status_e lsu_mpu_status_ex;
+  mpu_status_e lsu_mpu_status_wb;
   logic [31:0] lsu_rdata_wb;
   logic        lsu_err_wb;
   logic [31:0] lsu_addr_wb;
@@ -456,7 +456,6 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .lsu_ready_o                ( lsu_ready_ex                 ),
     .lsu_valid_o                ( lsu_valid_ex                 ),
     .lsu_ready_i                ( lsu_ready_0                  ),
-    .lsu_mpu_status_i           ( lsu_mpu_status_ex            ),
     .lsu_misaligned_i           ( lsu_misaligned_ex)           ,
 
     // Pipeline handshakes
@@ -497,7 +496,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
 
     // Stage 0 outputs (EX)
     .lsu_misaligned_0_o    ( lsu_misaligned_ex  ),
-    .lsu_mpu_status_0_o    ( lsu_mpu_status_ex  ),
+    .lsu_mpu_status_1_o    ( lsu_mpu_status_wb  ),
 
     // Stage 1 outputs (WB)
     .lsu_addr_1_o          ( lsu_addr_wb        ), // To controller (has WB timing, but does not pass through WB stage)
@@ -654,6 +653,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
                                                                  
     // LSU
     .lsu_misaligned_i               ( lsu_misaligned_ex      ),
+    .lsu_mpu_status_i               ( lsu_mpu_status_wb      ),
     .lsu_addr_wb_i                  ( lsu_addr_wb            ),
     .lsu_err_wb_i                   ( lsu_err_wb             ),
   

--- a/rtl/cv32e40x_core.sv
+++ b/rtl/cv32e40x_core.sv
@@ -533,6 +533,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
 
     // LSU
     .lsu_rdata_i                ( lsu_rdata_wb                 ),
+    .lsu_mpu_status_i           ( lsu_mpu_status_wb            ),
 
     // Write back to register file
     .rf_we_wb_o                 ( rf_we_wb                     ),

--- a/rtl/cv32e40x_core.sv
+++ b/rtl/cv32e40x_core.sv
@@ -456,7 +456,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .lsu_ready_o                ( lsu_ready_ex                 ),
     .lsu_valid_o                ( lsu_valid_ex                 ),
     .lsu_ready_i                ( lsu_ready_0                  ),
-    .lsu_misaligned_i           ( lsu_misaligned_ex)           ,
+    .lsu_misaligned_i           ( lsu_misaligned_ex            ),
 
     // Pipeline handshakes
     .ex_ready_o                 ( ex_ready                     ),
@@ -653,8 +653,8 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .csr_op_id_i                    ( csr_op_id              ),
                                                                  
     // LSU
-    .lsu_misaligned_i               ( lsu_misaligned_ex      ),
-    .lsu_mpu_status_i               ( lsu_mpu_status_wb      ),
+    .lsu_misaligned_ex_i            ( lsu_misaligned_ex      ),
+    .lsu_mpu_status_wb_i            ( lsu_mpu_status_wb      ),
     .lsu_addr_wb_i                  ( lsu_addr_wb            ),
     .lsu_err_wb_i                   ( lsu_err_wb             ),
   

--- a/rtl/cv32e40x_core.sv
+++ b/rtl/cv32e40x_core.sv
@@ -158,6 +158,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
 
   // LSU
   logic        lsu_misaligned_ex;
+  mpu_status_e lsu_mpustatus_ex;
   logic [31:0] lsu_rdata_wb;
   logic        lsu_err_wb;
   logic [31:0] lsu_addr_wb;
@@ -455,6 +456,8 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .lsu_ready_o                ( lsu_ready_ex                 ),
     .lsu_valid_o                ( lsu_valid_ex                 ),
     .lsu_ready_i                ( lsu_ready_0                  ),
+    .lsu_mpustatus_i            ( lsu_mpustatus_ex             ),
+    .lsu_misaligned_i           ( lsu_misaligned_ex)           ,
 
     // Pipeline handshakes
     .ex_ready_o                 ( ex_ready                     ),
@@ -494,6 +497,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
 
     // Stage 0 outputs (EX)
     .lsu_misaligned_0_o    ( lsu_misaligned_ex  ),
+    .lsu_mpustatus_0_o     ( lsu_mpustatus_ex   ),
 
     // Stage 1 outputs (WB)
     .lsu_addr_1_o          ( lsu_addr_wb        ), // To controller (has WB timing, but does not pass through WB stage)

--- a/rtl/cv32e40x_core.sv
+++ b/rtl/cv32e40x_core.sv
@@ -158,7 +158,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
 
   // LSU
   logic        lsu_misaligned_ex;
-  mpu_status_e lsu_mpustatus_ex;
+  mpu_status_e lsu_mpu_status_ex;
   logic [31:0] lsu_rdata_wb;
   logic        lsu_err_wb;
   logic [31:0] lsu_addr_wb;
@@ -456,7 +456,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .lsu_ready_o                ( lsu_ready_ex                 ),
     .lsu_valid_o                ( lsu_valid_ex                 ),
     .lsu_ready_i                ( lsu_ready_0                  ),
-    .lsu_mpustatus_i            ( lsu_mpustatus_ex             ),
+    .lsu_mpu_status_i           ( lsu_mpu_status_ex            ),
     .lsu_misaligned_i           ( lsu_misaligned_ex)           ,
 
     // Pipeline handshakes
@@ -497,7 +497,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
 
     // Stage 0 outputs (EX)
     .lsu_misaligned_0_o    ( lsu_misaligned_ex  ),
-    .lsu_mpustatus_0_o     ( lsu_mpustatus_ex   ),
+    .lsu_mpu_status_0_o    ( lsu_mpu_status_ex  ),
 
     // Stage 1 outputs (WB)
     .lsu_addr_1_o          ( lsu_addr_wb        ), // To controller (has WB timing, but does not pass through WB stage)

--- a/rtl/cv32e40x_ex_stage.sv
+++ b/rtl/cv32e40x_ex_stage.sv
@@ -59,7 +59,7 @@ module cv32e40x_ex_stage import cv32e40x_pkg::*;
   output logic        lsu_ready_o,
   output logic        lsu_valid_o,
   input  logic        lsu_ready_i,
-  input  mpu_status_e lsu_mpustatus_i,        // PMA error detected in LSU
+  input  mpu_status_e lsu_mpu_status_i,        // PMA error detected in LSU
   input  logic        lsu_misaligned_i,       // LSU is performing first part of a misaligned instruction
 
   // Stage ready/valid
@@ -267,9 +267,9 @@ module cv32e40x_ex_stage import cv32e40x_pkg::*;
         ex_wb_pipe_o.instr_valid <= 1'b1;
         // Deassert rf_we in case of illegal csr instruction, PMA error in LSU or
         // when the first half of a misaligned LSU goes to WB.
-        ex_wb_pipe_o.rf_we       <= (csr_illegal_i              ||
-                                    (lsu_mpustatus_i != MPU_OK) ||
-                                    lsu_misaligned_i)            ? 1'b0 : id_ex_pipe_i.rf_we;
+        ex_wb_pipe_o.rf_we       <= (csr_illegal_i               ||
+                                    (lsu_mpu_status_i != MPU_OK) ||
+                                    lsu_misaligned_i)             ? 1'b0 : id_ex_pipe_i.rf_we;
         ex_wb_pipe_o.lsu_en      <= id_ex_pipe_i.lsu_en;
           
         if (id_ex_pipe_i.rf_we) begin
@@ -301,7 +301,7 @@ module cv32e40x_ex_stage import cv32e40x_pkg::*;
         ex_wb_pipe_o.fencei_insn    <= id_ex_pipe_i.fencei_insn;
         ex_wb_pipe_o.mret_insn      <= id_ex_pipe_i.mret_insn;
         ex_wb_pipe_o.dret_insn      <= id_ex_pipe_i.dret_insn;
-        ex_wb_pipe_o.lsu_mpu_status <= lsu_mpustatus_i; // From load_store_unit
+        ex_wb_pipe_o.lsu_mpu_status <= lsu_mpu_status_i; // From load_store_unit
         ex_wb_pipe_o.trigger_match  <= id_ex_pipe_i.trigger_match;
       end else if (wb_ready_i) begin
         // we are ready for a new instruction, but there is none available,

--- a/rtl/cv32e40x_ex_stage.sv
+++ b/rtl/cv32e40x_ex_stage.sv
@@ -59,6 +59,8 @@ module cv32e40x_ex_stage import cv32e40x_pkg::*;
   output logic        lsu_ready_o,
   output logic        lsu_valid_o,
   input  logic        lsu_ready_i,
+  input  mpu_status_e lsu_mpustatus_i,        // PMA error detected in LSU
+  input  logic        lsu_misaligned_i,       // LSU is performing first part of a misaligned instruction
 
   // Stage ready/valid
   output logic        ex_ready_o,       // EX stage is ready for new data
@@ -263,8 +265,11 @@ module cv32e40x_ex_stage import cv32e40x_pkg::*;
     begin
       if (ex_valid_o && wb_ready_i) begin
         ex_wb_pipe_o.instr_valid <= 1'b1;
-        // Deassert rf_we in case of illegal csr instruction
-        ex_wb_pipe_o.rf_we       <= csr_illegal_i ? 1'b0 : id_ex_pipe_i.rf_we;
+        // Deassert rf_we in case of illegal csr instruction, PMA error in LSU or
+        // when the first half of a misaligned LSU goes to WB.
+        ex_wb_pipe_o.rf_we       <= (csr_illegal_i              ||
+                                    (lsu_mpustatus_i != MPU_OK) ||
+                                    lsu_misaligned_i)            ? 1'b0 : id_ex_pipe_i.rf_we;
         ex_wb_pipe_o.lsu_en      <= id_ex_pipe_i.lsu_en;
           
         if (id_ex_pipe_i.rf_we) begin
@@ -296,7 +301,7 @@ module cv32e40x_ex_stage import cv32e40x_pkg::*;
         ex_wb_pipe_o.fencei_insn    <= id_ex_pipe_i.fencei_insn;
         ex_wb_pipe_o.mret_insn      <= id_ex_pipe_i.mret_insn;
         ex_wb_pipe_o.dret_insn      <= id_ex_pipe_i.dret_insn;
-        ex_wb_pipe_o.lsu_mpu_status <= MPU_OK; // TODO:OK:low Set to actual MPU status when MPU is implemented on data side.
+        ex_wb_pipe_o.lsu_mpu_status <= lsu_mpustatus_i; // From load_store_unit
         ex_wb_pipe_o.trigger_match  <= id_ex_pipe_i.trigger_match;
       end else if (wb_ready_i) begin
         // we are ready for a new instruction, but there is none available,

--- a/rtl/cv32e40x_ex_stage.sv
+++ b/rtl/cv32e40x_ex_stage.sv
@@ -263,7 +263,7 @@ module cv32e40x_ex_stage import cv32e40x_pkg::*;
     begin
       if (ex_valid_o && wb_ready_i) begin
         ex_wb_pipe_o.instr_valid <= 1'b1;
-        // Deassert rf_we in case of illegal csr instruction, PMA error in LSU or
+        // Deassert rf_we in case of illegal csr instruction or
         // when the first half of a misaligned LSU goes to WB.
         ex_wb_pipe_o.rf_we       <= (csr_illegal_i               ||
                                     lsu_misaligned_i)             ? 1'b0 : id_ex_pipe_i.rf_we;
@@ -290,8 +290,10 @@ module cv32e40x_ex_stage import cv32e40x_pkg::*;
         //          and LSU it not in use
         ex_wb_pipe_o.pc             <= id_ex_pipe_i.pc;
         ex_wb_pipe_o.instr          <= id_ex_pipe_i.instr;
+
         // CSR illegal instruction detected in this stage, OR'ing in the status
         ex_wb_pipe_o.illegal_insn   <= id_ex_pipe_i.illegal_insn || csr_illegal_i;
+
         ex_wb_pipe_o.ebrk_insn      <= id_ex_pipe_i.ebrk_insn;
         ex_wb_pipe_o.wfi_insn       <= id_ex_pipe_i.wfi_insn;
         ex_wb_pipe_o.ecall_insn     <= id_ex_pipe_i.ecall_insn;

--- a/rtl/cv32e40x_ex_stage.sv
+++ b/rtl/cv32e40x_ex_stage.sv
@@ -59,7 +59,6 @@ module cv32e40x_ex_stage import cv32e40x_pkg::*;
   output logic        lsu_ready_o,
   output logic        lsu_valid_o,
   input  logic        lsu_ready_i,
-  input  mpu_status_e lsu_mpu_status_i,        // PMA error detected in LSU
   input  logic        lsu_misaligned_i,       // LSU is performing first part of a misaligned instruction
 
   // Stage ready/valid
@@ -254,7 +253,6 @@ module cv32e40x_ex_stage import cv32e40x_pkg::*;
       ex_wb_pipe_o.mret_insn      <= 1'b0;
       ex_wb_pipe_o.dret_insn      <= 1'b0;
       ex_wb_pipe_o.lsu_en         <= 1'b0;
-      ex_wb_pipe_o.lsu_mpu_status <= MPU_OK;
       ex_wb_pipe_o.csr_en         <= 1'b0;
       ex_wb_pipe_o.csr_op         <= CSR_OP_READ;
       ex_wb_pipe_o.csr_addr       <= 12'h000;
@@ -268,7 +266,6 @@ module cv32e40x_ex_stage import cv32e40x_pkg::*;
         // Deassert rf_we in case of illegal csr instruction, PMA error in LSU or
         // when the first half of a misaligned LSU goes to WB.
         ex_wb_pipe_o.rf_we       <= (csr_illegal_i               ||
-                                    (lsu_mpu_status_i != MPU_OK) ||
                                     lsu_misaligned_i)             ? 1'b0 : id_ex_pipe_i.rf_we;
         ex_wb_pipe_o.lsu_en      <= id_ex_pipe_i.lsu_en;
           
@@ -301,7 +298,6 @@ module cv32e40x_ex_stage import cv32e40x_pkg::*;
         ex_wb_pipe_o.fencei_insn    <= id_ex_pipe_i.fencei_insn;
         ex_wb_pipe_o.mret_insn      <= id_ex_pipe_i.mret_insn;
         ex_wb_pipe_o.dret_insn      <= id_ex_pipe_i.dret_insn;
-        ex_wb_pipe_o.lsu_mpu_status <= lsu_mpu_status_i; // From load_store_unit
         ex_wb_pipe_o.trigger_match  <= id_ex_pipe_i.trigger_match;
       end else if (wb_ready_i) begin
         // we are ready for a new instruction, but there is none available,

--- a/rtl/cv32e40x_if_stage.sv
+++ b/rtl/cv32e40x_if_stage.sv
@@ -192,7 +192,9 @@ module cv32e40x_if_stage import cv32e40x_pkg::*;
      .clk                  ( clk   ),
      .rst_n                ( rst_n ),
      .atomic_access_i      ( 1'b0  ), // No atomic transfers on instruction side
-
+     .misaligned_access_i  ( 1'b0  ), // MPU on instruction side will not issue misaligned access fault
+                                      // Misaligned access to main is allowed, and accesses outside main will result in instruction access fault (which will have priority over misaligned from I/O fault)
+     
      .core_one_txn_pend_n  ( prefetch_one_txn_pend_n ),
      .core_trans_valid_i   ( prefetch_trans_valid    ),
      .core_trans_ready_o   ( prefetch_trans_ready    ),

--- a/rtl/cv32e40x_load_store_unit.sv
+++ b/rtl/cv32e40x_load_store_unit.sv
@@ -413,8 +413,8 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
   assign ready_1_o = (cnt_q == 2'b00) ? !ctrl_fsm_i.halt_wb : resp_valid && !ctrl_fsm_i.halt_wb && ready_1_i;
 
   // LSU second stage is valid when resp_valid (typically data_rvalid_i) is received. For a misaligned
-  // load/store only its second phase is marked as valid (last_q == 1'b1).
-  assign valid_1_o = (cnt_q == 2'b00) ? 1'b0 : last_q && resp_valid && valid_1_i; // todo:AB (cnt_q == 2'b00) should be same as !WB.lsu_en
+  // load/store only its second phase is marked as valid (last_q == 1'b1), except if the first access failed MPU checks, indicated by resp.mpu_status
+  assign valid_1_o = (cnt_q == 2'b00) ? 1'b0 : (last_q || (resp.mpu_status != MPU_OK)) && resp_valid && valid_1_i; // todo:AB (cnt_q == 2'b00) should be same as !WB.lsu_en
 
   // LSU EX stage readyness requires two criteria to be met:
   // 

--- a/rtl/cv32e40x_load_store_unit.sv
+++ b/rtl/cv32e40x_load_store_unit.sv
@@ -51,7 +51,7 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
   output logic [31:0] lsu_addr_1_o,
   output logic        lsu_err_1_o,           
   output logic [31:0] lsu_rdata_1_o,            // LSU read data
-  output mpu_status_e lsu_mpu_status_1_o,       // MPU (PMA) status, response/WB timing. To controller
+  output mpu_status_e lsu_mpu_status_1_o,       // MPU (PMA) status, response/WB timing. To controller and wb_stage
 
   // Handshakes
   input  logic        valid_0_i,        // Handshakes for first LSU stage (EX)
@@ -413,8 +413,8 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
   assign ready_1_o = (cnt_q == 2'b00) ? !ctrl_fsm_i.halt_wb : resp_valid && !ctrl_fsm_i.halt_wb && ready_1_i;
 
   // LSU second stage is valid when resp_valid (typically data_rvalid_i) is received. For a misaligned
-  // load/store only its second phase is marked as valid (last_q == 1'b1), except if the first access failed MPU checks, indicated by resp.mpu_status
-  assign valid_1_o = (cnt_q == 2'b00) ? 1'b0 : (last_q || (resp.mpu_status != MPU_OK)) && resp_valid && valid_1_i; // todo:AB (cnt_q == 2'b00) should be same as !WB.lsu_en
+  // load/store only its second phase is marked as valid (last_q == 1'b1)
+  assign valid_1_o = (cnt_q == 2'b00) ? 1'b0 : last_q && resp_valid && valid_1_i; // todo:AB (cnt_q == 2'b00) should be same as !WB.lsu_en
 
   // LSU EX stage readyness requires two criteria to be met:
   // 

--- a/rtl/cv32e40x_load_store_unit.sv
+++ b/rtl/cv32e40x_load_store_unit.sv
@@ -46,12 +46,12 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
 
   // Stage 0 outputs (EX)
   output logic        lsu_misaligned_0_o,       // Misaligned access was detected (to controller)
-  output mpu_status_e lsu_mpu_status_1_o,       // MPU (PMA) status, response/WB timing. To controller
 
   // Stage 1 outputs (WB)
   output logic [31:0] lsu_addr_1_o,
   output logic        lsu_err_1_o,           
-  output logic [31:0] lsu_rdata_1_o,    // LSU read data
+  output logic [31:0] lsu_rdata_1_o,            // LSU read data
+  output mpu_status_e lsu_mpu_status_1_o,       // MPU (PMA) status, response/WB timing. To controller
 
   // Handshakes
   input  logic        valid_0_i,        // Handshakes for first LSU stage (EX)
@@ -440,7 +440,7 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
 
 // todo:AB lsu_en_gated should maybe be replaced by valid_0_i
 
-  // Export mpu status to EX stage
+  // Export mpu status to WB stage/controller
   assign lsu_mpu_status_1_o = resp.mpu_status;
 
   // Update signals for EX/WB registers (when EX has valid data itself and is ready for next)

--- a/rtl/cv32e40x_load_store_unit.sv
+++ b/rtl/cv32e40x_load_store_unit.sv
@@ -111,6 +111,7 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
   logic [31:0]  wdata;
 
   logic         misaligned_st;          // high if we are currently performing the second part of a misaligned store
+  logic         misaligned_access;
 
   logic [31:0]  rdata_q;
 
@@ -350,6 +351,8 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
 
   assign misaligned_st = id_ex_pipe_i.lsu_misaligned; // todo: rename
 
+  // misaligned_access is high for both transfers of a misaligned transfer
+  assign misaligned_access = misaligned_st || lsu_misaligned_0_o;
 
 
   // check for misaligned accesses that need a second memory access
@@ -537,22 +540,23 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
       .PMA_CFG         (PMA_CFG        ))
   mpu_i
     (
-     .clk                  ( clk             ),
-     .rst_n                ( rst_n           ),
-     .atomic_access_i      ( 1'b0            ), // TODO:OE update to support atomic PMA checks
+     .clk                  ( clk               ),
+     .rst_n                ( rst_n             ),
+     .atomic_access_i      ( 1'b0              ), // TODO:OE update to support atomic PMA checks
+     .misaligned_access_i  ( misaligned_access ),
 
-     .core_one_txn_pend_n  ( cnt_is_one_next ),
-     .core_trans_valid_i   ( trans_valid     ),
-     .core_trans_ready_o   ( trans_ready     ),
-     .core_trans_i         ( trans           ),
-     .core_resp_valid_o    ( resp_valid      ),
-     .core_resp_o          ( resp            ),
+     .core_one_txn_pend_n  ( cnt_is_one_next   ),
+     .core_trans_valid_i   ( trans_valid       ),
+     .core_trans_ready_o   ( trans_ready       ),
+     .core_trans_i         ( trans             ),
+     .core_resp_valid_o    ( resp_valid        ),
+     .core_resp_o          ( resp              ),
 
-     .bus_trans_valid_o    ( bus_trans_valid ),
-     .bus_trans_ready_i    ( bus_trans_ready ),
-     .bus_trans_o          ( bus_trans       ),
-     .bus_resp_valid_i     ( bus_resp_valid  ),
-     .bus_resp_i           ( bus_resp        ));
+     .bus_trans_valid_o    ( bus_trans_valid   ),
+     .bus_trans_ready_i    ( bus_trans_ready   ),
+     .bus_trans_o          ( bus_trans         ),
+     .bus_resp_valid_i     ( bus_resp_valid    ),
+     .bus_resp_i           ( bus_resp          ));
 
   // Extract rdata and err from response struct
   assign resp_rdata = resp.bus_resp.rdata;

--- a/rtl/cv32e40x_load_store_unit.sv
+++ b/rtl/cv32e40x_load_store_unit.sv
@@ -46,6 +46,7 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
 
   // Stage 0 outputs (EX)
   output logic        lsu_misaligned_0_o,       // Misaligned access was detected (to controller)
+  output mpu_status_e lsu_mpustatus_0_o,        // MPU (PMA) status (to ex_stage)
 
   // Stage 1 outputs (WB)
   output logic [31:0] lsu_addr_1_o,
@@ -436,6 +437,8 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
 
 // todo:AB lsu_en_gated should maybe be replaced by valid_0_i
 
+  // Export mpu status to EX stage
+  assign lsu_mpustatus_0_o = resp.mpu_status;
 
   // Update signals for EX/WB registers (when EX has valid data itself and is ready for next)
   assign ctrl_update = ready_0_o && lsu_en_gated;

--- a/rtl/cv32e40x_load_store_unit.sv
+++ b/rtl/cv32e40x_load_store_unit.sv
@@ -46,7 +46,7 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
 
   // Stage 0 outputs (EX)
   output logic        lsu_misaligned_0_o,       // Misaligned access was detected (to controller)
-  output mpu_status_e lsu_mpu_status_0_o,       // MPU (PMA) status (to ex_stage)
+  output mpu_status_e lsu_mpu_status_1_o,       // MPU (PMA) status, response/WB timing. To controller
 
   // Stage 1 outputs (WB)
   output logic [31:0] lsu_addr_1_o,
@@ -349,7 +349,7 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
   // output to register file
   assign lsu_rdata_1_o = (resp_valid == 1'b1) ? rdata_ext : rdata_q;
 
-  assign misaligned_st = id_ex_pipe_i.lsu_misaligned; // todo: rename
+  assign misaligned_st = id_ex_pipe_i.lsu_misaligned; // todo: rename && possibly kill?
 
   // misaligned_access is high for both transfers of a misaligned transfer
   assign misaligned_access = misaligned_st || lsu_misaligned_0_o;
@@ -441,7 +441,7 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
 // todo:AB lsu_en_gated should maybe be replaced by valid_0_i
 
   // Export mpu status to EX stage
-  assign lsu_mpu_status_0_o = resp.mpu_status;
+  assign lsu_mpu_status_1_o = resp.mpu_status;
 
   // Update signals for EX/WB registers (when EX has valid data itself and is ready for next)
   assign ctrl_update = ready_0_o && lsu_en_gated;

--- a/rtl/cv32e40x_load_store_unit.sv
+++ b/rtl/cv32e40x_load_store_unit.sv
@@ -46,7 +46,7 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
 
   // Stage 0 outputs (EX)
   output logic        lsu_misaligned_0_o,       // Misaligned access was detected (to controller)
-  output mpu_status_e lsu_mpustatus_0_o,        // MPU (PMA) status (to ex_stage)
+  output mpu_status_e lsu_mpu_status_0_o,       // MPU (PMA) status (to ex_stage)
 
   // Stage 1 outputs (WB)
   output logic [31:0] lsu_addr_1_o,
@@ -438,7 +438,7 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
 // todo:AB lsu_en_gated should maybe be replaced by valid_0_i
 
   // Export mpu status to EX stage
-  assign lsu_mpustatus_0_o = resp.mpu_status;
+  assign lsu_mpu_status_0_o = resp.mpu_status;
 
   // Update signals for EX/WB registers (when EX has valid data itself and is ready for next)
   assign ctrl_update = ready_0_o && lsu_en_gated;

--- a/rtl/cv32e40x_mpu.sv
+++ b/rtl/cv32e40x_mpu.sv
@@ -35,7 +35,8 @@ module cv32e40x_mpu import cv32e40x_pkg::*;
    input logic  clk,
    input logic  rst_n,
 
-   input logic  atomic_access_i, // Indicate that ongoing access is atomic
+   input logic  atomic_access_i,     // Indicate that ongoing access is atomic
+   input logic  misaligned_access_i, // Indicate that ongoing access is part of a misaligned access
 
    // Interface towards bus interface
    input logic  bus_trans_ready_i,
@@ -174,6 +175,7 @@ module cv32e40x_mpu import cv32e40x_pkg::*;
      .speculative_access_i(speculative_access),
      .atomic_access_i(atomic_access_i),
      .execute_access_i(execute_access),
+     .misaligned_access_i(misaligned_access_i),
      .pma_err_o(pma_err),
      .pma_bufferable_o(bus_trans_bufferable),
      .pma_cacheable_o(bus_trans_cacheable));
@@ -196,4 +198,6 @@ module cv32e40x_mpu import cv32e40x_pkg::*;
     end
   endgenerate
 
+// TODO:OE any way to check that the 2nd access of a failed misalgn will not reach the MPU?
+  
 endmodule

--- a/rtl/cv32e40x_pma.sv
+++ b/rtl/cv32e40x_pma.sv
@@ -33,6 +33,7 @@ module cv32e40x_pma import cv32e40x_pkg::*;
    input logic        speculative_access_i, // Indicate that ongoing access is speculative
    input logic        atomic_access_i,      // Indicate that ongoing access is atomic
    input logic        execute_access_i,     // Indicate that ongoing access is intended for execution
+   input logic        misaligned_access_i,  // Indicate that ongoing access is part of a misaligned access
    output logic       pma_err_o,
    output logic       pma_bufferable_o,
    output logic       pma_cacheable_o
@@ -103,7 +104,11 @@ module cv32e40x_pma import cv32e40x_pkg::*;
     if (execute_access_i && !pma_cfg.main) begin
       pma_err_o   = 1'b1;
     end
-    
+
+    // Misaligned access to I/O memory
+    if (misaligned_access_i && !pma_cfg.main) begin
+      pma_err_o   = 1'b1;
+    end
   end
 
   // Set cacheable and bufferable based on PMA region attributes

--- a/rtl/cv32e40x_wb_stage.sv
+++ b/rtl/cv32e40x_wb_stage.sv
@@ -84,7 +84,8 @@ module cv32e40x_wb_stage import cv32e40x_pkg::*;
   // Note that write back is not suppressed during bus errors (in order to prevent
   // a timing path from the late arriving data_err_i into the register file).
   //
-  // Note that the register file is written twice in case of a misaligned load.
+  // Note that the register file is only written for the last part of a misaligned load.
+  // (rf_we suppressed in ex_stage for the first part)
   //
   // Note that the register file is written multiple times in case waited loads (in
   // order to prevent a timing path from the late arriving data_rvalid_i into the

--- a/rtl/cv32e40x_wb_stage.sv
+++ b/rtl/cv32e40x_wb_stage.sv
@@ -65,7 +65,7 @@ module cv32e40x_wb_stage import cv32e40x_pkg::*;
 );
 
   logic                 instr_valid;
-  logic                 wb_valid;       // Only used by RVFI
+  logic                 wb_valid;
 
   assign instr_valid = ex_wb_pipe_i.instr_valid && !ctrl_fsm_i.kill_wb && !ctrl_fsm_i.halt_wb;
 
@@ -86,7 +86,7 @@ module cv32e40x_wb_stage import cv32e40x_pkg::*;
   // a timing path from the late arriving data_err_i into the register file).
   //
   // Note that the register file is only written for the last part of a misaligned load.
-  // (rf_we suppressed in ex_stage for the first part)
+  // (rf_we suppressed in ex_stage for the first part, lsu aggregates data for second part)
   //
   // Note that the register file is written multiple times in case waited loads (in
   // order to prevent a timing path from the late arriving data_rvalid_i into the
@@ -115,7 +115,7 @@ module cv32e40x_wb_stage import cv32e40x_pkg::*;
 
   // todo: Above hould have similar structure as ex_ready_o
   // todo: Want the following expression, but currently not SEC clean; might just be caused by fact that OBI assumes are not loaded during SEC
-  //  assign wb_ready_o = ctrl_fsThankm_i.kill_wb || (lsu_ready_i && !ctrl_fsm_i.halt_wb);
+  //  assign wb_ready_o = ctrl_fsm_i.kill_wb || (lsu_ready_i && !ctrl_fsm_i.halt_wb);
 
   // wb_valid
   //

--- a/rtl/cv32e40x_wb_stage.sv
+++ b/rtl/cv32e40x_wb_stage.sv
@@ -46,6 +46,7 @@ module cv32e40x_wb_stage import cv32e40x_pkg::*;
 
   // LSU
   input  logic [31:0]   lsu_rdata_i,
+  input  mpu_status_e   lsu_mpu_status_i,
 
   // Register file interface
   output logic          rf_we_wb_o,     // Register file write enable
@@ -90,8 +91,11 @@ module cv32e40x_wb_stage import cv32e40x_pkg::*;
   // Note that the register file is written multiple times in case waited loads (in
   // order to prevent a timing path from the late arriving data_rvalid_i into the
   // register file.
+  //
+  // In case of MPU/PMA error, the register file should not be written.
+  // rf_we_wb_o is deasserted if lsu_mpu_status is not equal to MPU_OK
 
-  assign rf_we_wb_o     = ex_wb_pipe_i.rf_we && instr_valid ; // TODO:OK:low deassert in case of MPU error (already do this in EX stage)
+  assign rf_we_wb_o     = ex_wb_pipe_i.rf_we && (lsu_mpu_status_i == MPU_OK) && instr_valid;
   assign rf_waddr_wb_o  = ex_wb_pipe_i.rf_waddr;
   assign rf_wdata_wb_o  = ex_wb_pipe_i.lsu_en ? lsu_rdata_i : ex_wb_pipe_i.rf_wdata;
 

--- a/rtl/include/cv32e40x_pkg.sv
+++ b/rtl/include/cv32e40x_pkg.sv
@@ -988,7 +988,6 @@ typedef struct packed {
 
   // LSU
   logic         lsu_en;
-  mpu_status_e  lsu_mpu_status; // MPU timing on gnt, ready in EX
 
   // Trigger match on insn
   logic         trigger_match;

--- a/rtl/include/cv32e40x_pkg.sv
+++ b/rtl/include/cv32e40x_pkg.sv
@@ -779,9 +779,8 @@ parameter EXC_CAUSE_ILLEGAL_INSN    = 5'h02;
 parameter EXC_CAUSE_BREAKPOINT      = 5'h03;
 parameter EXC_CAUSE_LOAD_FAULT      = 5'h05;
 parameter EXC_CAUSE_STORE_FAULT     = 5'h07;
-parameter EXC_CAUSE_ECALL_UMODE     = 5'h08;
 parameter EXC_CAUSE_ECALL_MMODE     = 5'h0B;
-parameter EXC_CAUSE_INSTR_BUS_FAULT = 5'h18;
+parameter EXC_CAUSE_INSTR_BUS_FAULT = 5'h18; // todo: 0x30
 
 // Interrupt mask
 parameter IRQ_MASK = 32'hFFFF0888;

--- a/sva/cv32e40x_ex_stage_sva.sv
+++ b/sva/cv32e40x_ex_stage_sva.sv
@@ -31,8 +31,13 @@ module cv32e40x_ex_stage_sva
   input logic           rst_n,
 
   input logic           ex_ready_o,
-  input logic           ex_valid_o,  
-  input ctrl_fsm_t      ctrl_fsm_i
+  input logic           ex_valid_o,
+  input logic           wb_ready_i,
+  input ctrl_fsm_t      ctrl_fsm_i,
+
+  input id_ex_pipe_t    id_ex_pipe_i,
+  input ex_wb_pipe_t    ex_wb_pipe_o,
+  input logic           lsu_misaligned_i
 );
 /* todo:medium uncomment and fix
   // Halt implies not ready and not valid
@@ -56,4 +61,10 @@ module cv32e40x_ex_stage_sva
                       |-> (!ctrl_fsm_i.halt_ex))
       else `uvm_error("ex_stage", "Kill and halt should not both be asserted")
 */
+
+// First access of misaligned LSU should have rf_we deasserted
+a_misaligned_rf_we:
+  assert property (@(posedge clk) disable iff (!rst_n)
+                    (ex_valid_o && wb_ready_i && id_ex_pipe_i.lsu_en && lsu_misaligned_i)
+                    |=> !ex_wb_pipe_o.rf_we);
 endmodule // cv32e40x_ex_stage_sva

--- a/sva/cv32e40x_mpu_sva.sv
+++ b/sva/cv32e40x_mpu_sva.sv
@@ -33,6 +33,7 @@ module cv32e40x_mpu_sva import cv32e40x_pkg::*; import uvm_pkg::*;
    
    input logic        speculative_access,
    input logic        atomic_access_i,
+   input logic        misaligned_access_i,
    input logic        execute_access,
    input logic        bus_trans_bufferable,
    input logic        bus_trans_cacheable,
@@ -170,9 +171,9 @@ module cv32e40x_mpu_sva import cv32e40x_pkg::*; import uvm_pkg::*;
       pma_expected_cfg = is_pma_matched ? PMA_CFG[pma_lowest_match] : PMA_R_DEFAULT;
     end
   end
-  assign pma_expected_err =
-    ((execute_access || speculative_access) && !pma_expected_cfg.main)
-    || (atomic_access_i && !pma_expected_cfg.atomic);
+  assign pma_expected_err = ((execute_access || speculative_access) && !pma_expected_cfg.main) ||
+                            (misaligned_access_i && !pma_expected_cfg.main)                    ||
+                            (atomic_access_i && !pma_expected_cfg.atomic);
   a_pma_expect_cfg :
     assert property (@(posedge clk) disable iff (!rst_n) pma_cfg == pma_expected_cfg)
       else `uvm_error("mpu", "RTL cfg don't match SVA expectations")

--- a/sva/cv32e40x_mpu_sva.sv
+++ b/sva/cv32e40x_mpu_sva.sv
@@ -182,9 +182,9 @@ module cv32e40x_mpu_sva import cv32e40x_pkg::*; import uvm_pkg::*;
   a_pma_expect_cacheable :
     assert property (@(posedge clk) disable iff (!rst_n) bus_trans_cacheable == pma_expected_cfg.cacheable)
       else `uvm_error("mpu", "expected different cacheable flag")
-//  a_pma_expect_err :
-//    assert property (@(posedge clk) disable iff (!rst_n) pma_err == pma_expected_err)
-//      else `uvm_error("mpu", "expected different err flag")
+  a_pma_expect_err :
+    assert property (@(posedge clk) disable iff (!rst_n) pma_err == pma_expected_err)
+      else `uvm_error("mpu", "expected different err flag")
 
   // Bufferable
   logic obibuf_expected;

--- a/sva/cv32e40x_mpu_sva.sv
+++ b/sva/cv32e40x_mpu_sva.sv
@@ -182,9 +182,9 @@ module cv32e40x_mpu_sva import cv32e40x_pkg::*; import uvm_pkg::*;
   a_pma_expect_cacheable :
     assert property (@(posedge clk) disable iff (!rst_n) bus_trans_cacheable == pma_expected_cfg.cacheable)
       else `uvm_error("mpu", "expected different cacheable flag")
-  a_pma_expect_err :
-    assert property (@(posedge clk) disable iff (!rst_n) pma_err == pma_expected_err)
-      else `uvm_error("mpu", "expected different err flag")
+//  a_pma_expect_err :
+//    assert property (@(posedge clk) disable iff (!rst_n) pma_err == pma_expected_err)
+//      else `uvm_error("mpu", "expected different err flag")
 
   // Bufferable
   logic obibuf_expected;


### PR DESCRIPTION
PMA/MPU work by silabs-oivind, controller and plumbing by silabs-oysteink.

- Implements PMA check for misaligned load/store to IO regions
- Implements support for LSU PMA exceptions.
- Suppresses ex_wb_pipe.rf_we for first half of misaligned LSU instructions (only second half will write to RF)
- Suppresses WB stage rf_we in case of PMA errors.
