### PR TITLE
Implement X_EXT, instruction IDs, and stalls in case of data hazards for the CORE-V-XIF

### DIFF
--- a/rtl/cv32e40x_controller_bypass.sv
+++ b/rtl/cv32e40x_controller_bypass.sv
@@ -159,10 +159,10 @@ module cv32e40x_controller_bypass import cv32e40x_pkg::*;
       ctrl_byp_o.deassert_we = 1'b1;
     end
 
-    // Stall because of load operation
+    // Stall because of load or XIF operation
     if (
-        (id_ex_pipe_i.lsu_en && rf_we_ex && |rf_rd_ex_hz) || // load-use hazard (EX)
-        (!wb_ready_i         && rf_we_wb && |rf_rd_wb_hz)    // load-use hazard (WB during wait-state)
+        ((id_ex_pipe_i.lsu_en || id_ex_pipe_i.xif_en) && rf_we_ex && |rf_rd_ex_hz) || // load-use hazard (EX)
+        (!wb_ready_i                                  && rf_we_wb && |rf_rd_wb_hz)    // load-use hazard (WB during wait-state)
        )
     begin
       ctrl_byp_o.load_stall  = 1'b1;

--- a/rtl/cv32e40x_controller_fsm.sv
+++ b/rtl/cv32e40x_controller_fsm.sv
@@ -886,7 +886,7 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
   // which ensures that only one offloaded instruction is committed at a time and
   // thus the coprocessor is forced to return results in order)
   assign xif_commit_if.x_commit_valid       = ex_valid_i && wb_ready_i && id_ex_pipe_i.xif_en;
-  assign xif_commit_if.x_commit.id          = '0;   // TODO: use an actual id
+  assign xif_commit_if.x_commit.id          = id_ex_pipe_i.xif_id;
   assign xif_commit_if.x_commit.commit_kill = 1'b0; // TODO: when should the offloaded instr be killed?
 
 endmodule //cv32e40x_controller_fsm

--- a/rtl/cv32e40x_core.sv
+++ b/rtl/cv32e40x_core.sv
@@ -369,7 +369,8 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .id_ready_i          ( id_ready                  ),
 
     // eXtension interface
-    .xif_compressed_if   ( xif_compressed_if         )
+    .xif_compressed_if   ( xif_compressed_if         ),
+    .id_offload_i        ( xif_issue_if.x_issue_valid )
   );
 
 

--- a/rtl/cv32e40x_core.sv
+++ b/rtl/cv32e40x_core.sv
@@ -34,6 +34,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
   parameter NUM_MHPMCOUNTERS             =  1,
   parameter LIB                          =  0,
   parameter b_ext_e B_EXT                =  NONE,
+  parameter bit     X_EXT                =  0,
   parameter int          PMA_NUM_REGIONS =  0,
   parameter pma_region_t PMA_CFG[PMA_NUM_REGIONS-1:0] = '{default:PMA_R_DEFAULT}
 )
@@ -316,6 +317,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
   //////////////////////////////////////////////////
   cv32e40x_if_stage
     #(.A_EXTENSION(A_EXTENSION),
+      .X_EXT      ( X_EXT ),
       .PMA_NUM_REGIONS(PMA_NUM_REGIONS),
       .PMA_CFG(PMA_CFG))
   if_stage_i
@@ -382,7 +384,8 @@ module cv32e40x_core import cv32e40x_pkg::*;
   cv32e40x_id_stage
   #(
     .A_EXTENSION                  ( A_EXTENSION               ),
-    .B_EXT                        ( B_EXT                     )
+    .B_EXT                        ( B_EXT                     ),
+    .X_EXT                        ( X_EXT                     )
   )
   id_stage_i
   (

--- a/rtl/cv32e40x_ex_stage.sv
+++ b/rtl/cv32e40x_ex_stage.sv
@@ -280,6 +280,7 @@ module cv32e40x_ex_stage import cv32e40x_pkg::*;
       ex_wb_pipe_o.csr_wdata      <= 32'h00000000;
       ex_wb_pipe_o.trigger_match  <= 1'b0;
       ex_wb_pipe_o.xif_en         <= 1'b0;
+      ex_wb_pipe_o.xif_id         <= '0;
     end
     else
     begin
@@ -327,6 +328,7 @@ module cv32e40x_ex_stage import cv32e40x_pkg::*;
 
         // eXtension interface
         ex_wb_pipe_o.xif_en         <= id_ex_pipe_i.xif_en;
+        ex_wb_pipe_o.xif_id         <= id_ex_pipe_i.xif_id;
       end else if (wb_ready_i) begin
         // we are ready for a new instruction, but there is none available,
         // so we introduce a bubble

--- a/rtl/cv32e40x_id_stage.sv
+++ b/rtl/cv32e40x_id_stage.sv
@@ -502,6 +502,7 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
       id_ex_pipe_o.mret_insn              <= 1'b0;
       id_ex_pipe_o.dret_insn              <= 1'b0;
       id_ex_pipe_o.xif_en                 <= 1'b0;
+      id_ex_pipe_o.xif_id                 <= '0;
 
     end else begin
       // normal pipeline unstall case
@@ -584,6 +585,7 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
 
         // eXtension interface
         id_ex_pipe_o.xif_en                 <= xif_insn_accept;
+        id_ex_pipe_o.xif_id                 <= if_id_pipe_i.xif_id;
 
         id_ex_pipe_o.trigger_match          <= if_id_pipe_i.trigger_match;
 
@@ -638,6 +640,7 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
 
       assign xif_issue_if.x_issue_req.instr     = instr;
       assign xif_issue_if.x_issue_req.mode      = PRIV_LVL_M;
+      assign xif_issue_if.x_issue_req.id        = if_id_pipe_i.xif_id;
       always_comb begin
         xif_issue_if.x_issue_req.rs       = '0;
         xif_issue_if.x_issue_req.rs_valid = '0;
@@ -658,7 +661,6 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
       assign xif_issue_if.x_issue_req.frs       = '{default: '0};
       assign xif_issue_if.x_issue_req.frs_valid = '0;
 
