### PR TITLE
Redirect extension interface into submodules

### DIFF
--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -89,7 +89,12 @@ module cv32e40x_wrapper
   input  logic        data_exokay_i,
 
   // eXtension interface
-  if_core_v_xif.cpu   if_xif,
+  if_core_v_xif.cpu_compressed if_xif_compressed,
+  if_core_v_xif.cpu_issue      if_xif_issue,
+  if_core_v_xif.cpu_commit     if_xif_commit,
+  if_core_v_xif.cpu_mem        if_xif_mem,
+  if_core_v_xif.cpu_mem_result if_xif_mem_result,
+  if_core_v_xif.cpu_result     if_xif_result,
 
   // Interrupt inputs
   input  logic [31:0] irq_i,                    // CLINT interrupts + CLINT extension interrupts

--- a/rtl/cv32e40x_core.sv
+++ b/rtl/cv32e40x_core.sv
@@ -78,7 +78,12 @@ module cv32e40x_core import cv32e40x_pkg::*;
   input  logic        data_exokay_i,
 
   // eXtension interface
-  if_core_v_xif.cpu   if_xif,
+  if_core_v_xif.cpu_compressed if_xif_compressed,
+  if_core_v_xif.cpu_issue      if_xif_issue,
+  if_core_v_xif.cpu_commit     if_xif_commit,
+  if_core_v_xif.cpu_mem        if_xif_mem,
+  if_core_v_xif.cpu_mem_result if_xif_mem_result,
+  if_core_v_xif.cpu_result     if_xif_result,
 
   // Interrupt inputs
   input  logic [31:0] irq_i,                    // CLINT interrupts + CLINT extension interrupts
@@ -263,19 +268,6 @@ module cv32e40x_core import cv32e40x_pkg::*;
   assign irq_id  = ctrl_fsm.irq_id;
   assign dbg_ack = ctrl_fsm.dbg_ack;
 
-  // Drive all eXtension interface outputs to 0 for now
-  assign if_xif.x_compressed_valid = '0;
-  assign if_xif.x_compressed_req   = '0;
-  assign if_xif.x_issue_valid      = '0;
-  assign if_xif.x_issue_req        = '0;
-  assign if_xif.x_commit_valid     = '0;
-  assign if_xif.x_commit           = '0;
-  assign if_xif.x_mem_ready        = '0;
-  assign if_xif.x_mem_resp         = '0;
-  assign if_xif.x_mem_result_valid = '0;
-  assign if_xif.x_mem_result       = '0;
-  assign if_xif.x_result_ready     = '0;
-
   //////////////////////////////////////////////////////////////////////////////////////////////
   //   ____ _            _      __  __                                                   _    //
   //  / ___| | ___   ___| | __ |  \/  | __ _ _ __   __ _  __ _  ___ _ __ ___   ___ _ __ | |_  //
@@ -370,7 +362,10 @@ module cv32e40x_core import cv32e40x_pkg::*;
 
     // Pipeline handshakes
     .if_valid_o          ( if_valid                  ),
-    .id_ready_i          ( id_ready                  )
+    .id_ready_i          ( id_ready                  ),
+
+    // eXtension interface
+    .if_xif_compressed   ( if_xif_compressed         )
   );
 
 
@@ -438,7 +433,11 @@ module cv32e40x_core import cv32e40x_pkg::*;
     // Pipeline handshakes
     .id_ready_o                   ( id_ready                  ),
     .id_valid_o                   ( id_valid                  ),
-    .ex_ready_i                   ( ex_ready                  )
+    .ex_ready_i                   ( ex_ready                  ),
+
+    // eXtension interface
+    .if_xif_issue                 ( if_xif_issue              ),
+    .if_xif_commit                ( if_xif_commit             )
   );
 
 
@@ -536,7 +535,11 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .valid_1_i             ( lsu_valid_wb       ), // Second LSU stage (WB)
     .ready_1_o             ( lsu_ready_1        ),
     .valid_1_o             ( lsu_valid_1        ),
-    .ready_1_i             ( lsu_ready_wb       )
+    .ready_1_i             ( lsu_ready_wb       ),
+
+    // eXtension interface
+    .if_xif_mem            ( if_xif_mem         ),
+    .if_xif_mem_result     ( if_xif_mem_result  )
   );
 
   ////////////////////////////////////////////////////////////////////////////////////////
@@ -574,7 +577,10 @@ module cv32e40x_core import cv32e40x_pkg::*;
 
     // Valid/ready
     .wb_ready_o                 ( wb_ready                     ),
