### PR TITLE
Updated register file to a different data type to the register file wrapper

### DIFF
--- a/rtl/cv32e40x_register_file.sv
+++ b/rtl/cv32e40x_register_file.sv
@@ -27,24 +27,24 @@
 module cv32e40x_register_file import cv32e40x_pkg::*;
 (
     // Clock and Reset
-    input  logic         clk,
-    input  logic         rst_n,
+    input logic                           clk,
+    input logic                           rst_n,
 
     // Read ports
-    input  rf_addr_t     raddr_i [REGFILE_NUM_READ_PORTS],
-    output rf_data_t     rdata_o [REGFILE_NUM_READ_PORTS],
+    input                                 rf_addr_t raddr_i [REGFILE_NUM_READ_PORTS],
+    output logic [REGFILE_WORD_WIDTH-1:0] rdata_o [REGFILE_NUM_READ_PORTS],
 
     // Write ports
-    input rf_addr_t      waddr_i [REGFILE_NUM_WRITE_PORTS],
-    input rf_data_t      wdata_i [REGFILE_NUM_WRITE_PORTS],
-    input logic          we_i [REGFILE_NUM_WRITE_PORTS]
+    input                                 rf_addr_t waddr_i [REGFILE_NUM_WRITE_PORTS],
+    input logic [REGFILE_WORD_WIDTH-1:0]  wdata_i [REGFILE_NUM_WRITE_PORTS],
+    input logic                           we_i [REGFILE_NUM_WRITE_PORTS]
 );
 
   // integer register file
-  rf_data_t mem [REGFILE_NUM_WORDS];
+  logic [REGFILE_WORD_WIDTH-1:0]          mem [REGFILE_NUM_WORDS];
 
   // write enable signals for all registers
-  logic [REGFILE_NUM_WORDS-1:0] we_dec[REGFILE_NUM_WRITE_PORTS];
+  logic [REGFILE_NUM_WORDS-1:0]           we_dec[REGFILE_NUM_WRITE_PORTS];
 
   //-----------------------------------------------------------------------------
   //-- READ : Read address decoder RAD

--- a/rtl/cv32e40x_register_file.sv
+++ b/rtl/cv32e40x_register_file.sv
@@ -31,11 +31,11 @@ module cv32e40x_register_file import cv32e40x_pkg::*;
     input logic                           rst_n,
 
     // Read ports
-    input                                 rf_addr_t raddr_i [REGFILE_NUM_READ_PORTS],
+    input  rf_addr_t                      raddr_i [REGFILE_NUM_READ_PORTS],
     output logic [REGFILE_WORD_WIDTH-1:0] rdata_o [REGFILE_NUM_READ_PORTS],
 
     // Write ports
-    input                                 rf_addr_t waddr_i [REGFILE_NUM_WRITE_PORTS],
+    input rf_addr_t                       waddr_i [REGFILE_NUM_WRITE_PORTS],
     input logic [REGFILE_WORD_WIDTH-1:0]  wdata_i [REGFILE_NUM_WRITE_PORTS],
     input logic                           we_i [REGFILE_NUM_WRITE_PORTS]
 );

--- a/rtl/include/cv32e40x_pkg.sv
+++ b/rtl/include/cv32e40x_pkg.sv
@@ -588,6 +588,9 @@ parameter REGFILE_ADDR_WIDTH = 5;
 // Data width of register file
 parameter REGFILE_DATA_WIDTH = 32;
 
+// Word width of register file memory
+parameter REGFILE_WORD_WIDTH = REGFILE_DATA_WIDTH;
+
 // Number of regfile integer registers
 parameter REGFILE_NUM_WORDS = 2**(REGFILE_ADDR_WIDTH);
 


### PR DESCRIPTION
Updated register file to not use same data type as register file wrapper to allow inserting ECC in other cores (like 40s) while keeping the register file merge-able.

Signed-off-by: Halfdan Bechmann <halfdan.bechmann@silabs.com>