### PR TITLE
Exception code was five bits, but some codes needs six

### DIFF
--- a/docs/user_manual/source/control_status_registers.rst
+++ b/docs/user_manual/source/control_status_registers.rst
@@ -605,12 +605,12 @@ Reset Value: 0x0000_0000
 +=============+===========+==================================================================================+
 | 31          |   RW      | **Interrupt:** This bit is set when the exception was triggered by an interrupt. |
 +-------------+-----------+----------------------------------------------------------------------------------+
-| 30:5        |   RO (0)  | Always 0                                                                         |
+| 30:6        |   RO (0)  | Always 0                                                                         |
 +-------------+-----------+----------------------------------------------------------------------------------+
-| 4:0         |   RW      | **Exception Code**   (See note below)                                            |
+| 5:0         |   RW      | **Exception Code**   (See note below)                                            |
 +-------------+-----------+----------------------------------------------------------------------------------+
 
-**NOTE**: software accesses to `mcause[4:0]` must be sensitive to the WLRL field specification of this CSR.  For example,
+**NOTE**: software accesses to `mcause[5:0]` must be sensitive to the WLRL field specification of this CSR.  For example,
 when `mcause[31]` is set, writing 0x1 to `mcause[1]` (Supervisor software interrupt) will result in UNDEFINED behavior.
 
 

--- a/rtl/cv32e40x_controller_fsm.sv
+++ b/rtl/cv32e40x_controller_fsm.sv
@@ -362,7 +362,7 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
     ctrl_fsm_o.csr_save_ex         = 1'b0;
     ctrl_fsm_o.csr_save_wb         = 1'b0;
     ctrl_fsm_o.csr_save_cause      = 1'b0;
-    ctrl_fsm_o.csr_cause           = 7'h0;
+    ctrl_fsm_o.csr_cause           = 32'h0;
 
     ctrl_fsm_o.exc_pc_mux          = EXC_PC_IRQ;
     exc_cause                      = 5'b0;
@@ -420,7 +420,8 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
           ctrl_fsm_o.irq_id  = irq_id_ctrl_i;
 
           ctrl_fsm_o.csr_save_cause  = 1'b1;