-  assign xif_issue_if.x_issue_req.id        = '0; // TODO: use an actual id instead of 0
       // need to wait if the coprocessor is not ready and has not already accepted or rejected the instruction
       assign xif_waiting = xif_issue_if.x_issue_valid && !xif_issue_if.x_issue_ready && !xif_accepted_q && !xif_rejected_q;
 

--- a/rtl/cv32e40x_if_stage.sv
+++ b/rtl/cv32e40x_if_stage.sv
@@ -28,6 +28,7 @@
 
 module cv32e40x_if_stage import cv32e40x_pkg::*;
   #(parameter bit          A_EXTENSION     = 0,
+    parameter bit          X_EXT           = 0,
     parameter int          PMA_NUM_REGIONS = 0,
     parameter pma_region_t PMA_CFG[PMA_NUM_REGIONS-1:0] = '{default:PMA_R_DEFAULT})
 (
@@ -298,8 +299,24 @@ instruction_obi_i
     .illegal_instr_o ( illegal_c_insn          )
   );
 
-  // Drive eXtension interface outputs to 0 for now
-  assign xif_compressed_if.x_compressed_valid = '0;
-  assign xif_compressed_if.x_compressed_req   = '0;
+
+  //---------------------------------------------------------------------------
+  // eXtension interface
+  //---------------------------------------------------------------------------
+
+  generate
+    if (X_EXT) begin
+
+      // TODO: implement offloading of compressed instruction
+      assign xif_compressed_if.x_compressed_valid = '0;
+      assign xif_compressed_if.x_compressed_req   = '0;
+
+    end else begin
+
+      assign xif_compressed_if.x_compressed_valid = '0;
+      assign xif_compressed_if.x_compressed_req   = '0;
+
+    end
+  endgenerate
 
 endmodule // cv32e40x_if_stage

--- a/rtl/cv32e40x_wb_stage.sv
+++ b/rtl/cv32e40x_wb_stage.sv
@@ -156,6 +156,7 @@ module cv32e40x_wb_stage import cv32e40x_pkg::*;
 
   // TODO: How to handle conflicting values of ex_wb_pipe_i.rf_waddr and xif_result_if.x_result.rd?
   // TODO: How to handle conflicting values of ex_wb_pipe_i.rf_we (based on xif_issue_if.x_issue_resp.writeback in ID) and xif_result_if.x_result.we?
+  // TODO: Check whether result IDs match the instruction IDs propagated along the pipeline
 
   // Need to wait for the result
   assign xif_waiting = ex_wb_pipe_i.instr_valid && ex_wb_pipe_i.xif_en && !xif_result_if.x_result_valid;

--- a/rtl/include/cv32e40x_pkg.sv
+++ b/rtl/include/cv32e40x_pkg.sv
@@ -569,6 +569,10 @@ parameter logic [31:0] TMATCH_CONTROL_RST_VAL = {
   1'b0,                  // store   : not supported
   1'b0};                 // load    : not supported
 
+// eXtension Interface constant parameters
+parameter int X_DATAWIDTH = 32;  // Width of an integer register in bits. Must be equal to XLEN
+parameter int X_NUM_FRS   = 2;   // Number of floating-point register file read ports that can be used by the eXtension interface
+parameter int X_ID_WIDTH  = 3;   // Identification width for the eXtension interface
 
 ///////////////////////////////////////////////
 //   ___ ____    ____  _                     //
@@ -933,6 +937,7 @@ typedef struct packed {
   logic [15:0] compressed_instr;
   logic        illegal_c_insn;
   logic        trigger_match;
+  logic [X_ID_WIDTH-1:0] xif_id;  // ID of offloaded instruction
 } if_id_pipe_t;
 
 // ID/EX pipeline
@@ -994,6 +999,7 @@ typedef struct packed {
 
   // eXtension interface
   logic         xif_en;           // Instruction has been offloaded via eXtension interface
+  logic [X_ID_WIDTH-1:0] xif_id;  // ID of offloaded instruction
 } id_ex_pipe_t;
 
 // EX/WB pipeline
@@ -1029,6 +1035,7 @@ typedef struct packed {
 
   // eXtension interface
   logic         xif_en;           // Instruction has been offloaded via eXtension interface
+  logic [X_ID_WIDTH-1:0] xif_id;  // ID of offloaded instruction
 } ex_wb_pipe_t;
 
 // Performance counter events
@@ -1136,8 +1143,4 @@ typedef struct packed {
   // Enum used for configuration of B extension
   typedef enum logic [1:0] {NONE, ZBA_ZBB_ZBS, ZBA_ZBB_ZBC_ZBS} b_ext_e;
 
-  // eXtension Interface constant parameters
-  parameter int X_DATAWIDTH = 32;  // Width of an integer register in bits. Must be equal to XLEN
-  parameter int X_NUM_FRS   = 2;   // Number of floating-point register file read ports that can be used by the eXtension interface
-  parameter int X_ID_WIDTH  = 3;   // Identification width for the eXtension interface
 endpackage


### PR DESCRIPTION
This PR continues implementation of the CORE-V-XIF eXtension interface by adding the `X_EXT` parameter to enable/disable the XIF, instruction IDs, and stalls in case there is a data hazard for an XIF instruction in the EX stage.