### PR TITLE
Added check CSR instruction accepted by xif AND pipeline.

### DIFF
--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -179,6 +179,8 @@ module cv32e40x_wrapper
                               .lsu_outstanding_cnt (core_i.load_store_unit_i.cnt_q),
                               .rf_we_wb_i          (core_i.wb_stage_i.rf_we_wb_o  ),
                               .csr_we_i            (core_i.cs_registers_i.csr_we_int  ),
+                              .csr_illegal_i       (core_i.cs_registers_i.csr_illegal_o),
+                              .xif_commit_kill     (core_i.xif_commit_if.commit.commit_kill),
                               .*);
   bind cv32e40x_cs_registers:        core_i.cs_registers_i              cv32e40x_cs_registers_sva cs_registers_sva (.*);
 

--- a/rtl/cv32e40x_controller.sv
+++ b/rtl/cv32e40x_controller.sv
@@ -106,7 +106,8 @@ module cv32e40x_controller import cv32e40x_pkg::*;
   input logic         fencei_flush_ack_i,
 
   // eXtension interface
-  if_xif.cpu_commit   xif_commit_if
+  if_xif.cpu_commit   xif_commit_if,
+  input               xif_csr_error_i
 );
 
   // Main FSM and debug FSM
@@ -175,7 +176,8 @@ module cv32e40x_controller import cv32e40x_pkg::*;
     .ctrl_fsm_o                  ( ctrl_fsm_o               ),
     
     // eXtension interface
-    .xif_commit_if               ( xif_commit_if            )
+    .xif_commit_if               ( xif_commit_if            ),
+    .xif_csr_error_i             ( xif_csr_error_i          )
   );
 
 

--- a/rtl/cv32e40x_controller_fsm.sv
+++ b/rtl/cv32e40x_controller_fsm.sv
@@ -100,7 +100,8 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
   if_c_obi.monitor     m_c_obi_data_if,
 
   // eXtension interface
-  if_xif.cpu_commit    xif_commit_if
+  if_xif.cpu_commit    xif_commit_if,
+  input                xif_csr_error_i
 );
 
    // FSM state encoding
@@ -895,9 +896,12 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
       //       Perhaps not factor in wb_ready_i and uncoditionally signal commit_valid, preventing
       //       to commit the same instruction multiple times
       // TODO: data_gnt_i currently fans into commit_valid below. Can this be removed?
+      // TODO: Can only allow commit when older instructions are guaranteed to complete without exceptions
+      // TODO: If kill_ex is 1 (for taking exceptions from WB for intance), ex_valid_i will be 0 and we
+      //       cannot signal commit_kill properly
       assign xif_commit_if.commit_valid       = ex_valid_i && wb_ready_i && id_ex_pipe_i.xif_en;
       assign xif_commit_if.commit.id          = id_ex_pipe_i.xif_id;
-      assign xif_commit_if.commit.commit_kill = 1'b0; // TODO: when should the offloaded instr be killed?
+      assign xif_commit_if.commit.commit_kill = xif_csr_error_i; // TODO: when should the offloaded instr be killed?
 
     end else begin : no_x_ext
 

--- a/rtl/cv32e40x_controller_fsm.sv
+++ b/rtl/cv32e40x_controller_fsm.sv
@@ -609,7 +609,7 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
       SLEEP: begin
         ctrl_fsm_o.ctrl_busy = 1'b0;
         ctrl_fsm_o.instr_req = 1'b0;
-
+        // TODO: Check that below statement is true by checking SEC when halting all stages.
         ctrl_fsm_o.halt_wb   = 1'b1; // implicitly halts earlier stages
         if(ctrl_fsm_o.wake_from_sleep) begin
           ctrl_fsm_ns = FUNCTIONAL;

--- a/rtl/cv32e40x_core.sv
+++ b/rtl/cv32e40x_core.sv
@@ -228,6 +228,9 @@ module cv32e40x_core import cv32e40x_pkg::*;
   csr_opcode_e csr_op_id;
   logic        csr_illegal;
 
+  // CSR illegal in EX due to offloading and pipeline accept
+  logic        xif_csr_error_ex;
+
   // irq signals
   // TODO:AB Should find a proper suffix for signals from interrupt_controller
   logic        irq_req_ctrl;
@@ -485,6 +488,8 @@ module cv32e40x_core import cv32e40x_pkg::*;
     // Branch decision
     .branch_decision_o          ( branch_decision_ex           ),
     .branch_target_o            ( branch_target_ex             ),
+
+    .xif_csr_error_o            ( xif_csr_error_ex             ),
 
     // Register file forwarding
     .rf_wdata_o                 ( rf_wdata_ex                  ),
