### PR TITLE
New event for minstret counter.

### DIFF
--- a/bhv/cv32e40x_rvfi.sv
+++ b/bhv/cv32e40x_rvfi.sv
@@ -417,14 +417,16 @@ module cv32e40x_rvfi
   logic [31:0][31:0] csr_mhpmcounter_we_l;
   logic [31:0][31:0] csr_mhpmcounter_we_h;
 
-  // Signals for special handling of minstret
-  logic [31:0] minstret_rdata_q;
-  logic [31:0] minstreth_rdata_q;
-  logic [31:0] minstret_wdata_q;
-  logic [31:0] minstreth_wdata_q;
-  // Minstret was written during WB and possibly before wb_valid
-  logic        minstret_during_wb;
-  logic        minstreth_during_wb;
+  // Signals for special handling of performance counters
+  logic [31:0][31:0] mhpmcounter_l_rdata_q;
+  logic [31:0][31:0] mhpmcounter_l_wdata_q;
+  logic [31:0][31:0] mhpmcounter_h_rdata_q;
+  logic [31:0][31:0] mhpmcounter_h_wdata_q;
+
+  // Counter was written during WB and possibly before wb_valid
+  logic [31:0]       mhpmcounter_l_during_wb;
+  logic [31:0]       mhpmcounter_h_during_wb;
+
 
 
 
@@ -648,40 +650,42 @@ module cv32e40x_rvfi
     end
   end // always_ff @
 
-  // Capture possible minstret writes during WB, before wb_valid
-  // If minstret happens before wb_valid (LSU stalled waiting for rvalid),
+  // Capture possible performance counter writes during WB, before wb_valid
+  // If counter write happens before wb_valid (LSU stalled waiting for rvalid for example),
   // we must keep _n and _q values to correctly set _rdata and _wdata when rvfi_valid is set.
   // If wb_valid occurs in the same cycle as the write, the flags are zero and any
   // stored values will not be used.
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni) begin
-      minstret_rdata_q <= '0;
-      minstreth_rdata_q <= '0;
-      minstret_wdata_q <= '0;
-      minstreth_wdata_q <= '0;
-      minstret_during_wb <= 1'b0;
-      minstreth_during_wb <= 1'b0;
-    end else begin
-      // Clear flags on wb_valid
-      if (wb_valid_i) begin
-        minstret_during_wb <= 1'b0;
-        minstreth_during_wb <= 1'b0;
+  generate for (genvar i = 0; i < 32; i++)
+    always_ff @(posedge clk_i or negedge rst_ni) begin
+      if (!rst_ni) begin
+        mhpmcounter_l_rdata_q[i] <= '0;
+        mhpmcounter_h_rdata_q[i] <= '0;
+        mhpmcounter_l_wdata_q[i] <= '0;
+        mhpmcounter_h_wdata_q[i] <= '0;
+        mhpmcounter_l_during_wb[i] <= 1'b0;
+        mhpmcounter_h_during_wb[i] <= 1'b0;
       end else begin
