### PR TITLE
Bugfix: Did not stall for reading of instret, only minstret

### DIFF
--- a/rtl/cv32e40x_controller.sv
+++ b/rtl/cv32e40x_controller.sv
@@ -77,7 +77,6 @@ module cv32e40x_controller import cv32e40x_pkg::*;
   input  logic         regfile_alu_we_id_i,        // currently decoded we enable
 
   // CSR raddr in ex
-  input  csr_num_e     csr_raddr_ex_i,
   input  logic         csr_counter_read_i,         // A performance counter is read in CSR (EX)
 
   input logic [REGFILE_NUM_READ_PORTS-1:0]         rf_re_i,
@@ -180,7 +179,6 @@ module cv32e40x_controller import cv32e40x_pkg::*;
     .debug_trigger_match_id_i   ( debug_trigger_match_id_i ),
 
     // From EX
-    .csr_raddr_ex_i             ( csr_raddr_ex_i           ),
     .csr_counter_read_i         ( csr_counter_read_i       ),
 
     // From WB

--- a/rtl/cv32e40x_controller.sv
+++ b/rtl/cv32e40x_controller.sv
@@ -78,6 +78,7 @@ module cv32e40x_controller import cv32e40x_pkg::*;
 
   // CSR raddr in ex
   input  csr_num_e     csr_raddr_ex_i,
+  input  logic         csr_counter_read_i,         // A performance counter is read in CSR (EX)
 
   input logic [REGFILE_NUM_READ_PORTS-1:0]         rf_re_i,
   input rf_addr_t     rf_raddr_i[REGFILE_NUM_READ_PORTS],
@@ -180,6 +181,7 @@ module cv32e40x_controller import cv32e40x_pkg::*;
 
     // From EX
     .csr_raddr_ex_i             ( csr_raddr_ex_i           ),
+    .csr_counter_read_i         ( csr_counter_read_i       ),
 
     // From WB
     .wb_ready_i                 ( wb_ready_i               ),

--- a/rtl/cv32e40x_controller_bypass.sv
+++ b/rtl/cv32e40x_controller_bypass.sv
@@ -54,8 +54,7 @@ module cv32e40x_controller_bypass import cv32e40x_pkg::*;
   input  logic        debug_trigger_match_id_i,         // Trigger match in ID
 
   // From EX
-  input  csr_num_e    csr_raddr_ex_i,             // CSR read address (EX)
-  input  logic        csr_counter_read_i,         // CSR is reading a counter (EX)
+  input  logic        csr_counter_read_i,         // CSR is reading a counter (EX).
 
   // From WB
   input  logic        wb_ready_i,                 // WB stage is ready
@@ -188,6 +187,7 @@ module cv32e40x_controller_bypass import cv32e40x_pkg::*;
     end
 
     // Stall (EX) due to performance counter read
+    // csr_counter_read_i is derived from csr_raddr, which is gated with id_ex_pipe.csr_en and id_ex_pipe.instr_valid
     if (csr_counter_read_i && ex_wb_pipe_i.instr_valid) begin
       ctrl_byp_o.minstret_stall = 1'b1;
     end

--- a/rtl/cv32e40x_controller_bypass.sv
+++ b/rtl/cv32e40x_controller_bypass.sv
@@ -55,6 +55,7 @@ module cv32e40x_controller_bypass import cv32e40x_pkg::*;
 
   // From EX
   input  csr_num_e    csr_raddr_ex_i,             // CSR read address (EX)
+  input  logic        csr_counter_read_i,         // CSR is reading a counter (EX)
 
   // From WB
   input  logic        wb_ready_i,                 // WB stage is ready
@@ -73,9 +74,6 @@ module cv32e40x_controller_bypass import cv32e40x_pkg::*;
 
   // Detect CSR write in EX or WB (implicit and explicit)
   logic csr_write_in_ex_wb;
-
-  // Detect minstret/minstreth read in EX.
-  logic minstret_read_in_ex;
 
   // EX register file write enable
   logic rf_we_ex;
