### PR TITLE
add parameters to write_buffer RTL module for SVA

### DIFF
--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -272,8 +272,8 @@ bind cv32e40x_sleep_unit:
   bind cv32e40x_write_buffer:
     core_i.load_store_unit_i.write_buffer_i
     cv32e40x_write_buffer_sva
-             #(.PMA_NUM_REGIONS(core_i.PMA_NUM_REGIONS),
-               .PMA_CFG(core_i.PMA_CFG))
+             #(.PMA_NUM_REGIONS(PMA_NUM_REGIONS),
+               .PMA_CFG(PMA_CFG))
       write_buffer_sva(.*);
 
   bind cv32e40x_rvfi:

--- a/rtl/cv32e40x_load_store_unit.sv
+++ b/rtl/cv32e40x_load_store_unit.sv
@@ -52,7 +52,7 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
 
   // Stage 1 outputs (WB)
   output logic [31:0] lsu_addr_1_o,
-  output logic        lsu_err_1_o,           
+  output logic        lsu_err_1_o,
   output logic [31:0] lsu_rdata_1_o,            // LSU read data
   output mpu_status_e lsu_mpu_status_1_o,       // MPU (PMA) status, response/WB timing. To controller and wb_stage
 
@@ -84,7 +84,7 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
   logic [31:0]  resp_rdata;
   logic         resp_err;               // Unused for now
   data_resp_t   resp;
-  
+
   // Transaction request (from cv32e40x_mpu to cv32e40x_write_buffer)
   logic          buffer_trans_valid;
   logic          buffer_trans_ready;
@@ -98,7 +98,7 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
   // Transaction response (from cv32e40x_data_obi_interface to cv32e40x_mpu)
   logic           bus_resp_valid;
   obi_data_resp_t bus_resp;
-  
+
   // Counter to count maximum number of outstanding transactions
   logic [1:0]   cnt_q;                  // Transaction counter
   logic [1:0]   next_cnt;               // Next value for cnt_q
@@ -458,14 +458,14 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
   assign valid_1_o = (cnt_q == 2'b00) ? 1'b0 : last_q && resp_valid && valid_1_i; // todo:AB (cnt_q == 2'b00) should be same as !WB.lsu_en
 
   // LSU EX stage readyness requires two criteria to be met:
-  // 
+  //
   // - A data request has been forwarded/accepted (trans_valid && trans_ready)
   // - The LSU WB stage is available such that EX and WB can be updated in lock step
   //
   // Default (if there is not even a data request) LSU EX is signaled to be ready, else
   // if there are no outstanding transactions the EX stage is ready again once the transaction
   // request is accepted (at which time this load/store will move to the WB stage), else
-  // in case there is already at least one outstanding transaction (so WB is full) the EX 
+  // in case there is already at least one outstanding transaction (so WB is full) the EX
   // and WB stage can only signal readiness in lock step (so resp_valid is used as well).
 
   // todo:AB lsu_en_gated should maybe be replaced by valid_0_i
@@ -486,7 +486,7 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
   // otherwise we may let a new instruction into EX, overwriting second phase of split access..
   assign ready_0_o = done_0 && !lsu_split_0_o;
 
-  
+
 
   // Export mpu status to WB stage/controller
   assign lsu_mpu_status_1_o = resp.mpu_status;
@@ -496,11 +496,11 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
 
 
   //////////////////////////////////////////////////////////////////////////////
-  // Counter (cnt_q, next_cnt) to count number of outstanding OBI transactions 
+  // Counter (cnt_q, next_cnt) to count number of outstanding OBI transactions
   // (maximum = DEPTH)
-  // 
+  //
   // Counter overflow is prevented by limiting the number of outstanding transactions
-  // to DEPTH. Counter underflow is prevented by the assumption that resp_valid = 1 
+  // to DEPTH. Counter underflow is prevented by the assumption that resp_valid = 1
    // will only occur in response to accepted transfer request (as per the OBI protocol).
   //////////////////////////////////////////////////////////////////////////////
 
@@ -578,7 +578,7 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
   assign trans.prot[0]   = 1'b1;  // Transfers from LSU are data transfers
   assign trans.prot[2:1] = PRIV_LVL_M; // Machine mode
   assign trans.memtype   = 2'b00; // memtype is assigned in the MPU, tie off.
-  
+
   cv32e40x_mpu
   #(
     .IF_STAGE           ( 0                    ),
@@ -620,6 +620,10 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
   //////////////////////////////////////////////////////////////////////////////
 
   cv32e40x_write_buffer
+  #(
+    .PMA_NUM_REGIONS    ( PMA_NUM_REGIONS      ),
+    .PMA_CFG            ( PMA_CFG              )
+  )
   write_buffer_i
   (
     .clk                ( clk                ),

--- a/rtl/cv32e40x_write_buffer.sv
+++ b/rtl/cv32e40x_write_buffer.sv
@@ -29,8 +29,11 @@
 //                                                                            //
 ////////////////////////////////////////////////////////////////////////////////
 
-module cv32e40x_write_buffer
-  import cv32e40x_pkg::*;
+module cv32e40x_write_buffer import cv32e40x_pkg::*;
+#(
+  parameter int          PMA_NUM_REGIONS = 0,
+  parameter pma_region_t PMA_CFG[PMA_NUM_REGIONS-1:0] = '{default:PMA_R_DEFAULT}
+)
   (
    // clock and reset
    input logic           clk,


### PR DESCRIPTION
This avoids hierarchical parameters which are not supported in some simulators.  There should be no functional change introduced with this PR.

Fixes issues with Metrics/Dsim and latest RTL hash.  See this: https://github.com/openhwgroup/core-v-verif/pull/1010#issuecomment-964357559