-          ctrl_fsm_o.csr_cause       = {2'b10,irq_id_ctrl_i};
+          ctrl_fsm_o.csr_cause.interrupt = 1'b1;
+          ctrl_fsm_o.csr_cause.exception_code = {1'b0, irq_id_ctrl_i};
 
           // Save pc from oldest valid instruction
           if (ex_wb_pipe_i.instr_valid) begin
@@ -457,7 +458,7 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
             // Save CSR from WB
             ctrl_fsm_o.csr_save_wb     = 1'b1;
             ctrl_fsm_o.csr_save_cause  = !debug_mode_q; // Do not update CSRs if in debug mode
-            ctrl_fsm_o.csr_cause       = {1'b0, exception_cause_wb};
+            ctrl_fsm_o.csr_cause.exception_code = exception_cause_wb;
           // Special insn
           end else if (wfi_in_wb) begin
             // Not halting EX/WB to allow insn (interruptible bubble) in EX to pass to WB before sleeping

--- a/rtl/cv32e40x_controller_fsm.sv
+++ b/rtl/cv32e40x_controller_fsm.sv
@@ -121,7 +121,7 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
   
   // Events in WB
   logic exception_in_wb;
-  logic [4:0] exception_cause_wb;
+  logic [5:0] exception_cause_wb;
   logic wfi_in_wb;
   logic fencei_in_wb;
   logic mret_in_wb;
@@ -192,7 +192,7 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
                               ex_wb_pipe_i.ebrk_insn                        ? EXC_CAUSE_BREAKPOINT      :
                               (lsu_mpu_status_wb_i == MPU_WR_FAULT)         ? EXC_CAUSE_STORE_FAULT     :
                               (lsu_mpu_status_wb_i == MPU_RE_FAULT)         ? EXC_CAUSE_LOAD_FAULT      :
-                              'h0; // todo:ok: could default to EXC_CAUSE_LOAD_FAULT instead
+                              6'h0; // todo:ok: could default to EXC_CAUSE_LOAD_FAULT instead
 
   // wfi in wb
   assign wfi_in_wb = ex_wb_pipe_i.wfi_insn && ex_wb_pipe_i.instr_valid;
@@ -362,7 +362,7 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
     ctrl_fsm_o.csr_save_ex         = 1'b0;
     ctrl_fsm_o.csr_save_wb         = 1'b0;
     ctrl_fsm_o.csr_save_cause      = 1'b0;
-    ctrl_fsm_o.csr_cause           = '0;
+    ctrl_fsm_o.csr_cause           = 7'h0;
 
     ctrl_fsm_o.exc_pc_mux          = EXC_PC_IRQ;
     exc_cause                      = 5'b0;
@@ -420,7 +420,7 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
           ctrl_fsm_o.irq_id  = irq_id_ctrl_i;
 
           ctrl_fsm_o.csr_save_cause  = 1'b1;
-          ctrl_fsm_o.csr_cause       = {1'b1,irq_id_ctrl_i};
+          ctrl_fsm_o.csr_cause       = {2'b10,irq_id_ctrl_i};
 
           // Save pc from oldest valid instruction
           if (ex_wb_pipe_i.instr_valid) begin

--- a/rtl/cv32e40x_cs_registers.sv
+++ b/rtl/cv32e40x_cs_registers.sv
@@ -389,7 +389,7 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
                               default: 'b0
                             };
     mstatus_we               = 1'b0;
-    mcause_n                 = {csr_wdata_int[31], 26'd0, csr_wdata_int[4:0]};
+    mcause_n                 = {csr_wdata_int[31], 25'd0, csr_wdata_int[5:0]};
     mcause_we                = 1'b0;
     exception_pc             = if_id_pipe_i.pc;
     priv_lvl_n               = priv_lvl_q;
@@ -486,7 +486,7 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
             mepc_n = exception_pc;
             mepc_we = 1'b1;
 
-            mcause_n       = {ctrl_fsm_i.csr_cause[5], 26'd0, ctrl_fsm_i.csr_cause[4:0]};
+            mcause_n       = {ctrl_fsm_i.csr_cause[6], 25'd0, ctrl_fsm_i.csr_cause[5:0]};
             mcause_we = 1'b1;
         end
       end //ctrl_fsm_i.csr_save_cause

--- a/rtl/cv32e40x_cs_registers.sv
+++ b/rtl/cv32e40x_cs_registers.sv
@@ -389,7 +389,12 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
                               default: 'b0
                             };
     mstatus_we               = 1'b0;
-    mcause_n                 = {csr_wdata_int[31], 25'd0, csr_wdata_int[5:0]};
+
+    mcause_n                 = '{
+                                  interrupt:      csr_wdata_int[31],
+                                  exception_code: csr_wdata_int[5:0],
+                                  default: 'b0
+                                };
     mcause_we                = 1'b0;
     exception_pc             = if_id_pipe_i.pc;
     priv_lvl_n               = priv_lvl_q;
@@ -486,7 +491,7 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
             mepc_n = exception_pc;
             mepc_we = 1'b1;
 
-            mcause_n       = {ctrl_fsm_i.csr_cause[6], 25'd0, ctrl_fsm_i.csr_cause[5:0]};
+            mcause_n       = ctrl_fsm_i.csr_cause;
             mcause_we = 1'b1;
         end
       end //ctrl_fsm_i.csr_save_cause

--- a/rtl/include/cv32e40x_pkg.sv
+++ b/rtl/include/cv32e40x_pkg.sv
@@ -513,8 +513,8 @@ typedef struct packed{
 
 typedef struct packed {
   logic           interrupt;
-  logic [30:5]    zero0;
-  logic [4:0]     exception_code;
+  logic [30:6]    zero0;
+  logic [5:0]     exception_code;
 } Mcause_t;
 
 typedef struct packed {
@@ -774,13 +774,13 @@ typedef enum logic[1:0] {
 } exc_pc_mux_e;
 
 // Exception Cause
-parameter EXC_CAUSE_INSTR_FAULT     = 5'h01;
-parameter EXC_CAUSE_ILLEGAL_INSN    = 5'h02;
-parameter EXC_CAUSE_BREAKPOINT      = 5'h03;
-parameter EXC_CAUSE_LOAD_FAULT      = 5'h05;
-parameter EXC_CAUSE_STORE_FAULT     = 5'h07;
-parameter EXC_CAUSE_ECALL_MMODE     = 5'h0B;
-parameter EXC_CAUSE_INSTR_BUS_FAULT = 5'h30;
+parameter EXC_CAUSE_INSTR_FAULT     = 6'h01;
+parameter EXC_CAUSE_ILLEGAL_INSN    = 6'h02;
+parameter EXC_CAUSE_BREAKPOINT      = 6'h03;
+parameter EXC_CAUSE_LOAD_FAULT      = 6'h05;
+parameter EXC_CAUSE_STORE_FAULT     = 6'h07;
+parameter EXC_CAUSE_ECALL_MMODE     = 6'h0B;
+parameter EXC_CAUSE_INSTR_BUS_FAULT = 6'h30;
 
 // Interrupt mask
 parameter IRQ_MASK = 32'hFFFF0888;
@@ -1065,7 +1065,7 @@ typedef struct packed {
   logic        csr_save_id;         // Save PC from ID stage
   logic        csr_save_ex;         // Save PC from EX stage (currently unused)
   logic        csr_save_wb;         // Save PC from WB stage
-  logic [5:0]  csr_cause;           // CSR cause (saves to mcause CSR)
+  logic [6:0]  csr_cause;           // CSR cause (saves to mcause CSR)
   logic        csr_restore_mret; // Restore CSR due to mret
   logic        csr_restore_dret; // Restore CSR due to dret
   logic        csr_save_cause;      // Update CSRs

--- a/rtl/include/cv32e40x_pkg.sv
+++ b/rtl/include/cv32e40x_pkg.sv
@@ -1065,7 +1065,7 @@ typedef struct packed {
   logic        csr_save_id;         // Save PC from ID stage
   logic        csr_save_ex;         // Save PC from EX stage (currently unused)
   logic        csr_save_wb;         // Save PC from WB stage
-  logic [6:0]  csr_cause;           // CSR cause (saves to mcause CSR)
+  Mcause_t     csr_cause;           // CSR cause (saves to mcause CSR)
   logic        csr_restore_mret; // Restore CSR due to mret
   logic        csr_restore_dret; // Restore CSR due to dret
   logic        csr_save_cause;      // Update CSRs

--- a/sva/cv32e40x_core_sva.sv
+++ b/sva/cv32e40x_core_sva.sv
@@ -50,7 +50,7 @@ module cv32e40x_core_sva
    // probed cs_registers signals
   input logic [31:0] cs_registers_mie_q,
   input logic [31:0] cs_registers_mepc_n,
-  input logic [5:0]  cs_registers_csr_cause_i,
+  input logic [6:0]  cs_registers_csr_cause_i,
   input              Mcause_t cs_registers_mcause_q,
   input              Status_t cs_registers_mstatus_q);
 


### PR DESCRIPTION
SEC clean if no CSR writes to mcause set bit mcause[5].

Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>