@@ -126,11 +124,6 @@ module cv32e40x_controller_bypass import cv32e40x_pkg::*;
                               (id_ex_pipe_i.instr_valid && (id_ex_pipe_i.csr_en || id_ex_pipe_i.mret_insn)) ||
                               (ex_wb_pipe_i.instr_valid && (ex_wb_pipe_i.csr_en || ex_wb_pipe_i.mret_insn))
                               );
-
-  // minstret/minstreh is read in EX
-  assign minstret_read_in_ex =  ((id_ex_pipe_i.instr_valid && id_ex_pipe_i.csr_en) &&
-                                ((csr_raddr_ex_i  == CSR_MINSTRET) || (csr_raddr_ex_i == CSR_MINSTRETH)));
-
 
   // Stall ID when WFI is active in EX.
   // Used to create an interruptible bubble after WFI // todo:low only needed for load/store following WFI; should actually halt EX when WFI in WB
@@ -194,8 +187,8 @@ module cv32e40x_controller_bypass import cv32e40x_pkg::*;
       ctrl_byp_o.csr_stall = 1'b1;
     end
 
-    // Stall (EX) due to minstret read
-    if (minstret_read_in_ex && ex_wb_pipe_i.instr_valid) begin
+    // Stall (EX) due to performance counter read
+    if (csr_counter_read_i && ex_wb_pipe_i.instr_valid) begin
       ctrl_byp_o.minstret_stall = 1'b1;
     end
   end

--- a/rtl/cv32e40x_controller_fsm.sv
+++ b/rtl/cv32e40x_controller_fsm.sv
@@ -760,7 +760,7 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
         // Later errors could overwrite the bit for load/store type, and with mtval the address would be overwritten.
         // todo: if mtval is implemented, address must be sticky as well
         nmi_pending_q <= 1'b1;
-        nmi_is_store_q <= ~ex_wb_pipe_i.rf_we;
+        nmi_is_store_q <= !ex_wb_pipe_i.rf_we;
       // Clear when the controller takes the NMI
       end else if (ctrl_fsm_o.pc_set && (ctrl_fsm_o.exc_pc_mux == EXC_PC_NMI)) begin
         nmi_pending_q <= 1'b0;

--- a/rtl/cv32e40x_core.sv
+++ b/rtl/cv32e40x_core.sv
@@ -208,7 +208,6 @@ module cv32e40x_core import cv32e40x_pkg::*;
 
   logic        csr_en_id;
   csr_opcode_e csr_op_id;
-  csr_num_e    csr_raddr_ex;
   logic        csr_illegal;
 
   // irq signals
@@ -598,7 +597,6 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .csr_illegal_o              (csr_illegal             ),
 
     // Raddr from first stage (EX)
-    .csr_raddr_o                ( csr_raddr_ex           ),
     .csr_counter_read_o         ( csr_counter_read       ),
 
     // Interrupt related control signals
@@ -636,7 +634,6 @@ module cv32e40x_core import cv32e40x_pkg::*;
     // From ID/EX pipeline
     .id_ex_pipe_i                   ( id_ex_pipe             ),
 
-    .csr_raddr_ex_i                 ( csr_raddr_ex           ),
     .csr_counter_read_i             ( csr_counter_read       ),
 
     // From EX/WB pipeline

--- a/rtl/cv32e40x_core.sv
+++ b/rtl/cv32e40x_core.sv
@@ -153,6 +153,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
   logic [1:0]  mtvec_mode;
 
   logic [31:0] csr_rdata;
+  logic csr_counter_read;
 
   PrivLvl_t    current_priv_lvl;
 
@@ -598,6 +599,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
 
     // Raddr from first stage (EX)
     .csr_raddr_o                ( csr_raddr_ex           ),
+    .csr_counter_read_o         ( csr_counter_read       ),
 
     // Interrupt related control signals
     .mie_o                      ( mie                    ),
@@ -635,6 +637,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .id_ex_pipe_i                   ( id_ex_pipe             ),
 
     .csr_raddr_ex_i                 ( csr_raddr_ex           ),
+    .csr_counter_read_i             ( csr_counter_read       ),
 
     // From EX/WB pipeline
     .ex_wb_pipe_i                   ( ex_wb_pipe             ),