-        // Capture minstret writes.
-        if (csr_mhpmcounter_we_l[CSR_MINSTRET & 'hF]) begin
-          minstret_during_wb <= 1'b1;
-          minstret_rdata_q <= csr_mhpmcounter_q_l [CSR_MINSTRET & 'hF];
-          minstret_wdata_q <= csr_mhpmcounter_n_l [CSR_MINSTRET & 'hF];
-        end
+        // Clear flags on wb_valid
+        if (wb_valid_i) begin
+          mhpmcounter_l_during_wb[i] <= 1'b0;
+          mhpmcounter_h_during_wb[i] <= 1'b0;
+        end else begin
+          // Capture counter writes.
+          if (csr_mhpmcounter_we_l[i]) begin
+            mhpmcounter_l_during_wb <= 1'b1;
+            mhpmcounter_l_rdata_q <= csr_mhpmcounter_q_l[i];
+            mhpmcounter_l_wdata_q <= csr_mhpmcounter_n_l[i];
+          end
 
-        if (csr_mhpmcounter_we_h[CSR_MINSTRETH & 'hF]) begin
-          minstreth_during_wb <= 1'b1;
-          minstreth_rdata_q <= csr_mhpmcounter_q_h [CSR_MINSTRETH & 'hF];
-          minstreth_wdata_q <= csr_mhpmcounter_n_h [CSR_MINSTRETH & 'hF];
+          if (csr_mhpmcounter_we_h[i]) begin
+            mhpmcounter_h_during_wb <= 1'b1;
+            mhpmcounter_h_rdata_q <= csr_mhpmcounter_q_h[i];
+            mhpmcounter_h_wdata_q <= csr_mhpmcounter_n_h[i];
+          end
         end
       end
     end
-  end
+  endgenerate
   //////////////////
 
 
@@ -841,16 +845,22 @@ module cv32e40x_rvfi
   assign rvfi_csr_wmask_d.mcycle             = csr_mhpmcounter_we_l[CSR_MCYCLE & 'hF];
 
   // Used flopped values in case write happened before wb_valid
-  assign rvfi_csr_rdata_d.minstret           = !minstret_during_wb ? csr_mhpmcounter_q_l [CSR_MINSTRET & 'hF] : minstret_rdata_q;
-  assign rvfi_csr_wdata_d.minstret           = !minstret_during_wb ? csr_mhpmcounter_n_l [CSR_MINSTRET & 'hF] : minstret_wdata_q;
-  assign rvfi_csr_wmask_d.minstret           = !minstret_during_wb ? csr_mhpmcounter_we_l[CSR_MINSTRET & 'hF] : '1;
+  assign rvfi_csr_rdata_d.minstret           = !mhpmcounter_l_during_wb[CSR_MINSTRET & 'hF] ? csr_mhpmcounter_q_l [CSR_MINSTRET & 'hF] : mhpmcounter_l_rdata_q[CSR_MINSTRET & 'hF];
+  assign rvfi_csr_wdata_d.minstret           = !mhpmcounter_l_during_wb[CSR_MINSTRET & 'hF] ? csr_mhpmcounter_n_l [CSR_MINSTRET & 'hF] : mhpmcounter_l_wdata_q[CSR_MINSTRET & 'hF];
+  assign rvfi_csr_wmask_d.minstret           = !mhpmcounter_l_during_wb[CSR_MINSTRET & 'hF] ? csr_mhpmcounter_we_l[CSR_MINSTRET & 'hF] : '1;
 
   assign rvfi_csr_rdata_d.mhpmcounter[ 2:0]  = 'Z;
   assign rvfi_csr_wdata_d.mhpmcounter[ 2:0]  = 'Z; // Does not exist
   assign rvfi_csr_wmask_d.mhpmcounter[ 2:0]  = '0;
-  assign rvfi_csr_rdata_d.mhpmcounter[31:3]  = csr_mhpmcounter_q_l [31:3];
-  assign rvfi_csr_wdata_d.mhpmcounter[31:3]  = csr_mhpmcounter_q_l [31:3];
-  assign rvfi_csr_wmask_d.mhpmcounter[31:3]  = csr_mhpmcounter_we_l[31:3];
+
+  // Used flopped values in case write happened before wb_valid
+  generate
+    for (genvar i = 3; i < 32; i++) begin
+      assign rvfi_csr_rdata_d.mhpmcounter[i]  = !mhpmcounter_l_during_wb[i] ? csr_mhpmcounter_q_l [i] : mhpmcounter_l_rdata_q[i];
+      assign rvfi_csr_wdata_d.mhpmcounter[i]  = !mhpmcounter_l_during_wb[i] ? csr_mhpmcounter_n_l [i] : mhpmcounter_l_wdata_q[i];
+      assign rvfi_csr_wmask_d.mhpmcounter[i]  = !mhpmcounter_l_during_wb[i] ? csr_mhpmcounter_we_l[i] : '1;
+    end
+  endgenerate
 
   assign ex_csr_rdata_d.mcycleh              = csr_mhpmcounter_q_h [CSR_MCYCLEH & 'hF];
   assign rvfi_csr_rdata_d.mcycleh            = ex_csr_rdata.mcycleh;
@@ -858,16 +868,22 @@ module cv32e40x_rvfi
   assign rvfi_csr_wmask_d.mcycleh            = csr_mhpmcounter_we_h[CSR_MCYCLEH & 'hF];
 
   // Used flopped values in case write happened before wb_valid
-  assign rvfi_csr_rdata_d.minstreth          = !minstreth_during_wb ? csr_mhpmcounter_q_h [CSR_MINSTRETH & 'hF] : minstreth_rdata_q;
-  assign rvfi_csr_wdata_d.minstreth          = !minstreth_during_wb ? csr_mhpmcounter_n_h [CSR_MINSTRETH & 'hF] : minstreth_wdata_q;
-  assign rvfi_csr_wmask_d.minstreth          = !minstreth_during_wb ? csr_mhpmcounter_we_h[CSR_MINSTRETH & 'hF] : '1;
+  assign rvfi_csr_rdata_d.minstreth          = !mhpmcounter_h_during_wb[CSR_MINSTRETH & 'hF] ? csr_mhpmcounter_q_h [CSR_MINSTRETH & 'hF] : mhpmcounter_h_rdata_q[CSR_MINSTRETH & 'hF];
+  assign rvfi_csr_wdata_d.minstreth          = !mhpmcounter_h_during_wb[CSR_MINSTRETH & 'hF] ? csr_mhpmcounter_n_h [CSR_MINSTRETH & 'hF] : mhpmcounter_h_wdata_q[CSR_MINSTRETH & 'hF];
+  assign rvfi_csr_wmask_d.minstreth          = !mhpmcounter_h_during_wb[CSR_MINSTRETH & 'hF] ? csr_mhpmcounter_we_h[CSR_MINSTRETH & 'hF] : '1;
 
   assign rvfi_csr_rdata_d.mhpmcounterh[ 2:0] = 'Z;
   assign rvfi_csr_wdata_d.mhpmcounterh[ 2:0] = 'Z;  // Does not exist
   assign rvfi_csr_wmask_d.mhpmcounterh[ 2:0] = '0;
-  assign rvfi_csr_rdata_d.mhpmcounterh[31:3] = csr_mhpmcounter_q_h [31:3];
-  assign rvfi_csr_wdata_d.mhpmcounterh[31:3] = csr_mhpmcounter_n_h [31:3];
-  assign rvfi_csr_wmask_d.mhpmcounterh[31:3] = csr_mhpmcounter_we_h[31:3];
+
+  // Used flopped values in case write happened before wb_valid
+  generate
+    for (genvar i = 3; i < 32; i++) begin
+      assign rvfi_csr_rdata_d.mhpmcounterh[i]  = !mhpmcounter_h_during_wb[i] ? csr_mhpmcounter_q_h [i] : mhpmcounter_h_rdata_q[i];
+      assign rvfi_csr_wdata_d.mhpmcounterh[i]  = !mhpmcounter_h_during_wb[i] ? csr_mhpmcounter_n_h [i] : mhpmcounter_h_wdata_q[i];
+      assign rvfi_csr_wmask_d.mhpmcounterh[i]  = !mhpmcounter_h_during_wb[i] ? csr_mhpmcounter_we_h[i] : '1;
+    end
+  endgenerate
 
   assign ex_csr_rdata_d.cycle                = csr_mhpmcounter_q_l [CSR_CYCLE & 'hF];
   assign rvfi_csr_rdata_d.cycle              = ex_csr_rdata.cycle;

--- a/rtl/cv32e40x_controller.sv
+++ b/rtl/cv32e40x_controller.sv
@@ -127,6 +127,7 @@ module cv32e40x_controller import cv32e40x_pkg::*;
     .branch_decision_ex_i        ( branch_decision_ex_i     ),
     .ex_valid_i                  ( ex_valid_i               ),
     .obi_data_req_i              ( obi_data_req_i           ),
+    .lsu_split_ex_i              ( lsu_split_ex_i           ),
 
     // From WB stage
     .lsu_err_wb_i                ( lsu_err_wb_i             ),

--- a/rtl/cv32e40x_controller_fsm.sv
+++ b/rtl/cv32e40x_controller_fsm.sv
@@ -55,6 +55,7 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
   input  id_ex_pipe_t id_ex_pipe_i,        
   input  logic        branch_decision_ex_i,       // branch decision signal from EX ALU
   input  logic        obi_data_req_i,             // LSU OBI interface req
+  input  logic        lsu_split_ex_i,             // LSU is splitting misaligned, first half is in EX
 
   // From WB stage
   input  logic        lsu_err_wb_i,               // LSU caused bus_error in WB stage, gated with data_rvalid_i inside load_store_unit
@@ -159,6 +160,8 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
   logic       fencei_flush_req_set;
   logic       fencei_req_and_ack_q;
   logic       fencei_ongoing;    
+
+  logic       wb_minstret_event;
 
   assign fencei_ready = 1'b1; // TODO: connect when write buffer is implemented
 
@@ -296,7 +299,7 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
   assign nmi_allowed = interrupt_allowed;
 
   // Performance counter events
-  assign ctrl_fsm_o.mhpmevent.minstret = wb_valid_i && !exception_in_wb && !trigger_match_in_wb;
+  assign ctrl_fsm_o.mhpmevent.minstret = wb_minstret_event && !exception_in_wb && !trigger_match_in_wb && !ctrl_fsm_o.kill_wb && !ctrl_fsm_o.halt_wb;
   assign ctrl_fsm_o.mhpmevent.load = 1'b0; // todo:low
   assign ctrl_fsm_o.mhpmevent.store = 1'b0; // todo:low
   assign ctrl_fsm_o.mhpmevent.jump = 1'b0; // todo:low
@@ -797,6 +800,25 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
       end
       else if (fencei_flush_req_set) begin
         fencei_flush_req_o <= 1'b1;
+      end
+    end
+  end
+
+  // minstret event
+  always_ff @(posedge clk, negedge rst_n) begin
+    if (rst_n == 1'b0) begin
+      wb_minstret_event <= 1'b0;
+    end else begin
+      // Minstret event for first cycle of WB
+      // First half of misaligned split will not count
+      if(ex_valid_i && wb_ready_i && !lsu_split_ex_i) begin
+        wb_minstret_event <= 1'b1;
+      end else begin
+        // Clear event to make sure only first cycle of WB counts
+        // unless WB is halted (for fence.i for example), then we must wait until un-halt to clear event flag
+        if(!ctrl_fsm_o.halt_wb) begin
+          wb_minstret_event <= 1'b0;
+        end
       end
     end
   end


### PR DESCRIPTION
Instead of using wb_valid which factors in data_rvalid_i,
minstret is counted for the first cycle of a valid instruction in WB.
For LSU instructions with stalls on rvalid, this means we count before the instruction retires.
RVFI is altered to detect this and report correct values for the retired instruction.

Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>