### PR TITLE
Misaligned load/store handled inside LSU

### DIFF
--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -306,7 +306,7 @@ bind cv32e40x_sleep_unit:
          .lsu_en_wb_i              ( core_i.wb_stage_i.ex_wb_pipe_i.lsu_en                                ),
          .lsu_addr_ex_i            ( core_i.load_store_unit_i.trans.addr                                  ), // todo:low should really use further downstream signals, ideally OBI
          .lsu_wdata_ex_i           ( core_i.load_store_unit_i.trans.wdata                                 ), // todo:low should really use further downstream signals, ideally OBI
-         .lsu_misaligned_ex_i      ( core_i.load_store_unit_i.id_ex_pipe_i.lsu_misaligned                 ),
+         .lsu_misaligned_ex_i      ( 1'b0/*core_i.load_store_unit_i.id_ex_pipe_i.lsu_misaligned */        ), // todo:ok: Temporarily tied off
 
          .rd_we_wb_i               ( core_i.wb_stage_i.rf_we_wb_o                                         ),
          .rd_addr_wb_i             ( core_i.wb_stage_i.rf_waddr_wb_o                                      ),

--- a/rtl/cv32e40x_controller_bypass.sv
+++ b/rtl/cv32e40x_controller_bypass.sv
@@ -220,9 +220,6 @@ module cv32e40x_controller_bypass import cv32e40x_pkg::*;
     end
   end
 
-  // stall because of misaligned data access
-  assign ctrl_byp_o.misaligned_stall = lsu_misaligned_ex_i;
-
   // Forwarding control unit
   always_comb
   begin
@@ -259,12 +256,6 @@ module cv32e40x_controller_bypass import cv32e40x_pkg::*;
       end
     end
 
-    // for misaligned memory accesses
-    if (lsu_misaligned_ex_i)
-    begin
-      ctrl_byp_o.operand_a_fw_mux_sel = SEL_FW_EX;
-      ctrl_byp_o.operand_b_fw_mux_sel = SEL_REGFILE;
-    end
   end
 
 endmodule // cv32e40x_controller_bypass

--- a/rtl/cv32e40x_controller_fsm.sv
+++ b/rtl/cv32e40x_controller_fsm.sv
@@ -223,7 +223,6 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
   // LSU will now set valid_1_o only for second part of misaligned instructions.
   // We can always allow single step when checking for wb_valid_i in 'pending_single_step'
   // - no other instructions should be in the pipeline.
-  // todo:ok: Remove 'single_step_allowed'
   assign single_step_allowed = 1'b1;
                              
   // Single step are mutually exclusive from any other reason to enter debug

--- a/rtl/cv32e40x_controller_fsm.sv
+++ b/rtl/cv32e40x_controller_fsm.sv
@@ -262,10 +262,7 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
   // LSU instructions which were suppressed due to previous exceptions or trigger match
   // will be interruptable as they were convered to NOP in ID stage.
   // TODO:OK:low May allow interuption of Zce to idempotent memories
-  // TODO:low Should be able remove lsu_misaligned as well, but is not SEC clean since the code does not check for id_ex_pipe.instr_valid. 
-  // todo: if lsu_misaligned remain in below expression, then it should be qualified with id_ex_pipe_i.instr_valid
-  assign interrupt_allowed = ((!(ex_wb_pipe_i.lsu_en && ex_wb_pipe_i.instr_valid) && !obi_data_req_q &&
-                              !id_ex_pipe_i.lsu_misaligned)) && !debug_mode_q;
+  assign interrupt_allowed = !(ex_wb_pipe_i.lsu_en && ex_wb_pipe_i.instr_valid) && !obi_data_req_q && !debug_mode_q;
                                
   // Performance counter events
   assign ctrl_fsm_o.mhpmevent.minstret = wb_valid_i && !exception_in_wb && !trigger_match_in_wb;

--- a/rtl/cv32e40x_id_stage.sv
+++ b/rtl/cv32e40x_id_stage.sv
@@ -464,7 +464,6 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
       id_ex_pipe_o.lsu_type               <= 2'b0;
       id_ex_pipe_o.lsu_sign_ext           <= 1'b0;
       id_ex_pipe_o.lsu_reg_offset         <= 2'b0;
-      id_ex_pipe_o.lsu_misaligned         <= 1'b0;
       id_ex_pipe_o.lsu_atop               <= 5'b0;
       id_ex_pipe_o.lsu_prepost_useincr    <= 1'b1;
 
@@ -489,96 +488,77 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
 
       if (id_valid && ex_ready_i) begin
         id_ex_pipe_o.instr_valid  <= 1'b1;
-
-        if (ctrl_byp_i.misaligned_stall) begin
-          // misaligned data access case
-          // if we are using post increments, then we have to use the
-          // original value of the register for the second memory access
-          // => keep it stalled
-          if (id_ex_pipe_o.lsu_prepost_useincr)
-          begin
-            id_ex_pipe_o.alu_operand_a        <= operand_a_fw;
-          end
-
-          id_ex_pipe_o.alu_operand_b          <= 32'h4;
-          id_ex_pipe_o.lsu_prepost_useincr    <= 1'b1;
-          id_ex_pipe_o.lsu_misaligned         <= 1'b1;
-        end else begin // !ctrl_byp_i.misaligned_stall
-          id_ex_pipe_o.alu_en                 <= alu_en;
-          if (alu_en)
-          begin
-            id_ex_pipe_o.operand_c            <= operand_c;
-          end
-
-          if (alu_en || div_en || csr_en) begin // todo: the addition of csr_en here is not SEC clean. However, csr_en should have been implied alu_en. Eventually this needs to become (alu_en || div_en) again.
-            id_ex_pipe_o.alu_operator         <= alu_operator;
-            id_ex_pipe_o.alu_operand_a        <= operand_a;
-            id_ex_pipe_o.alu_operand_b        <= operand_b;
-          end
-
-          id_ex_pipe_o.div_en                 <= div_en;
-          if (div_en) begin
-            id_ex_pipe_o.div_operator         <= div_operator; // todo: consider letting div/rem use mul_operands
-          end
-          
-          id_ex_pipe_o.mul_en                 <= mul_en;
-          if (mul_en) begin
-            id_ex_pipe_o.mul_operator         <= mul_operator;
-            id_ex_pipe_o.mul_signed_mode      <= mul_signed_mode;
-            id_ex_pipe_o.mul_operand_a        <= operand_a;
-            id_ex_pipe_o.mul_operand_b        <= operand_b;
-          end
-
-          id_ex_pipe_o.rf_we                  <= rf_we;
-          if (rf_we) begin
-            id_ex_pipe_o.rf_waddr             <= rf_waddr_o;
-          end
-
-          id_ex_pipe_o.csr_en                 <= csr_en;
-          id_ex_pipe_o.csr_op                 <= csr_op;
-
-          id_ex_pipe_o.lsu_en                 <= lsu_en;
-          if (lsu_en) begin
-            id_ex_pipe_o.lsu_we               <= lsu_we;
-            id_ex_pipe_o.lsu_type             <= lsu_type;
-            id_ex_pipe_o.lsu_sign_ext         <= lsu_sign_ext;
-            id_ex_pipe_o.lsu_reg_offset       <= lsu_reg_offset;
-            id_ex_pipe_o.lsu_atop             <= lsu_atop;
-            id_ex_pipe_o.lsu_prepost_useincr  <= lsu_prepost_useincr;
-          end
-
-          // Only applicable when misalignes_stall_i == 1'b1 (handled above).
-          // For all other cases it will be 1'b0
-          id_ex_pipe_o.lsu_misaligned         <= 1'b0;
-
-          id_ex_pipe_o.branch_in_ex           <= ctrl_transfer_insn_o == BRANCH_COND;
-
-          // Propagate signals needed for exception handling in WB
-          // TODO:OK:low Clock gating of pc if no existing exceptions
-          //          and LSU it not in use
-          id_ex_pipe_o.pc                     <= if_id_pipe_i.pc;
-
-          if (if_id_pipe_i.is_compressed) begin
-            // Overwrite instruction word in case of compressed instruction
-            id_ex_pipe_o.instr.bus_resp.rdata <= {16'h0, if_id_pipe_i.compressed_instr};
-            id_ex_pipe_o.instr.bus_resp.err   <= if_id_pipe_i.instr.bus_resp.err;
-            id_ex_pipe_o.instr.mpu_status     <= if_id_pipe_i.instr.mpu_status;
-          end
-          else begin
-            id_ex_pipe_o.instr                <= if_id_pipe_i.instr;
-          end
-
-          // Exceptions and special instructions
-          id_ex_pipe_o.illegal_insn           <= illegal_insn;
-          id_ex_pipe_o.ebrk_insn              <= ebrk_insn;
-          id_ex_pipe_o.wfi_insn               <= wfi_insn;
-          id_ex_pipe_o.ecall_insn             <= ecall_insn;
-          id_ex_pipe_o.fencei_insn            <= fencei_insn;
-          id_ex_pipe_o.mret_insn              <= mret_insn;
-          id_ex_pipe_o.dret_insn              <= dret_insn;
-
-          id_ex_pipe_o.trigger_match          <= debug_trigger_match_id_i;
+        
+        id_ex_pipe_o.alu_en                 <= alu_en;
+        if (alu_en)
+        begin
+          id_ex_pipe_o.operand_c            <= operand_c;
         end
+
+        if (alu_en || div_en || csr_en) begin // todo: the addition of csr_en here is not SEC clean. However, csr_en should have been implied alu_en. Eventually this needs to become (alu_en || div_en) again.
+          id_ex_pipe_o.alu_operator         <= alu_operator;
+          id_ex_pipe_o.alu_operand_a        <= operand_a;
+          id_ex_pipe_o.alu_operand_b        <= operand_b;
+        end
+
+        id_ex_pipe_o.div_en                 <= div_en;
+        if (div_en) begin
+          id_ex_pipe_o.div_operator         <= div_operator; // todo: consider letting div/rem use mul_operands
+        end
+        
+        id_ex_pipe_o.mul_en                 <= mul_en;
+        if (mul_en) begin
+          id_ex_pipe_o.mul_operator         <= mul_operator;
+          id_ex_pipe_o.mul_signed_mode      <= mul_signed_mode;
+          id_ex_pipe_o.mul_operand_a        <= operand_a;
+          id_ex_pipe_o.mul_operand_b        <= operand_b;
+        end
+
+        id_ex_pipe_o.rf_we                  <= rf_we;
+        if (rf_we) begin
+          id_ex_pipe_o.rf_waddr             <= rf_waddr_o;
+        end
+
+        id_ex_pipe_o.csr_en                 <= csr_en;
+        id_ex_pipe_o.csr_op                 <= csr_op;
+
+        id_ex_pipe_o.lsu_en                 <= lsu_en;
+        if (lsu_en) begin
+          id_ex_pipe_o.lsu_we               <= lsu_we;
+          id_ex_pipe_o.lsu_type             <= lsu_type;
+          id_ex_pipe_o.lsu_sign_ext         <= lsu_sign_ext;
+          id_ex_pipe_o.lsu_reg_offset       <= lsu_reg_offset;
+          id_ex_pipe_o.lsu_atop             <= lsu_atop;
+          id_ex_pipe_o.lsu_prepost_useincr  <= lsu_prepost_useincr;
+        end
+
+        id_ex_pipe_o.branch_in_ex           <= ctrl_transfer_insn_o == BRANCH_COND;
+
+        // Propagate signals needed for exception handling in WB
+        // TODO:OK:low Clock gating of pc if no existing exceptions
+        //          and LSU it not in use
+        id_ex_pipe_o.pc                     <= if_id_pipe_i.pc;
+
+        if (if_id_pipe_i.is_compressed) begin
+          // Overwrite instruction word in case of compressed instruction
+          id_ex_pipe_o.instr.bus_resp.rdata <= {16'h0, if_id_pipe_i.compressed_instr};
+          id_ex_pipe_o.instr.bus_resp.err   <= if_id_pipe_i.instr.bus_resp.err;
+          id_ex_pipe_o.instr.mpu_status     <= if_id_pipe_i.instr.mpu_status;
+        end
+        else begin
+          id_ex_pipe_o.instr                <= if_id_pipe_i.instr;
+        end
+
+        // Exceptions and special instructions
+        id_ex_pipe_o.illegal_insn           <= illegal_insn;
+        id_ex_pipe_o.ebrk_insn              <= ebrk_insn;
+        id_ex_pipe_o.wfi_insn               <= wfi_insn;
+        id_ex_pipe_o.ecall_insn             <= ecall_insn;
+        id_ex_pipe_o.fencei_insn            <= fencei_insn;
+        id_ex_pipe_o.mret_insn              <= mret_insn;
+        id_ex_pipe_o.dret_insn              <= dret_insn;
+
+        id_ex_pipe_o.trigger_match          <= debug_trigger_match_id_i;
       end else if (ex_ready_i) begin
         id_ex_pipe_o.instr_valid            <= 1'b0;
       end
@@ -589,7 +569,7 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
   assign csr_op_o = csr_op;
 
   // stall control for multicyle ID instructions (currently only misaligned LSU)
-  assign multi_cycle_id_stall = ctrl_byp_i.misaligned_stall;
+  assign multi_cycle_id_stall = 1'b0;//todo:ok Zce push/pop will use this
 
   // Stage ready/valid
   //
@@ -603,9 +583,12 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
   // itself is only in ID for one cycle.
 
   assign id_ready_o = ctrl_fsm_i.kill_id || (!multi_cycle_id_stall && ex_ready_i && !ctrl_fsm_i.halt_id);
-  assign id_valid = instr_valid || multi_cycle_id_stall;
+  //assign id_valid = instr_valid || multi_cycle_id_stall;
 
   // todo:AB would want to use the following expression, but this is not SEC clean; need to investigate
-  // assign id_valid = instr_valid || (multi_cycle_id_stall && !ctrl_fsm_i.kill_id && !ctrl_fsm_i.halt_id);
+  // misaligned LSU in EX causes multi_cycle_id_stall. id_valid is required to assert to update
+  // id_ex_pipe for the second half. At the same time, we may be halted due to load_stall or jr_stall.
+  // In the case of halt, it would deassert id_valid and not cause updates for the second half.
+  assign id_valid = instr_valid || (multi_cycle_id_stall && !ctrl_fsm_i.kill_id && !ctrl_fsm_i.halt_id);
 
 endmodule // cv32e40x_id_stage

--- a/rtl/cv32e40x_load_store_unit.sv
+++ b/rtl/cv32e40x_load_store_unit.sv
@@ -347,7 +347,9 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
   end
 
   // output to register file
-  assign lsu_rdata_1_o = (resp_valid == 1'b1) ? rdata_ext : rdata_q;
+  // Always rdata_ext regardless of aligned/misaligned
+  // Output will be valid (valid_1_o) only for the last phase of misaligned.
+  assign lsu_rdata_1_o = rdata_ext;
 
   assign misaligned_st = id_ex_pipe_i.lsu_misaligned; // todo: rename && possibly kill?
 

--- a/rtl/include/cv32e40x_pkg.sv
+++ b/rtl/include/cv32e40x_pkg.sv
@@ -951,7 +951,6 @@ typedef struct packed {
   logic [1:0]   lsu_type;
   logic         lsu_sign_ext;
   logic [1:0]   lsu_reg_offset;
-  logic         lsu_misaligned;
   logic [5:0]   lsu_atop;
   logic         lsu_prepost_useincr;
 
@@ -1024,7 +1023,6 @@ typedef struct packed {
   op_fw_mux_e  operand_a_fw_mux_sel;  // Operand A forward mux sel
   op_fw_mux_e  operand_b_fw_mux_sel;  // Operand B forward mux sel
   jalr_fw_mux_e jalr_fw_mux_sel;      // Jump target forward mux sel
-  logic        misaligned_stall;      // Stall due to misaligned load/store
   logic        jr_stall;              // Stall due to JR hazard (JR used result from EX or LSU result in WB)
   logic        load_stall;            // Stall due to load operation
   logic        csr_stall;


### PR DESCRIPTION
Previously, the ID stage would update the id_ex_pipe for the second phase of a misaligned load/store while ID stage itself actually contained the next instruction. Now the load store unit does this itself. The ALU is no longer used for address calculation, and the alu_en may be set to 0 in a later change.

PR is SEC clean with one exception (see comments to diff).