### PR TITLE
Fix Issue 257

### DIFF
--- a/docs/user_manual/source/pma.rst
+++ b/docs/user_manual/source/pma.rst
@@ -36,7 +36,7 @@ load access fault (exception code 5). An attempt to perform a non-naturally alig
 
 Bufferable and Cacheable
 ~~~~~~~~~~~~~~~~~~~~~~~~
-Accesses to regions marked as bufferable (``bufferable=1``) will result in the OBI mem_type[0] bit being set.
+Accesses to regions marked as bufferable (``bufferable=1``) will result in the OBI mem_type[0] bit being set, except if the access was an instruction fetch, a load, or part of an atomic memory operation.
 Accesses to regions marked as cacheable (``cacheable=1``) will result in the OBI mem_type[1] bit being set.
 
 Atomic operations

--- a/rtl/cv32e40x_mpu.sv
+++ b/rtl/cv32e40x_mpu.sv
@@ -69,8 +69,8 @@ module cv32e40x_mpu import cv32e40x_pkg::*;
   logic        bus_trans_cacheable;
   logic        bus_trans_bufferable;
   logic        core_trans_we;
-  logic        execute_access;
-  logic        speculative_access;
+  logic        instr_fetch_access;
+  logic        load_access;
   
   // FSM that will "consume" transfers failing PMA checks.
   // Upon failing checks, this FSM will prevent the transfer from going out on the bus
@@ -172,10 +172,10 @@ module cv32e40x_mpu import cv32e40x_pkg::*;
       .PMA_CFG(PMA_CFG))
   pma_i
     (.trans_addr_i(core_trans_i.addr),
-     .speculative_access_i(speculative_access),
+     .instr_fetch_access_i(instr_fetch_access),
      .atomic_access_i(atomic_access_i),
-     .execute_access_i(execute_access),
      .misaligned_access_i(misaligned_access_i),
+     .load_access_i(load_access),
      .pma_err_o(pma_err),
      .pma_bufferable_o(bus_trans_bufferable),
      .pma_cacheable_o(bus_trans_cacheable));
@@ -187,14 +187,14 @@ module cv32e40x_mpu import cv32e40x_pkg::*;
   // Tie to 1'b0 if this MPU is instantiatied in the IF stage
   generate
     if (IF_STAGE) begin: mpu_if
+      assign instr_fetch_access = 1'b1;
+      assign load_access        = 1'b0;
       assign core_trans_we      = 1'b0;
-      assign execute_access     = 1'b1;
-      assign speculative_access = 1'b1;
     end
     else begin: mpu_lsu
+      assign instr_fetch_access = 1'b0;
+      assign load_access        = !core_trans_i.we;
       assign core_trans_we      = core_trans_i.we;
-      assign execute_access     = 1'b0;
-      assign speculative_access = 1'b0;
     end
   endgenerate
 

--- a/sva/cv32e40x_mpu_sva.sv
+++ b/sva/cv32e40x_mpu_sva.sv
@@ -180,8 +180,8 @@ module cv32e40x_mpu_sva import cv32e40x_pkg::*; import uvm_pkg::*;
       pma_expected_cfg = is_pma_matched ? PMA_CFG[pma_lowest_match] : PMA_R_DEFAULT;
     end
   end
-  assign pma_expected_err = (instr_fetch_access && !pma_expected_cfg.main) ||
-                            (misaligned_access_i && !pma_expected_cfg.main)                    ||
+  assign pma_expected_err = (instr_fetch_access && !pma_expected_cfg.main)  ||
+                            (misaligned_access_i && !pma_expected_cfg.main) ||
                             (atomic_access_i && !pma_expected_cfg.atomic);
   a_pma_expect_cfg :
     assert property (@(posedge clk) disable iff (!rst_n) pma_cfg == pma_expected_cfg)

--- a/sva/cv32e40x_mpu_sva.sv
+++ b/sva/cv32e40x_mpu_sva.sv
@@ -31,10 +31,9 @@ module cv32e40x_mpu_sva import cv32e40x_pkg::*; import uvm_pkg::*;
    input logic        clk,
    input logic        rst_n,
 
-   input logic        speculative_access,
+   input logic        instr_fetch_access,
    input logic        atomic_access_i,
    input logic        misaligned_access_i,
-   input logic        execute_access,
    input logic        bus_trans_bufferable,
    input logic        bus_trans_cacheable,
 
@@ -181,7 +180,7 @@ module cv32e40x_mpu_sva import cv32e40x_pkg::*; import uvm_pkg::*;
       pma_expected_cfg = is_pma_matched ? PMA_CFG[pma_lowest_match] : PMA_R_DEFAULT;
     end
   end
-  assign pma_expected_err = ((execute_access || speculative_access) && !pma_expected_cfg.main) ||
+  assign pma_expected_err = (instr_fetch_access && !pma_expected_cfg.main) ||
                             (misaligned_access_i && !pma_expected_cfg.main)                    ||
                             (atomic_access_i && !pma_expected_cfg.atomic);
   a_pma_expect_cfg :
@@ -248,7 +247,7 @@ module cv32e40x_mpu_sva import cv32e40x_pkg::*; import uvm_pkg::*;
 
   covergroup cg_pma @(posedge clk);
     cp_err: coverpoint pma_err;
-    cp_exec: coverpoint execute_access;
+    cp_instr: coverpoint instr_fetch_access;
     cp_bufferable: coverpoint bus_trans_bufferable;
     cp_cacheable: coverpoint bus_trans_cacheable;
     cp_atomic: coverpoint atomic_access_i;
@@ -259,7 +258,7 @@ module cv32e40x_mpu_sva import cv32e40x_pkg::*; import uvm_pkg::*;
       illegal_bins il = default;
       }
 
-    x_err_exec: cross cp_err, cp_exec;
+    x_err_instr: cross cp_err, cp_instr;
     x_err_bufferable: cross cp_err, cp_bufferable;
     x_err_cacheable: cross cp_err, cp_cacheable;
     x_err_atomic: cross cp_err, cp_atomic;


### PR DESCRIPTION
PMA will now classify instruction fetches, loads and atomic operations as non-bufferable.