### PR TITLE
Single step + interrupt might not retire any instructions

### DIFF
--- a/rtl/cv32e40x_ex_stage.sv
+++ b/rtl/cv32e40x_ex_stage.sv
@@ -33,7 +33,7 @@ module cv32e40x_ex_stage import cv32e40x_pkg::*;
 (
   input  logic        clk,
   input  logic        rst_n,
-
+  
   // ID/EX pipeline
   input id_ex_pipe_t  id_ex_pipe_i,
 

--- a/rtl/cv32e40x_ex_stage.sv
+++ b/rtl/cv32e40x_ex_stage.sv
@@ -33,7 +33,7 @@ module cv32e40x_ex_stage import cv32e40x_pkg::*;
 (
   input  logic        clk,
   input  logic        rst_n,
-  
+
   // ID/EX pipeline
   input id_ex_pipe_t  id_ex_pipe_i,
 


### PR DESCRIPTION
If the core is stepping an interruptible instruction and an interrupt is asserted, the core will take the interrupt and not retire any instructions before entering debug mode. mepc/mcause is set according to the taken interrupt, and dpc will point to the first instruction of the interrupt handler.

This is in line with debug spec v1.0.0