### PR TITLE
Renaming 'misaligned' to 'split'

### DIFF
--- a/bhv/cv32e40x_rvfi.sv
+++ b/bhv/cv32e40x_rvfi.sv
@@ -60,7 +60,7 @@ module cv32e40x_rvfi
 
    input logic [31:0]                         data_addr_ex_i,
    input logic [31:0]                         data_wdata_ex_i,
-   input logic                                lsu_misaligned_q_ex_i,
+   input logic                                lsu_split_q_ex_i,
 
    //// WB probes ////
    input logic [31:0]                         pc_wb_i,
@@ -560,8 +560,8 @@ module cv32e40x_rvfi
         mem_wmask  [STAGE_EX] <= mem_wmask  [STAGE_ID];
         in_trap    [STAGE_EX] <= in_trap    [STAGE_ID];
 
-        if (!lsu_misaligned_q_ex_i) begin
-          // The second part of the misaligned acess is suppressed to keep
+        if (!lsu_split_q_ex_i) begin
+          // The second part of the split misaligned acess is suppressed to keep
           // the start address and data for the whole misaligned transfer
           ex_mem_addr         <= rvfi_mem_addr_d;
           ex_mem_wdata        <= rvfi_mem_wdata_d;

--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -306,7 +306,7 @@ bind cv32e40x_sleep_unit:
          .lsu_en_wb_i              ( core_i.wb_stage_i.ex_wb_pipe_i.lsu_en                                ),
          .data_addr_ex_i           ( core_i.data_addr_o                                                   ),
          .data_wdata_ex_i          ( core_i.data_wdata_o                                                  ),
-         .lsu_misaligned_q_ex_i    ( core_i.load_store_unit_i.misaligned_q                                ),
+         .lsu_split_q_ex_i         ( core_i.load_store_unit_i.split_q                                     ),
 
          .rf_re_id_i               ( core_i.id_stage_i.rf_re_o                                            ),
          .rf_we_wb_i               ( core_i.wb_stage_i.rf_we_wb_o                                         ),

--- a/rtl/cv32e40x_controller.sv
+++ b/rtl/cv32e40x_controller.sv
@@ -50,7 +50,7 @@ module cv32e40x_controller import cv32e40x_pkg::*;
   input  ex_wb_pipe_t ex_wb_pipe_i,
 
   // LSU
-  input  logic        lsu_misaligned_ex_i,        // LSU is misaligned
+  input  logic        lsu_split_ex_i,             // LSU is splitting misaligned
   input  mpu_status_e lsu_mpu_status_wb_i,        // MPU status (WB stage)
   input  logic        lsu_err_wb_i,               // LSU bus error in WB stage
   input  logic [31:0] lsu_addr_wb_i,              // LSU address in WB stage
@@ -175,9 +175,6 @@ module cv32e40x_controller import cv32e40x_pkg::*;
 
     // From WB
     .wb_ready_i                 ( wb_ready_i               ),
-
-    // From LSU
-    .lsu_misaligned_ex_i        ( lsu_misaligned_ex_i      ),
 
     // Outputs
     .ctrl_byp_o                 ( ctrl_byp_o               )

--- a/rtl/cv32e40x_controller_bypass.sv
+++ b/rtl/cv32e40x_controller_bypass.sv
@@ -59,9 +59,6 @@ module cv32e40x_controller_bypass import cv32e40x_pkg::*;
   // From WB
   input  logic        wb_ready_i,                 // WB stage is ready
 
-  // From LSU
-  input  logic        lsu_misaligned_ex_i,           // LSU detected a misaligned load/store instruction
-
   // Controller Bypass outputs
   output ctrl_byp_t     ctrl_byp_o
 );

--- a/rtl/cv32e40x_core.sv
+++ b/rtl/cv32e40x_core.sv
@@ -157,7 +157,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
   PrivLvl_t    current_priv_lvl;
 
   // LSU
-  logic        lsu_misaligned_ex;
+  logic        lsu_split_ex;
   mpu_status_e lsu_mpu_status_wb;
   logic [31:0] lsu_rdata_wb;
   logic        lsu_err_wb;
@@ -402,7 +402,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .csr_en_o                     ( csr_en_id                 ),
     .csr_op_o                     ( csr_op_id                 ),
 
-    .ctrl_transfer_insn_o         ( ctrl_transfer_insn_id),
+    .ctrl_transfer_insn_o         ( ctrl_transfer_insn_id     ),
     .ctrl_transfer_insn_raw_o     ( ctrl_transfer_insn_raw_id ),
 
     .rf_re_o                      ( rf_re_id                  ),
@@ -456,7 +456,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .lsu_ready_o                ( lsu_ready_ex                 ),
     .lsu_valid_o                ( lsu_valid_ex                 ),
     .lsu_ready_i                ( lsu_ready_0                  ),
-    .lsu_misaligned_i           ( lsu_misaligned_ex            ),
+    .lsu_split_i                ( lsu_split_ex                 ),
 
     // Pipeline handshakes
     .ex_ready_o                 ( ex_ready                     ),
@@ -495,7 +495,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .busy_o                ( lsu_busy           ),
 
     // Stage 0 outputs (EX)
