### PR TITLE
Rvfi suppressed intr fix

### DIFF
--- a/bhv/cv32e40x_rvfi.sv
+++ b/bhv/cv32e40x_rvfi.sv
@@ -67,6 +67,7 @@ module cv32e40x_rvfi
    input logic                                wb_ready_i,
    input logic                                wb_valid_i,
    input logic                                ebreak_in_wb_i,
+   input logic                                instr_valid_wb_i,
    input logic [31:0]                         instr_rdata_wb_i,
    input logic                                exception_in_wb_i,
    // Register writes
@@ -514,6 +515,10 @@ module cv32e40x_rvfi
           // Special case for debug entry from debug mode caused by EBREAK as it is not captured by debug_cause_i
           // A higher priority debug request (e.g. trigger match) will pull ebreak_in_wb_i low and allow the debug cause to propagate
           debug_cause_if_next <=  ebreak_in_wb_i ? 3'h1 : debug_cause_i;
+
+          // If there is a trap in write-back when debug is taken, the trap will be supressed but the side-effects will not.
+          // The succeeding instruction therefore needs to set the intr bit in this case.
+          in_trap_next <= in_trap[STAGE_EX] && instr_valid_wb_i;
         end
 
         // Picking up trap entry when IF is not valid to propagate for next valid instruction

--- a/bhv/cv32e40x_rvfi.sv
+++ b/bhv/cv32e40x_rvfi.sv
@@ -67,7 +67,6 @@ module cv32e40x_rvfi
    input logic                                wb_ready_i,
    input logic                                wb_valid_i,
    input logic                                ebreak_in_wb_i,
-   input logic                                instr_valid_wb_i,
    input logic [31:0]                         instr_rdata_wb_i,
    input logic                                exception_in_wb_i,
    // Register writes

--- a/bhv/cv32e40x_rvfi.sv
+++ b/bhv/cv32e40x_rvfi.sv
@@ -506,10 +506,6 @@ module cv32e40x_rvfi
       if (if_valid_i && id_ready_i) begin
         in_trap            [STAGE_IF] <= 1'b0;
         debug_cause        [STAGE_IF] <= '0;
-        intr_mcause_we     [STAGE_IF] <= '0;
-        intr_mcause_wdata  [STAGE_IF] <= '0;
-        intr_mstatus_we    [STAGE_IF] <= '0;
-        intr_mstatus_wdata [STAGE_IF] <= '0;
 
         debug_mode         [STAGE_ID] <= debug_mode_i; // Probing in IF to make sure any LSU instructions that are not killed can complete
         in_trap            [STAGE_ID] <= in_trap            [STAGE_IF]; // Set interrupt bit when entering trap handler
@@ -528,9 +524,9 @@ module cv32e40x_rvfi
           // A higher priority debug request (e.g. trigger match) will pull ebreak_in_wb_i low and allow the debug cause to propagate
           debug_cause[STAGE_IF] <=  ebreak_in_wb_i ? 3'h1 : debug_cause_i;
 
-          // If there is a trap in write-back when debug is taken, the trap will be supressed but the side-effects will not.
-          // The succeeding instruction therefore needs to set the intr bit in this case.
-          if (instr_valid_wb_i && in_trap[STAGE_WB]) begin
+          // If there is a trap in the pipeline when debug is taken, the trap will be supressed but the side-effects will not.
+          // The succeeding instruction therefore needs to re-trigger the intr bit if it it did not reach the rvfi output.
+          if (|in_trap && !rvfi_intr) begin
             in_trap[STAGE_IF]     <= 1'b1;
           end
         end

--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -269,7 +269,6 @@ bind cv32e40x_sleep_unit:
 
          .wb_valid_i               ( core_i.wb_stage_i.wb_valid_o                                         ),
          .wb_ready_i               ( core_i.wb_stage_i.wb_ready_o                                         ),
-         .instr_valid_wb_i         ( core_i.wb_stage_i.ex_wb_pipe_i.instr_valid                           ),
          .instr_rdata_wb_i         ( core_i.wb_stage_i.ex_wb_pipe_i.instr.bus_resp.rdata                  ),
          .ebreak_in_wb_i           ( core_i.controller_i.controller_fsm_i.ebreak_in_wb                    ),
 

--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -269,6 +269,7 @@ bind cv32e40x_sleep_unit:
 
          .wb_valid_i               ( core_i.wb_stage_i.wb_valid_o                                         ),
          .wb_ready_i               ( core_i.wb_stage_i.wb_ready_o                                         ),
+         .instr_valid_wb_i         ( core_i.wb_stage_i.ex_wb_pipe_i.instr_valid                           ),
          .instr_rdata_wb_i         ( core_i.wb_stage_i.ex_wb_pipe_i.instr.bus_resp.rdata                  ),
          .ebreak_in_wb_i           ( core_i.controller_i.controller_fsm_i.ebreak_in_wb                    ),
 


### PR DESCRIPTION
Fix for #204 - Debug regressions now passing with this branch.
Changed naming sceme of pipeline stages.
Added check in IF stage for traps in later stages suppressed by debug entry.
Added mstatus and mcause registers to pipeline.
