### PR TITLE
Halting CSR writes in WB

### DIFF
--- a/rtl/cv32e40x_cs_registers.sv
+++ b/rtl/cv32e40x_cs_registers.sv
@@ -178,7 +178,7 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
   logic illegal_csr_write; // Current CSR cannot be written
 
   // Local instr_valid for write portion (WB)
-  assign instr_valid = ex_wb_pipe_i.instr_valid && !ctrl_fsm_i.kill_wb;// && !ctrl_fsm_i.halt_wb; todo:ok: Not SEC equivalent
+  assign instr_valid = ex_wb_pipe_i.instr_valid && !ctrl_fsm_i.kill_wb && !ctrl_fsm_i.halt_wb;
 
   // CSR access. Read in EX, write in WB
   // Setting csr_raddr to zero in case of unused csr to save power (alu_operand_b toggles a lot)


### PR DESCRIPTION
CSR instructions were not affected by halt_wb. This could lead to CSR writes not being killed at debug entry.
Fixes issues #197 and #198.

Not SEC clean.

If no external debug is assumed, this change is SEC clean.

WB is halted for two scenarios:

1. Debug entry (external, trigger, ebreak). All stages are halted for one cycle before we kill all stages and enter debug.
2. While in sleep mode. In this case, there is no instruction in WB, since we insert a bubble after each WFI instruction to guarantee an interruptible bubble in WB

Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>