### PR TITLE
Timing optimization, kill_ex through divider

### DIFF
--- a/rtl/cv32e40x_div.sv
+++ b/rtl/cv32e40x_div.sv
@@ -50,6 +50,9 @@ module cv32e40x_div import cv32e40x_pkg::*;
     output logic [5:0]         alu_shift_amt_o,
     input logic [31:0]         alu_op_b_shifted_i,
  
+    // Divider enable
+    input logic                div_en_i,
+
     // Input handshake
     input logic                valid_i,
     output logic               ready_o,
@@ -135,12 +138,12 @@ module cv32e40x_div import cv32e40x_pkg::*;
     end
   endgenerate
 
-  assign alu_clz_en_o = valid_i;
+  assign alu_clz_en_o = div_en_i;
   
   // Deternmine initial shift of divisor
   assign op_b_is_neg = op_b_i[31] & div_signed;
   assign alu_shift_amt_o = alu_clz_result_i ;
-  assign alu_shift_en_o  = valid_i;
+  assign alu_shift_en_o  = div_en_i;
 
   // Check for op_b_i == 0
   assign op_b_is_zero = !(|op_b_i);

--- a/rtl/cv32e40x_ex_stage.sv
+++ b/rtl/cv32e40x_ex_stage.sv
@@ -86,6 +86,9 @@ module cv32e40x_ex_stage import cv32e40x_pkg::*;
   logic           lsu_en_gated;
   logic           previous_exception;
 
+  // div_en not affected by kill/halt
+  logic           div_en;
+
   // Divider signals
   logic           div_ready;
   logic           div_valid;
@@ -104,6 +107,8 @@ module cv32e40x_ex_stage import cv32e40x_pkg::*;
   assign mul_en_gated = id_ex_pipe_i.mul_en && instr_valid; // Factoring in instr_valid to kill mul instructions on kill/halt
   assign div_en_gated = id_ex_pipe_i.div_en && instr_valid; // Factoring in instr_valid to kill div instructions on kill/halt
   assign lsu_en_gated = id_ex_pipe_i.lsu_en && instr_valid; // Factoring in instr_valid to suppress bus transactions on kill/halt
+
+  assign div_en = id_ex_pipe_i.div_en && id_ex_pipe_i.instr_valid; // Valid DIV in EX, not affected by kill/halt
 
 
   // Exception happened during IF or ID, or trigger match in ID (converted to NOP).
@@ -195,6 +200,9 @@ module cv32e40x_ex_stage import cv32e40x_pkg::*;
 
     // Result
     .result_o           ( div_result                 ),
+
+    // divider enable, not affected by kill/halt
+    .div_en_i           ( div_en                     ),
 
     // Handshakes
     .valid_i            ( div_en_gated               ),


### PR DESCRIPTION
Optimized usage of valid_i in divider to remove long paths from ctrl_fsm_o.kill_ex to operand muxes in ID stage.

SEC clean.

Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>