--- a/rtl/cv32e40x_cs_registers.sv
+++ b/rtl/cv32e40x_cs_registers.sv
@@ -60,7 +60,6 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
   input  ctrl_fsm_t       ctrl_fsm_i,
 
   // To controller bypass logic
-  output csr_num_e        csr_raddr_o,
   output logic            csr_counter_read_o,
  
   // Interface to registers (SRAM like)
@@ -188,7 +187,6 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
   // CSR access. Read in EX, write in WB
   // Setting csr_raddr to zero in case of unused csr to save power (alu_operand_b toggles a lot)
   assign csr_raddr = csr_num_e'((id_ex_pipe_i.csr_en && id_ex_pipe_i.instr_valid) ? id_ex_pipe_i.alu_operand_b[11:0] : 12'b0);
-  assign csr_raddr_o = csr_raddr;
 
   // Not suppressing csr_waddr to zero when unused since its source are dedicated flipflops and would not save power as for raddr
   assign csr_waddr = csr_num_e'(ex_wb_pipe_i.csr_addr);

--- a/rtl/cv32e40x_cs_registers.sv
+++ b/rtl/cv32e40x_cs_registers.sv
@@ -61,6 +61,7 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
 
   // To controller bypass logic
   output csr_num_e        csr_raddr_o,
+  output logic            csr_counter_read_o,
  
   // Interface to registers (SRAM like)
   output logic [31:0]     csr_rdata_o,
@@ -231,7 +232,7 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
   always_comb
   begin
     illegal_csr_read = 1'b0;
-
+    csr_counter_read_o = 1'b0;
     case (csr_raddr)
       // mstatus: always M-mode, contains IE bit
       CSR_MSTATUS: csr_rdata_int = mstatus_q;
@@ -312,8 +313,10 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
       CSR_HPMCOUNTER16, CSR_HPMCOUNTER17, CSR_HPMCOUNTER18, CSR_HPMCOUNTER19,
       CSR_HPMCOUNTER20, CSR_HPMCOUNTER21, CSR_HPMCOUNTER22, CSR_HPMCOUNTER23,
       CSR_HPMCOUNTER24, CSR_HPMCOUNTER25, CSR_HPMCOUNTER26, CSR_HPMCOUNTER27,
-      CSR_HPMCOUNTER28, CSR_HPMCOUNTER29, CSR_HPMCOUNTER30, CSR_HPMCOUNTER31:
+      CSR_HPMCOUNTER28, CSR_HPMCOUNTER29, CSR_HPMCOUNTER30, CSR_HPMCOUNTER31: begin
         csr_rdata_int = mhpmcounter_q[csr_raddr[4:0]][31:0];
+        csr_counter_read_o = 1'b1;
+      end
 
       CSR_MCYCLEH,
       CSR_MINSTRETH,
@@ -334,8 +337,10 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
       CSR_HPMCOUNTER16H, CSR_HPMCOUNTER17H, CSR_HPMCOUNTER18H, CSR_HPMCOUNTER19H,
       CSR_HPMCOUNTER20H, CSR_HPMCOUNTER21H, CSR_HPMCOUNTER22H, CSR_HPMCOUNTER23H,
       CSR_HPMCOUNTER24H, CSR_HPMCOUNTER25H, CSR_HPMCOUNTER26H, CSR_HPMCOUNTER27H,
-      CSR_HPMCOUNTER28H, CSR_HPMCOUNTER29H, CSR_HPMCOUNTER30H, CSR_HPMCOUNTER31H:
+      CSR_HPMCOUNTER28H, CSR_HPMCOUNTER29H, CSR_HPMCOUNTER30H, CSR_HPMCOUNTER31H: begin
         csr_rdata_int = (MHPMCOUNTER_WIDTH == 64) ? mhpmcounter_q[csr_raddr[4:0]][63:32] : '0;
+        csr_counter_read_o = 1'b1;
+      end
 
       CSR_MCOUNTINHIBIT: csr_rdata_int = mcountinhibit_q;
 


### PR DESCRIPTION
Stalling EX on all performance counter reads if there is a valid instruction in WB.

Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>