-    .wb_valid_o                 ( wb_valid                     )
+    .wb_valid_o                 ( wb_valid                     ),
+
+    // eXtension interface
+    .if_xif_result              ( if_xif_result                )
   );
 
   //////////////////////////////////////

--- a/rtl/cv32e40x_id_stage.sv
+++ b/rtl/cv32e40x_id_stage.sv
@@ -19,6 +19,7 @@
 //                 Davide Schiavone - pschiavo@iis.ee.ethz.ch                 //
 //                 Halfdan Bechmann - halfdan.bechmann@silabs.com             //
 //                 Øystein Knauserud - oystein.knauserud@silabs.com           //
+//                 Michael Platzer - michael.platzer@tuwien.ac.at             //
 //                                                                            //
 // Design Name:    Instruction Decode Stage                                   //
 // Project Name:   RI5CY                                                      //
@@ -89,7 +90,11 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
   // Stage ready/valid
   output logic        id_ready_o,     // ID stage is ready for new data
   output logic        id_valid_o,     // ID stage has valid (non-bubble) data for next stage
-  input  logic        ex_ready_i      // EX stage is ready for new data
+  input  logic        ex_ready_i,     // EX stage is ready for new data
+
+  // eXtension interface
+  if_core_v_xif.cpu_issue  if_xif_issue,
+  if_core_v_xif.cpu_commit if_xif_commit
 );
 
   // Source/Destination register instruction index
@@ -595,5 +600,11 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
 
   // multi_cycle_id_stall is currently tied to 1'b0. Will be used for Zce push/pop instructions.
   assign id_valid_o = instr_valid || (multi_cycle_id_stall && !ctrl_fsm_i.kill_id && !ctrl_fsm_i.halt_id);
+
+  // Drive eXtension interface outputs to 0 for now
+  assign if_xif_issue.x_issue_valid   = '0;
+  assign if_xif_issue.x_issue_req     = '0;
+  assign if_xif_commit.x_commit_valid = '0;
+  assign if_xif_commit.x_commit       = '0;
 
 endmodule // cv32e40x_id_stage

--- a/rtl/cv32e40x_if_stage.sv
+++ b/rtl/cv32e40x_if_stage.sv
@@ -15,6 +15,7 @@
 //                 Igor Loi - igor.loi@unibo.it                               //
 //                 Andreas Traber - atraber@student.ethz.ch                   //
 //                 Sven Stucki - svstucki@student.ethz.ch                     //
+//                 Michael Platzer - michael.platzer@tuwien.ac.at             //
 //                                                                            //
 // Design Name:    Instruction Fetch Stage                                    //
 // Project Name:   RI5CY                                                      //
@@ -75,7 +76,10 @@ module cv32e40x_if_stage import cv32e40x_pkg::*;
 
     // Pipeline handshakes
     output logic        if_valid_o,
-    input  logic        id_ready_i
+    input  logic        id_ready_i,
+
+    // eXtension interface
+    if_core_v_xif.cpu_compressed if_xif_compressed
 );
 
   logic              if_ready;
@@ -289,5 +293,9 @@ instruction_obi_i
     .is_compressed_o ( instr_compressed_int    ),
     .illegal_instr_o ( illegal_c_insn          )
   );
+
+  // Drive eXtension interface outputs to 0 for now
+  assign if_xif_compressed.x_compressed_valid = '0;
+  assign if_xif_compressed.x_compressed_req   = '0;
 
 endmodule // cv32e40x_if_stage

--- a/rtl/cv32e40x_load_store_unit.sv
+++ b/rtl/cv32e40x_load_store_unit.sv
@@ -14,6 +14,7 @@
 // Additional contributions by:                                               //
 //                 Andreas Traber - atraber@iis.ee.ethz.ch                    //
 //                 Øystein Knauserud - oystein.knauserud@silabs.com           //
+//                 Michael Platzer - michael.platzer@tuwien.ac.at             //
 //                                                                            //
 // Design Name:    Load Store Unit                                            //
 // Project Name:   RI5CY                                                      //
@@ -62,7 +63,11 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
   input  logic        valid_1_i,        // Handshakes for second LSU stage (WB)
   output logic        ready_1_o,        // LSU ready for new data in WB stage
   output logic        valid_1_o,
