### PR TITLE
Make dcsr.nmip available on RVFI rdata. Trig rvfi_intr on NMI.

### DIFF
--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -405,7 +405,7 @@ bind cv32e40x_sleep_unit:
          .csr_tinfo_q_i            ( {16'h0, core_i.cs_registers_i.tinfo_types}                           ),
          .csr_tinfo_we_i           ( core_i.cs_registers_i.csr_we_int &&
                                      (core_i.cs_registers_i.csr_waddr == CSR_TINFO)                       ),
-         .csr_dcsr_q_i             ( core_i.cs_registers_i.dcsr_q                                         ),
+         .csr_dcsr_q_i             ( core_i.cs_registers_i.dcsr_rdata                                     ),
          .csr_dcsr_n_i             ( core_i.cs_registers_i.dcsr_n                                         ),
          .csr_dcsr_we_i            ( core_i.cs_registers_i.dcsr_we                                        ),
          .csr_debug_csr_save_i     ( core_i.cs_registers_i.ctrl_fsm_i.debug_csr_save                      ),

--- a/bhv/include/cv32e40x_rvfi_pkg.sv
+++ b/bhv/include/cv32e40x_rvfi_pkg.sv
@@ -35,6 +35,7 @@ package cv32e40x_rvfi_pkg;
     logic [31:0] cycle;
     logic [31:0] cycleh;
     logic [31:0] mip;
+    logic        nmip;
   } rvfi_auto_csr_map_t;
 
   typedef struct packed {


### PR DESCRIPTION
Signed-off-by: Oivind Ekelund <oivind.ekelund@silabs.com>