@@ -755,7 +760,8 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .ctrl_fsm_o                     ( ctrl_fsm               ),
 
     // eXtension interface
-    .xif_commit_if                  ( xif_commit_if          )
+    .xif_commit_if                  ( xif_commit_if          ),
+    .xif_csr_error_i                ( xif_csr_error_ex       )
  );
 
 ////////////////////////////////////////////////////////////////////////

--- a/rtl/cv32e40x_ex_stage.sv
+++ b/rtl/cv32e40x_ex_stage.sv
@@ -126,7 +126,7 @@ module cv32e40x_ex_stage import cv32e40x_pkg::*;
   // Using registered instr_valid, as gated instr_valid would not allow killing of offloaded instruction
   // in case of halt_ex==1. We need to kill this duplicate regardless of halt state.
   //  Currently, halt_ex is asserted in the cycle before debug entry, and if any performance counter is being read.
-  assign xif_csr_error_o = id_ex_pipe_i.instr_valid && id_ex_pipe_i.xif_en && (id_ex_pipe_i.csr_en && !csr_illegal_i);
+  assign xif_csr_error_o = instr_valid && id_ex_pipe_i.xif_en && (id_ex_pipe_i.csr_en && !csr_illegal_i);
 
   // CSR instruction is illegal if core signals illegal and NOT offloaded, or if both core and xif accepted it.
   assign csr_is_illegal = ((csr_illegal_i && !id_ex_pipe_i.xif_en) ||
@@ -320,7 +320,7 @@ module cv32e40x_ex_stage import cv32e40x_pkg::*;
         // Update signals for CSR access in WB
         // deassert csr_en in case of an internal illegal csr instruction
         // to avoid writing to CSRs inside the core.
-        ex_wb_pipe_o.csr_en     <= csr_illegal_i ? 1'b0 : id_ex_pipe_i.csr_en;
+        ex_wb_pipe_o.csr_en     <= (csr_illegal_i || xif_csr_error_o) ? 1'b0 : id_ex_pipe_i.csr_en;
         if (id_ex_pipe_i.csr_en) begin
           ex_wb_pipe_o.csr_addr  <= id_ex_pipe_i.alu_operand_b[11:0];
           ex_wb_pipe_o.csr_wdata <= id_ex_pipe_i.alu_operand_a;

--- a/rtl/cv32e40x_id_stage.sv
+++ b/rtl/cv32e40x_id_stage.sv
@@ -655,7 +655,9 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
       end
 
       // attempt to offload every valid instruction that is considered illegal by the decoder
-      assign xif_issue_if.issue_valid     = instr_valid && illegal_insn && !xif_accepted_q && !xif_rejected_q;
+      // Also attempt to offload any CSR instruction. The validity of such instructions are only
+      // checked in the EX stage.
+      assign xif_issue_if.issue_valid     = instr_valid && (illegal_insn || csr_en) && !xif_accepted_q && !xif_rejected_q;
 
       assign xif_issue_if.issue_req.instr = instr;
       assign xif_issue_if.issue_req.mode  = PRIV_LVL_M;

--- a/sva/cv32e40x_controller_fsm_sva.sv
+++ b/sva/cv32e40x_controller_fsm_sva.sv
@@ -286,12 +286,15 @@ module cv32e40x_controller_fsm_sva
   // flagged as killed on the eXtension interface
   a_duplicate_csr_kill:
   assert property (@(posedge clk) disable iff (!rst_n)
-                  id_ex_pipe_i.xif_en && id_ex_pipe_i.csr_en && !csr_illegal_i
+                  id_ex_pipe_i.xif_en && id_ex_pipe_i.csr_en && !csr_illegal_i && id_ex_pipe_i.instr_valid &&
+                  !ctrl_fsm_o.halt_ex
                   |-> xif_commit_kill)
     else `uvm_error("controller", "Duplicate CSR instruction not killed")
 
   // Assert that a CSR instruction that is accepted by both eXtension interface and pipeline
   // causes an illegal instruction
+  // TODO: The checks for mpu_status and bus_resp.err below can be removed once the
+  //       xif offload is fully implemented (no offload if mpu or bus error occured in IF)
   a_duplicate_csr_illegal:
     assert property (@(posedge clk) disable iff (!rst_n)
                     ex_valid_i && wb_ready_i && id_ex_pipe_i.xif_en && id_ex_pipe_i.csr_en && !csr_illegal_i &&

--- a/sva/cv32e40x_controller_fsm_sva.sv
+++ b/sva/cv32e40x_controller_fsm_sva.sv
@@ -44,8 +44,13 @@ module cv32e40x_controller_fsm_sva
   input if_id_pipe_t    if_id_pipe_i,
   input id_ex_pipe_t    id_ex_pipe_i,
   input ex_wb_pipe_t    ex_wb_pipe_i,
+  input logic           ex_valid_i,
+  input logic           wb_ready_i,
+  input logic           exception_in_wb,
+  input logic [7:0]     exception_cause_wb,
   input logic           rf_we_wb_i,
   input logic           csr_we_i,
+  input logic           csr_illegal_i,
   input logic           pending_single_step,
   input logic           trigger_match_in_wb,
   input logic           lsu_err_wb_i,
@@ -59,7 +64,8 @@ module cv32e40x_controller_fsm_sva
   input logic           pending_interrupt,
   input logic           interrupt_allowed,
   input logic           pending_nmi,
-  input logic           fencei_ready
+  input logic           fencei_ready,
+  input logic           xif_commit_kill
 );
 
 
@@ -276,5 +282,23 @@ module cv32e40x_controller_fsm_sva
                      ctrl_fsm_o.mhpmevent.wb_data_stall |-> ctrl_fsm_o.mhpmevent.wb_invalid)
       else `uvm_error("controller", "mhpmevent.wb_data_stall not a subset of mhpmevent.wb_invalid")
     
+  // Assert that a CSR instruction that is accepted by both eXtension interface and pipeline is
+  // flagged as killed on the eXtension interface
+  a_duplicate_csr_kill:
+  assert property (@(posedge clk) disable iff (!rst_n)
+                  id_ex_pipe_i.xif_en && id_ex_pipe_i.csr_en && !csr_illegal_i
+                  |-> xif_commit_kill)
+    else `uvm_error("controller", "Duplicate CSR instruction not killed")
+
+  // Assert that a CSR instruction that is accepted by both eXtension interface and pipeline
+  // causes an illegal instruction
+  a_duplicate_csr_illegal:
+    assert property (@(posedge clk) disable iff (!rst_n)
+                    ex_valid_i && wb_ready_i && id_ex_pipe_i.xif_en && id_ex_pipe_i.csr_en && !csr_illegal_i &&
+                    !((id_ex_pipe_i.instr.mpu_status != MPU_OK) || (id_ex_pipe_i.instr.bus_resp.err))
+                    |=> exception_in_wb && (exception_cause_wb == EXC_CAUSE_ILLEGAL_INSN))
+      else `uvm_error("controller", "Duplicate CSR instruction not mardked as illegal")
+
+
 endmodule // cv32e40x_controller_fsm_sva
 

--- a/sva/cv32e40x_controller_fsm_sva.sv
+++ b/sva/cv32e40x_controller_fsm_sva.sv
@@ -286,8 +286,8 @@ module cv32e40x_controller_fsm_sva
   // flagged as killed on the eXtension interface
   a_duplicate_csr_kill:
   assert property (@(posedge clk) disable iff (!rst_n)
-                  id_ex_pipe_i.xif_en && id_ex_pipe_i.csr_en && !csr_illegal_i && id_ex_pipe_i.instr_valid &&
-                  !ctrl_fsm_o.halt_ex
+                  id_ex_pipe_i.xif_en && id_ex_pipe_i.csr_en && !csr_illegal_i &&
+                  (id_ex_pipe_i.instr_valid && !ctrl_fsm_o.halt_ex && !ctrl_fsm_o.kill_ex)
                   |-> xif_commit_kill)
     else `uvm_error("controller", "Duplicate CSR instruction not killed")
 

--- a/sva/cv32e40x_id_stage_sva.sv
+++ b/sva/cv32e40x_id_stage_sva.sv
@@ -103,6 +103,7 @@ module cv32e40x_id_stage_sva
       endgenerate
 */
       // Check that illegal instruction has no other side effects
+      // TODO: Factor in that the eXtension interface may accept the instruction, and thus rf_we may still be 1
       property p_illegal_2;
         @(posedge clk) disable iff (!rst_n) (illegal_insn == 1'b1) |-> !(ebrk_insn || mret_insn || dret_insn ||
                                                                          ecall_insn || wfi_insn || fencei_insn ||


### PR DESCRIPTION
Killing xif instruction via commit interface in EX, and marking instruction
as illegal.

Note that the commit_kill signal is not fully implemented yet. It will get updated in a future PR with proper killing for interrupts, debug and exceptions. Changes are expected to the way commit_kill is signalled, as for killed instructions ex_valid will not be 1.

Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>