-  input  logic        ready_1_i
+  input  logic        ready_1_i,
+
+  // eXtension interface
+  if_core_v_xif.cpu_mem        if_xif_mem,
+  if_core_v_xif.cpu_mem_result if_xif_mem_result
 );
 
   localparam DEPTH = 2;                 // Maximum number of outstanding transactions
@@ -618,5 +623,11 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
 
     .m_c_obi_data_if       ( m_c_obi_data_if   )
   );
+
+  // Drive eXtension interface outputs to 0 for now
+  assign if_xif_mem.x_mem_ready               = '0;
+  assign if_xif_mem.x_mem_resp                = '0;
+  assign if_xif_mem_result.x_mem_result_valid = '0;
+  assign if_xif_mem_result.x_mem_result       = '0;
 
 endmodule // cv32e40x_load_store_unit

--- a/rtl/cv32e40x_wb_stage.sv
+++ b/rtl/cv32e40x_wb_stage.sv
@@ -23,6 +23,7 @@
 //                                                                            //
 // Additional contributions by:                                               //
 //                 Øystein Knauserud - oystein.knauserud@silabs.com           //
+//                 Michael Platzer - michael.platzer@tuwien.ac.at             //
 //                                                                            //
 // Design Name:    Write Back stage                                           //
 // Project Name:   CV32E40X                                                   //
@@ -64,7 +65,10 @@ module cv32e40x_wb_stage import cv32e40x_pkg::*;
 
   // Stage ready/valid
   output logic          wb_ready_o,
-  output logic          wb_valid_o
+  output logic          wb_valid_o,
+
+  // eXtension interface
+  if_core_v_xif.cpu_result if_xif_result
 );
 
   logic                 instr_valid;
@@ -140,5 +144,8 @@ module cv32e40x_wb_stage import cv32e40x_pkg::*;
 
   // Export signal indicating WB stage stalled by load/store
   assign data_stall_o = (ex_wb_pipe_i.lsu_en && !lsu_valid_i) && !wb_valid;
+
+  // Drive eXtension interface outputs to 0 for now
+  assign if_xif_result.x_result_ready = '0;
   
 endmodule // cv32e40x_wb_stage

--- a/rtl/if_core_v_xif.sv
+++ b/rtl/if_core_v_xif.sv
@@ -142,46 +142,66 @@ interface if_core_v_xif import cv32e40x_pkg::*;
 
 
   // Port directions for host CPU
-  modport cpu (
+  modport cpu_compressed (
     output x_compressed_valid,
     input  x_compressed_ready,
     output x_compressed_req,
-    input  x_compressed_resp,
+    input  x_compressed_resp
+  );
+  modport cpu_issue (
     output x_issue_valid,
     input  x_issue_ready,
     output x_issue_req,
-    input  x_issue_resp,
+    input  x_issue_resp
+  );
+  modport cpu_commit (
     output x_commit_valid,
-    output x_commit,
+    output x_commit
+  );
+  modport cpu_mem (
     input  x_mem_valid,
     output x_mem_ready,
     input  x_mem_req,
-    output x_mem_resp,
+    output x_mem_resp
+  );
+  modport cpu_mem_result (
     output x_mem_result_valid,
-    output x_mem_result,
+    output x_mem_result
+  );
+  modport cpu_result (
     input  x_result_valid,
     output x_result_ready,
     input  x_result
   );
 
   // Port directions for extension
-  modport coproc (
+  modport coproc_compressed (
     input  x_compressed_valid,
     output x_compressed_ready,
     input  x_compressed_req,
-    output x_compressed_resp,
+    output x_compressed_resp
+  );
+  modport coproc_issue (
     input  x_issue_valid,
     output x_issue_ready,
     input  x_issue_req,
-    output x_issue_resp,
+    output x_issue_resp
+  );
+  modport coproc_commit (
     input  x_commit_valid,
-    input  x_commit,
+    input  x_commit
+  );
+  modport coproc_mem (
     output x_mem_valid,
     input  x_mem_ready,
     output x_mem_req,
-    input  x_mem_resp,
+    input  x_mem_resp
+  );
+  modport coproc_mem_result (
     input  x_mem_result_valid,
-    input  x_mem_result,
+    input  x_mem_result
+  );
+  modport coproc_result (
     output x_result_valid,
     input  x_result_ready,
     output x_result


### PR DESCRIPTION
This PR splits the modports of the extension interface into individual modports for the `compressed`, `issue`, `commit`, `mem`, `mem_result`, and `result` interfaces, which allows to wire these ports to the respective units within CV32E40X.