### PR TITLE
NMI masked during single step if dcsr.stepie==1'b0

### DIFF
--- a/rtl/cv32e40x_controller.sv
+++ b/rtl/cv32e40x_controller.sv
@@ -70,8 +70,7 @@ module cv32e40x_controller import cv32e40x_pkg::*;
 
   // Debug Signal
   input  logic         debug_req_i,
-  input  logic         debug_single_step_i,
-  input  logic         debug_ebreakm_i,
+  input  Dcsr_t        dcsr_i,
   input  logic         debug_trigger_match_id_i,
 
   // Regfile target
@@ -142,8 +141,7 @@ module cv32e40x_controller import cv32e40x_pkg::*;
   
     // Debug Signal
     .debug_req_i                 ( debug_req_i              ),
-    .debug_single_step_i         ( debug_single_step_i      ),
-    .debug_ebreakm_i             ( debug_ebreakm_i          ),
+    .dcsr_i                      ( dcsr_i                   ),
     .debug_trigger_match_id_i    ( debug_trigger_match_id_i ),
 
     // Outputs

--- a/rtl/cv32e40x_core.sv
+++ b/rtl/cv32e40x_core.sv
@@ -194,8 +194,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
 
   // debug mode and dcsr configuration
   // From cs_registers
-  logic        debug_single_step;
-  logic        debug_ebreakm;
+  Dcsr_t       dcsr;
 
   // trigger match detected in cs_registers (using ID timing)
   logic        debug_trigger_match_id;
@@ -610,8 +609,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
     
     // debug
     .dpc_o                      ( dpc                    ),
-    .debug_single_step_o        ( debug_single_step      ),
-    .debug_ebreakm_o            ( debug_ebreakm          ),
+    .dcsr_o                     ( dcsr                   ),
     .debug_trigger_match_o      ( debug_trigger_match_id ),
 
     .priv_lvl_o                 ( current_priv_lvl       ),
@@ -674,8 +672,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
 
     // Debug signals
     .debug_req_i                    ( debug_req_i            ), 
-    .debug_single_step_i            ( debug_single_step      ),
-    .debug_ebreakm_i                ( debug_ebreakm          ),
+    .dcsr_i                         ( dcsr                   ),
     .debug_trigger_match_id_i       ( debug_trigger_match_id ),
     
     // Register File read, write back and forwards

--- a/rtl/cv32e40x_cs_registers.sv
+++ b/rtl/cv32e40x_cs_registers.sv
@@ -77,15 +77,13 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
 
   // debug
   output logic [31:0]     dpc_o,
-  output logic            debug_single_step_o,
-  output logic            debug_ebreakm_o,
+  output Dcsr_t           dcsr_o,
   output logic            debug_trigger_match_o,
 
   output PrivLvl_t        priv_lvl_o,
 
   input  logic [31:0]     pc_if_i
 );
-
   
   localparam logic [31:0] MISA_VALUE =
   (32'(A_EXTENSION)                     <<  0)  // A - Atomic Instructions extension
@@ -679,10 +677,8 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
   assign mtvec_mode_o    = mtvec_q.mode;
   
   assign mepc_o          = mepc_q;
-  assign dpc_o          = dpc_q;
-
-  assign debug_single_step_o  = dcsr_q.step;
-  assign debug_ebreakm_o      = dcsr_q.ebreakm;
+  assign dpc_o           = dpc_q;
+  assign dcsr_o          = dcsr_q;
 
   assign priv_lvl_q   = PRIV_LVL_M;
 

--- a/sva/cv32e40x_core_sva.sv
+++ b/sva/cv32e40x_core_sva.sv
@@ -32,7 +32,7 @@ module cv32e40x_core_sva
   input ctrl_fsm_t   ctrl_fsm,
   input logic [4:0]  exc_cause,
   input logic [31:0] mie,
-  input logic        debug_single_step,
+  input Dcsr_t       dcsr,
   input              if_id_pipe_t if_id_pipe,
   input              id_stage_multi_cycle_id_stall,
   input logic        id_stage_id_valid,
@@ -268,26 +268,26 @@ always_ff @(posedge clk , negedge rst_ni)
   // Should issue exactly one instruction from ID before entering debug_mode
   a_single_step_no_irq :
     assert property (@(posedge clk) disable iff (!rst_ni || interrupt_taken)
-                     (inst_taken && debug_single_step && !ctrl_fsm.debug_mode)
+                     (inst_taken && dcsr.step && !ctrl_fsm.debug_mode)
                      ##1 inst_taken [->1]
-                     |-> (ctrl_fsm.debug_mode && debug_single_step))
+                     |-> (ctrl_fsm.debug_mode && dcsr.step))
       else `uvm_error("core", "Assertion a_single_step_no_irq failed")
 
   // Single step with interrupt taken may issue up to two instructions
   // before entering debug mode
   a_single_step_with_irq :
     assert property (@(posedge clk) disable iff (!rst_ni)
-                      (inst_taken && debug_single_step && !ctrl_fsm.debug_mode && interrupt_taken) [*1:2]
+                      (inst_taken && dcsr.step && !ctrl_fsm.debug_mode && interrupt_taken) [*1:2]
                       ##1 inst_taken [->1]
-                      |-> (ctrl_fsm.debug_mode && debug_single_step))
+                      |-> (ctrl_fsm.debug_mode && dcsr.step))
       else `uvm_error("core", "Assertion a_single_step_with_irq failed")
 
   // Check that only a single instruction can retire during single step
   a_single_step_retire :
     assert property (@(posedge clk) disable iff (!rst_ni)
-                      (wb_valid && debug_single_step && !ctrl_fsm.debug_mode)
+                      (wb_valid && dcsr.step && !ctrl_fsm.debug_mode)
                       ##1 wb_valid [->1]
-                      |-> (ctrl_fsm.debug_mode && debug_single_step))
+                      |-> (ctrl_fsm.debug_mode && dcsr.step))
       else `uvm_error("core", "Multiple instructions retired during single stepping")
   
 endmodule // cv32e40x_core_sva


### PR DESCRIPTION
Using Dcsr_t struct instead of invidivual bits.

Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>