### PR TITLE
ALU not used for LSU instructions

### DIFF
--- a/rtl/cv32e40x_ex_stage.sv
+++ b/rtl/cv32e40x_ex_stage.sv
@@ -328,11 +328,11 @@ module cv32e40x_ex_stage import cv32e40x_pkg::*;
   assign ex_ready_o = ctrl_fsm_i.kill_ex || (alu_ready && csr_ready && mul_ready && div_ready && lsu_ready_i && !ctrl_fsm_i.halt_ex);
 
   // TODO:ab Reconsider setting alu_en for exception/trigger instead of using 'previous_exception'
-  assign ex_valid_o = ((id_ex_pipe_i.alu_en && !id_ex_pipe_i.lsu_en && alu_valid) ||
-                       (id_ex_pipe_i.alu_en &&  id_ex_pipe_i.lsu_en && alu_valid && lsu_valid_i) ||
-                       (id_ex_pipe_i.mul_en && mul_valid) ||
-                       (id_ex_pipe_i.div_en && div_valid) ||
-                       (id_ex_pipe_i.csr_en && csr_valid) ||
+  assign ex_valid_o = ((id_ex_pipe_i.alu_en && alu_valid)   ||
+                       (id_ex_pipe_i.lsu_en && lsu_valid_i) ||
+                       (id_ex_pipe_i.mul_en && mul_valid)   ||
+                       (id_ex_pipe_i.div_en && div_valid)   ||
+                       (id_ex_pipe_i.csr_en && csr_valid)   ||
                        previous_exception // todo:ab:remove
                       ) && instr_valid;
 

--- a/rtl/cv32e40x_i_decoder.sv
+++ b/rtl/cv32e40x_i_decoder.sv
@@ -123,7 +123,7 @@ module cv32e40x_i_decoder import cv32e40x_pkg::*;
         decoder_ctrl_o.lsu_we       = 1'b1;
         decoder_ctrl_o.rf_re[0]     = 1'b1;
         decoder_ctrl_o.rf_re[1]     = 1'b1;
-        decoder_ctrl_o.alu_operator = ALU_ADD;
+        decoder_ctrl_o.alu_en       = 1'b0;
         // pass write data through ALU operand c
         decoder_ctrl_o.op_c_mux_sel = OP_C_REGB_OR_FWD;
 
@@ -144,7 +144,7 @@ module cv32e40x_i_decoder import cv32e40x_pkg::*;
         decoder_ctrl_o.rf_we             = 1'b1;
         decoder_ctrl_o.rf_re[0]          = 1'b1;
         // offset from immediate
-        decoder_ctrl_o.alu_operator      = ALU_ADD;
+        decoder_ctrl_o.alu_en            = 1'b0;
         decoder_ctrl_o.alu_op_b_mux_sel  = OP_B_IMM;
         decoder_ctrl_o.imm_b_mux_sel     = IMMB_I;
         

--- a/rtl/cv32e40x_id_stage.sv
+++ b/rtl/cv32e40x_id_stage.sv
@@ -497,8 +497,8 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
         end
 
         // todo: alu_en is still set for LSU, could change to not setting alu_en and include lsu_en in if() below
-        if (alu_en || div_en || csr_en || lsu_en) begin // todo: the addition of csr_en here is not SEC clean. However, csr_en should have been implied alu_en. Eventually this needs to become (alu_en || div_en) again.
-          id_ex_pipe_o.alu_operator         <= alu_operator;
+        if (alu_en || div_en || csr_en || lsu_en) begin // todo: the addition of csr_en here is not SEC clean. However, csr_en should have been implied alu_en. Eventually this needs to become (alu_en || div_en || lsu_en) again.
+          id_ex_pipe_o.alu_operator         <= alu_operator; // todo: not needed for LSU. Could be moved to a separate block
           id_ex_pipe_o.alu_operand_a        <= operand_a;
           id_ex_pipe_o.alu_operand_b        <= operand_b;
         end

--- a/rtl/cv32e40x_id_stage.sv
+++ b/rtl/cv32e40x_id_stage.sv
@@ -489,13 +489,15 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
         id_ex_pipe_o.instr_valid  <= 1'b1;
         
         id_ex_pipe_o.alu_en                 <= alu_en;
-        if (alu_en)
+
+        // operand_c used by both ALU and LSU
+        if (alu_en || lsu_en)
         begin
           id_ex_pipe_o.operand_c            <= operand_c;
         end
 
         // todo: alu_en is still set for LSU, could change to not setting alu_en and include lsu_en in if() below
-        if (alu_en || div_en || csr_en) begin // todo: the addition of csr_en here is not SEC clean. However, csr_en should have been implied alu_en. Eventually this needs to become (alu_en || div_en) again.
+        if (alu_en || div_en || csr_en || lsu_en) begin // todo: the addition of csr_en here is not SEC clean. However, csr_en should have been implied alu_en. Eventually this needs to become (alu_en || div_en) again.
           id_ex_pipe_o.alu_operator         <= alu_operator;
           id_ex_pipe_o.alu_operand_a        <= operand_a;
           id_ex_pipe_o.alu_operand_b        <= operand_b;


### PR DESCRIPTION
As the LSU was updated to calculate the address for misaligned load/stores, the usage of the ALU is not needed anymore.

SEC clean.