### PR TITLE
Fix MPU SVAs so the simulator can compile

### DIFF
--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -245,7 +245,7 @@ bind cv32e40x_sleep_unit:
              .obi_addr   (core_i.instr_addr_o),
              .obi_req    (core_i.instr_req_o),
              .obi_gnt    (core_i.instr_gnt_i),
-             .write_buffer_state(write_buffer_state_e'('0)),
+             .write_buffer_state(cv32e40x_pkg::WBUF_EMPTY),
              .write_buffer_valid_o('0),
              .write_buffer_txn_bufferable('0),
              .write_buffer_txn_cacheable('0),


### PR DESCRIPTION
Simulation failed to compile because it doesn't have support for "static cast" used while assigning signals in a bind.
Formal had no problem problem with it but simulation did.

With this PR, simulation can now compile, and the PMA assertions still pass formal for all 7 pma configs.

Note, the write buffer related PMA assertions are planned to be updated once the write buffer implementation is finished, so these assignments are only temporary.