-    .lsu_misaligned_0_o    ( lsu_misaligned_ex  ),
+    .lsu_split_0_o         ( lsu_split_ex       ),
     .lsu_mpu_status_1_o    ( lsu_mpu_status_wb  ),
 
     // Stage 1 outputs (WB)
@@ -651,7 +651,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .csr_op_id_i                    ( csr_op_id              ),
                                                                  
     // LSU
-    .lsu_misaligned_ex_i            ( lsu_misaligned_ex      ),
+    .lsu_split_ex_i                 ( lsu_split_ex           ),
     .lsu_mpu_status_wb_i            ( lsu_mpu_status_wb      ),
     .lsu_addr_wb_i                  ( lsu_addr_wb            ),
     .lsu_err_wb_i                   ( lsu_err_wb             ),

--- a/rtl/cv32e40x_ex_stage.sv
+++ b/rtl/cv32e40x_ex_stage.sv
@@ -59,7 +59,7 @@ module cv32e40x_ex_stage import cv32e40x_pkg::*;
   output logic        lsu_ready_o,
   output logic        lsu_valid_o,
   input  logic        lsu_ready_i,
-  input  logic        lsu_misaligned_i,       // LSU is performing first part of a misaligned instruction
+  input  logic        lsu_split_i,      // LSU is performing first part of a misaligned/split instruction
 
   // Stage ready/valid
   output logic        ex_ready_o,       // EX stage is ready for new data
@@ -272,9 +272,9 @@ module cv32e40x_ex_stage import cv32e40x_pkg::*;
       if (ex_valid_o && wb_ready_i) begin
         ex_wb_pipe_o.instr_valid <= 1'b1;
         // Deassert rf_we in case of illegal csr instruction or
-        // when the first half of a misaligned LSU goes to WB.
-        ex_wb_pipe_o.rf_we       <= (csr_illegal_i               ||
-                                    lsu_misaligned_i)             ? 1'b0 : id_ex_pipe_i.rf_we;
+        // when the first half of a misaligned/split LSU goes to WB.
+        ex_wb_pipe_o.rf_we       <= (csr_illegal_i     ||
+                                    lsu_split_i)       ? 1'b0 : id_ex_pipe_i.rf_we;
         ex_wb_pipe_o.lsu_en      <= id_ex_pipe_i.lsu_en;
           
         if (id_ex_pipe_i.rf_we) begin

--- a/rtl/cv32e40x_wb_stage.sv
+++ b/rtl/cv32e40x_wb_stage.sv
@@ -88,7 +88,7 @@ module cv32e40x_wb_stage import cv32e40x_pkg::*;
   // Note that write back is not suppressed during bus errors (in order to prevent
   // a timing path from the late arriving data_err_i into the register file).
   //
-  // Note that the register file is only written for the last part of a misaligned load.
+  // Note that the register file is only written for the last part of a split misaligned load.
   // (rf_we suppressed in ex_stage for the first part, lsu aggregates data for second part)
   //
   // Note that the register file is written multiple times in case waited loads (in
@@ -125,7 +125,7 @@ module cv32e40x_wb_stage import cv32e40x_pkg::*;
   // - Will be 0 for interrupted instruction and debug entry
   // - Will be 1 for synchronous exceptions (which is easier to deal with for RVFI); this implies that wb_valid
   //   cannot be used to increment the minstret CSR (as that should not increment for e.g. ecall, ebreak, etc.)
-  // - Will be 1 only for the second phase of a misaligned load/store that completes without MPU errors.
+  // - Will be 1 only for the second phase of a split misaligned load/store that completes without MPU errors.
   //   If an MPU error occurs, wb_valid will be 1 due to lsu_exception (for any phase where the error occurs)
 
   assign wb_valid = ((!ex_wb_pipe_i.lsu_en && 1'b1)        ||     // Non-LSU instructions always have valid result in WB, also for exceptions.

--- a/sva/cv32e40x_ex_stage_sva.sv
+++ b/sva/cv32e40x_ex_stage_sva.sv
@@ -37,7 +37,7 @@ module cv32e40x_ex_stage_sva
 
   input id_ex_pipe_t    id_ex_pipe_i,
   input ex_wb_pipe_t    ex_wb_pipe_o,
-  input logic           lsu_misaligned_i
+  input logic           lsu_split_i
 );
 
   // Halt implies not ready and not valid
@@ -56,9 +56,9 @@ module cv32e40x_ex_stage_sva
 
 
 
-// First access of misaligned LSU should have rf_we deasserted
-a_misaligned_rf_we:
+// First access of split LSU instruction should have rf_we deasserted
+a_split_rf_we:
   assert property (@(posedge clk) disable iff (!rst_n)
-                    (ex_valid_o && wb_ready_i && id_ex_pipe_i.lsu_en && lsu_misaligned_i)
+                    (ex_valid_o && wb_ready_i && id_ex_pipe_i.lsu_en && lsu_split_i)
                     |=> !ex_wb_pipe_o.rf_we);
 endmodule // cv32e40x_ex_stage_sva


### PR DESCRIPTION
Renamed signals named *misaligned* to using 'split' instead, as this reflects the current behaviour of the LSU unit when it splits misaligned transfers.

SEC clean.

Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>