### PR TITLE
Moved halt expression from lsu to WB

### DIFF
--- a/rtl/cv32e40x_load_store_unit.sv
+++ b/rtl/cv32e40x_load_store_unit.sv
@@ -449,7 +449,7 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
   // LSU second stage is ready if it is not being used (i.e. no outstanding transfers, cnt_q = 0),
   // or if it is being used and the awaited response arrives (resp_rvalid).
 
-  assign ready_1_o = (cnt_q == 2'b00) ? !ctrl_fsm_i.halt_wb : resp_valid && !ctrl_fsm_i.halt_wb && ready_1_i;
+  assign ready_1_o = (cnt_q == 2'b00) ? 1'b1 : resp_valid && !ctrl_fsm_i.halt_wb && ready_1_i;
 
   // LSU second stage is valid when resp_valid (typically data_rvalid_i) is received. For a misaligned/split
   // load/store only its second phase is marked as valid (last_q == 1'b1)

--- a/rtl/cv32e40x_wb_stage.sv
+++ b/rtl/cv32e40x_wb_stage.sv
@@ -125,7 +125,7 @@ module cv32e40x_wb_stage import cv32e40x_pkg::*;
   //////////////////////////////////////////////////////////////////////////////
   // Stage ready/valid
 
-  assign wb_ready_o = lsu_ready_i && !xif_waiting;
+  assign wb_ready_o = lsu_ready_i && !xif_waiting && !ctrl_fsm_i.halt_wb;
 
   // todo: Above hould have similar structure as ex_ready_o
   // todo: Want the following expression, but currently not SEC clean; might just be caused by fact that OBI assumes are not loaded during SEC


### PR DESCRIPTION
Moved halt signal from lsu ready expression to wb ready expression to make next write buffer PR cleaner.

SEC Clean change.

Signed-off-by: Halfdan Bechmann <halfdan.bechmann@silabs.com>