### PR TITLE
Timing fix: Performance counter event not flopped

### DIFF
--- a/rtl/cv32e40x_cs_registers.sv
+++ b/rtl/cv32e40x_cs_registers.sv
@@ -783,7 +783,7 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
   /////////////////////////////////////////////////////////////////
 
   // Flop certain events to ease timing
-  localparam bit [15:0] HPM_EVENT_FLOP     = 16'b1011_1111_1100_0000;
+  localparam bit [15:0] HPM_EVENT_FLOP     = 16'b1111_1111_1100_0000;
   localparam bit [31:0] MCOUNTINHIBIT_MASK = {{(29-NUM_MHPMCOUNTERS){1'b0}},{(NUM_MHPMCOUNTERS){1'b1}},3'b101};
   
   logic [15:0]          hpm_events_raw;


### PR DESCRIPTION
Performance counter event for jr_stall was not flopped, leading to bad timing.

Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>