### PR TITLE
Cleanup of deassert signals

### DIFF
--- a/rtl/cv32e40x_decoder.sv
+++ b/rtl/cv32e40x_decoder.sv
@@ -33,8 +33,7 @@ module cv32e40x_decoder import cv32e40x_pkg::*;
 )
 (
   // singals running to/from controller
-  input  logic        deassert_we_i,            // deassert we, we are stalled or not active
-  input  logic        deassert_we_special_i,    // deassert we and special insn (exception in IF)
+  input  logic        deassert_we_i,    // deassert we and special insn (exception in IF)
 
   output logic        illegal_insn_o,           // illegal instruction encountered
   output logic        ebrk_insn_o,              // trap instruction encountered
@@ -202,22 +201,22 @@ module cv32e40x_decoder import cv32e40x_pkg::*;
   assign lsu_prepost_useincr_o          = decoder_ctrl_mux.lsu_prepost_useincr;               
 
   // Suppress control signals
-  assign alu_en_o             = deassert_we_i || deassert_we_special_i ? 1'b0        : alu_en;
-  assign mul_en_o             = deassert_we_i || deassert_we_special_i ? 1'b0        : mul_en;
-  assign div_en_o             = deassert_we_i || deassert_we_special_i ? 1'b0        : div_en;
-  assign lsu_en_o             = deassert_we_i || deassert_we_special_i ? 1'b0        : lsu_en;
-  assign csr_op_o             = deassert_we_i || deassert_we_special_i ? CSR_OP_READ : csr_op;
-  assign rf_we_o              = deassert_we_i || deassert_we_special_i ? 1'b0        : rf_we;
-  assign ctrl_transfer_insn_o = deassert_we_i || deassert_we_special_i ? BRANCH_NONE : ctrl_transfer_insn;
+  assign alu_en_o             = deassert_we_i ? 1'b0        : alu_en;
+  assign mul_en_o             = deassert_we_i ? 1'b0        : mul_en;
+  assign div_en_o             = deassert_we_i ? 1'b0        : div_en;
+  assign lsu_en_o             = deassert_we_i ? 1'b0        : lsu_en;
+  assign csr_op_o             = deassert_we_i ? CSR_OP_READ : csr_op;
+  assign rf_we_o              = deassert_we_i ? 1'b0        : rf_we;
+  assign ctrl_transfer_insn_o = deassert_we_i ? BRANCH_NONE : ctrl_transfer_insn;
 
   // Suppress special instruction/illegal instruction bits
-  assign mret_insn_o          = deassert_we_special_i ? 1'b0 : decoder_ctrl_mux.mret_insn;
-  assign dret_insn_o          = deassert_we_special_i ? 1'b0 : decoder_ctrl_mux.dret_insn;
-  assign ebrk_insn_o          = deassert_we_special_i ? 1'b0 : decoder_ctrl_mux.ebrk_insn;
-  assign ecall_insn_o         = deassert_we_special_i ? 1'b0 : decoder_ctrl_mux.ecall_insn;
-  assign wfi_insn_o           = deassert_we_special_i ? 1'b0 : decoder_ctrl_mux.wfi_insn;
-  assign fencei_insn_o        = deassert_we_special_i ? 1'b0 : decoder_ctrl_mux.fencei_insn;
-  assign illegal_insn_o       = deassert_we_special_i ? 1'b0 : decoder_ctrl_mux.illegal_insn;
+  assign mret_insn_o          = deassert_we_i ? 1'b0 : decoder_ctrl_mux.mret_insn;
+  assign dret_insn_o          = deassert_we_i ? 1'b0 : decoder_ctrl_mux.dret_insn;
+  assign ebrk_insn_o          = deassert_we_i ? 1'b0 : decoder_ctrl_mux.ebrk_insn;
+  assign ecall_insn_o         = deassert_we_i ? 1'b0 : decoder_ctrl_mux.ecall_insn;
+  assign wfi_insn_o           = deassert_we_i ? 1'b0 : decoder_ctrl_mux.wfi_insn;
+  assign fencei_insn_o        = deassert_we_i ? 1'b0 : decoder_ctrl_mux.fencei_insn;
+  assign illegal_insn_o       = deassert_we_i ? 1'b0 : decoder_ctrl_mux.illegal_insn;
 
 
   assign ctrl_transfer_insn_raw_o = ctrl_transfer_insn;

--- a/rtl/cv32e40x_id_stage.sv
+++ b/rtl/cv32e40x_id_stage.sv
@@ -357,8 +357,7 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
   decoder_i
   (
     // controller related signals
-    .deassert_we_i                   ( ctrl_byp_i.deassert_we         ),
-    .deassert_we_special_i           ( ctrl_byp_i.deassert_we_special ),
+    .deassert_we_i                   ( ctrl_byp_i.deassert_we ),
 
     .illegal_insn_o                  ( illegal_insn              ),
     .ebrk_insn_o                     ( ebrk_insn                 ),

--- a/rtl/include/cv32e40x_pkg.sv
+++ b/rtl/include/cv32e40x_pkg.sv
@@ -1035,8 +1035,7 @@ typedef struct packed {
   logic        csr_stall;
   logic        wfi_stall;
   logic        minstret_stall;        // Stall due to minstret/h read in EX
-  logic        deassert_we;           // Deassert write enable for next instruction
-  logic        deassert_we_special;   // Deassert write enable and special insn bits
+  logic        deassert_we;   // Deassert write enable and special insn bits
 } ctrl_byp_t;
 
 // Controller FSM outputs


### PR DESCRIPTION
Removed reduntant 'deassert_we' in controller bypass. Stall signals to ID stage would prevent deasserted bits to propagate anyway.

Renamed 'deassert_we_special' to 'deassert_we'.

SEC clean.

Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>