### PR TITLE
Fix forwarding of parameter X_EXT in controller_fsm

### DIFF
--- a/rtl/cv32e40x_controller.sv
+++ b/rtl/cv32e40x_controller.sv
@@ -30,6 +30,9 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 module cv32e40x_controller import cv32e40x_pkg::*;
+#(
+  parameter bit       X_EXT           = 0
+)
 (
   input  logic        clk,                        // Gated clock
   input  logic        clk_ungated_i,              // Ungated clock
@@ -106,7 +109,11 @@ module cv32e40x_controller import cv32e40x_pkg::*;
 );
 
   // Main FSM and debug FSM
-  cv32e40x_controller_fsm controller_fsm_i
+  cv32e40x_controller_fsm
+  #(
+    .X_EXT                       ( X_EXT                    )
+  )
+  controller_fsm_i
   (
     // Clocks and reset
     .clk                         ( clk                      ),

--- a/rtl/cv32e40x_controller_fsm.sv
+++ b/rtl/cv32e40x_controller_fsm.sv
@@ -31,7 +31,7 @@
 
 module cv32e40x_controller_fsm import cv32e40x_pkg::*;
 #(
-  parameter int       X_EXT
+  parameter bit       X_EXT           = 0
 )
 (
   // Clocks and reset

--- a/rtl/cv32e40x_core.sv
+++ b/rtl/cv32e40x_core.sv
@@ -659,7 +659,11 @@ module cv32e40x_core import cv32e40x_pkg::*;
   //   \____\___/|_| \_| |_| |_| \_\\___/|_____|_____|_____|_| \_\  //
   //                                                                //
   ////////////////////////////////////////////////////////////////////
-  cv32e40x_controller controller_i
+  cv32e40x_controller
+  #(
+    .X_EXT                          ( X_EXT                  )
+  )
+  controller_i
   (
     .clk                            ( clk                    ),         // Gated clock
     .clk_ungated_i                  ( clk_i                  ),         // Ungated clock


### PR DESCRIPTION
In commit 5e09ef24 when adding an X_EXT-based generate block to `cv32e40x_controller_fsm.sv` I forgot to forward the value of `X_EXT` to that module.