### PR TITLE
Fix for issue #317.

### DIFF
--- a/rtl/cv32e40x_controller.sv
+++ b/rtl/cv32e40x_controller.sv
@@ -60,6 +60,7 @@ module cv32e40x_controller import cv32e40x_pkg::*;
   input  logic        lsu_err_wb_i,               // LSU bus error in WB stage
   input  logic [31:0] lsu_addr_wb_i,              // LSU address in WB stage
   input  logic        lsu_busy_i,                 // LSU is busy with outstanding transfers
+  input  logic        lsu_interruptible_i,        // LSU may be interrupted
 
   // jump/branch signals
   input  logic        branch_decision_ex_i,       // branch decision signal from EX ALU
@@ -154,6 +155,7 @@ module cv32e40x_controller import cv32e40x_pkg::*;
     .wb_ready_i                  ( wb_ready_i               ),
     .wb_valid_i                  ( wb_valid_i               ),
 
+    .lsu_interruptible_i         ( lsu_interruptible_i      ),
     // Interrupt Controller Signals
     .irq_req_ctrl_i              ( irq_req_ctrl_i           ),
     .irq_id_ctrl_i               ( irq_id_ctrl_i            ),

--- a/rtl/cv32e40x_controller_fsm.sv
+++ b/rtl/cv32e40x_controller_fsm.sv
@@ -69,6 +69,7 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
 
   input  logic        lsu_busy_i,                 // LSU is busy with outstanding transfers
 
+  input  logic        lsu_interruptible_i,        // LSU can be interrupted
   // Interrupt Controller Signals
   input  logic        irq_req_ctrl_i,             // irq requst
   input  logic [4:0]  irq_id_ctrl_i,              // irq id
@@ -164,9 +165,6 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
   logic [2:0] debug_cause_n;
   logic [2:0] debug_cause_q;
   
-// Data request has been clocked without insn moving to WB
-  logic obi_data_req_q; // todo: should really look at 'trans'; rename accordingly
-
   logic [4:0] exc_cause; // id of taken interrupt
 
   logic       fencei_ready;
@@ -289,14 +287,11 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
   */
   assign pending_single_step = (!debug_mode_q && dcsr_i.step && (wb_valid_i || ctrl_fsm_o.irq_ack)) && !pending_debug;
 
-  // Regular debug will kill insn in WB, do not allow for LSU in WB as insn must finish with rvalid
-  // or for any case where a LSU in EX has asserted its obi data_req for at least one cycle.
-  // For misaligned LSU, if the first phase just arrived in EX, we may kill it and enter debug.
-  //  - If first phase stays in EX for more than one cycle, obi_data_req_q will be 1 and block debug.
-  //  - When first phase arrives in WB, we block debug. If first phase in WB finishes with rvalid
-  //    before second phase in EX gets grant, we block on obi_data_req_q
+  // Regular debug will kill insn in WB, do not allow if LSU is not interruptible or a fence.i handshake is taking place.
+  // LSU will not be interruptible if the outstanding counter != 0, or
+  // a trans_valid has been clocked without ex_valid && wb_ready handshake.
   // The cycle after fencei enters WB, the fencei handshake will be initiated. This must complete and the fencei instruction must retire before allowing debug.
-  assign debug_allowed = !(ex_wb_pipe_i.lsu_en && ex_wb_pipe_i.instr_valid) && !obi_data_req_q && !fencei_ongoing;
+  assign debug_allowed = lsu_interruptible_i && !fencei_ongoing;
 
   // Debug pending for any other reason than single step
   assign pending_debug = (trigger_match_in_wb) ||
@@ -328,7 +323,7 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
   // TODO:OK:low May allow interuption of Zce to idempotent memories
 
   // todo: Factor in stepie here instead of gating mie in cs_registers
-  assign interrupt_allowed = !(ex_wb_pipe_i.lsu_en && ex_wb_pipe_i.instr_valid) && !obi_data_req_q && !debug_mode_q && !fencei_ongoing;
+  assign interrupt_allowed = lsu_interruptible_i && !debug_mode_q && !fencei_ongoing;
 
   assign nmi_allowed = interrupt_allowed;
 
@@ -726,20 +721,6 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
   end
 
   assign ctrl_fsm_o.debug_mode = debug_mode_q;
-
-  // Detect when data_req has been clocked, and lsu insn is still in EX
-  // todo: Should look at 'trans' (goal (please check if true) it to not break a multicycle LSU instruction or already committed load/store; that cannot be judged by only looking at the OBI signals)
-  always_ff @(posedge clk, negedge rst_n) begin
-    if (rst_n == 1'b0) begin
-      obi_data_req_q <= 1'b0;
-    end else begin
-      if (m_c_obi_data_if.s_req.req && !(ex_valid_i && wb_ready_i)) begin
-        obi_data_req_q <= 1'b1;
-      end else if (ex_valid_i && wb_ready_i) begin
-        obi_data_req_q <= 1'b0;
-      end
-    end
-  end
 
   // sticky version of debug_req (must be on clk_ungated_i such that incoming pulse before core is enabled is not missed)
   always_ff @(posedge clk_ungated_i, negedge rst_n) begin

--- a/rtl/cv32e40x_controller_fsm.sv
+++ b/rtl/cv32e40x_controller_fsm.sv
@@ -316,7 +316,7 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
   assign pending_interrupt = irq_req_ctrl_i && !debug_mode_q;
 
   // Allow interrupts to be taken only if there is no data request in WB, 
-  // and no data_req has been clocked from EX to environment.
+  // and no trans_valid has been clocked from EX to environment.
   // LSU instructions which were suppressed due to previous exceptions or trigger match
   // will be interruptable as they were convered to NOP in ID stage.
   // The cycle after fencei enters WB, the fencei handshake will be initiated. This must complete and the fencei instruction must retire before allowing interrupts.

--- a/rtl/cv32e40x_core.sv
+++ b/rtl/cv32e40x_core.sv
@@ -125,6 +125,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
   // Busy signals
   logic        if_busy;
   logic        lsu_busy;
+  logic        lsu_interruptible;
 
   // ID/EX pipeline
   id_ex_pipe_t id_ex_pipe;
@@ -538,6 +539,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
 
     // Control signals
     .busy_o                ( lsu_busy           ),
+    .interruptible_o       ( lsu_interruptible  ),
 
     // Stage 0 outputs (EX)
     .lsu_split_0_o         ( lsu_split_ex       ),
@@ -716,6 +718,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .lsu_addr_wb_i                  ( lsu_addr_wb            ),
     .lsu_err_wb_i                   ( lsu_err_wb             ),
     .lsu_busy_i                     ( lsu_busy               ),
+    .lsu_interruptible_i            ( lsu_interruptible      ),
 
     // jump/branch control
     .branch_decision_ex_i           ( branch_decision_ex     ),

--- a/rtl/cv32e40x_load_store_unit.sv
+++ b/rtl/cv32e40x_load_store_unit.sv
@@ -557,7 +557,25 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
   //////////////////////////////////////////////////////////////////////////////
   // Check if LSU is interruptible
   //////////////////////////////////////////////////////////////////////////////
-
+  // OBI protocol should not be violated. For non-buffered writes, the trans_
+  // signals are fed directly through to the OBI interface. Buffered writes that have
+  // been accepted by the write buffer will complete regardless of interrupts,
+  // debug and killing of stages.
+  //
+  // A trans_valid that has been high for at least one clock cycle is not
+  // allowed to retract.
+  //
+  // LSU instructions shall not be interrupted/killed if the address phase is
+  // already done, the instruction must finish with resp_valid=1 in WB
+  // stage (cnt_q > 0 until resp_valid becomes 1)
+  //
+  // For misaligned split instructions, we may interrupt during the first
+  // cycle of the first half. If the first half stays in EX for more than one
+  // cycle, we cannot interrupt it (trans_valid_q == 1). When the first half
+  // goes to WB, cnt_q != 0 will block interrupts. If the first half finishes
+  // in WB before the second half gets grant, trans_valid_q will again be
+  // 1 and block interrupts, and cnt_q will block the last half while it is in
+  // WB.
   always_ff @(posedge clk, negedge rst_n)
   begin
     if(rst_n == 1'b0) begin

--- a/sva/cv32e40x_controller_fsm_sva.sv
+++ b/sva/cv32e40x_controller_fsm_sva.sv
@@ -282,6 +282,13 @@ module cv32e40x_controller_fsm_sva
     assert property (@(posedge clk) disable iff (!rst_n)
                      ctrl_fsm_o.mhpmevent.wb_data_stall |-> ctrl_fsm_o.mhpmevent.wb_invalid)
       else `uvm_error("controller", "mhpmevent.wb_data_stall not a subset of mhpmevent.wb_invalid")
+
+  // Assert that interrupts are not allowed when WB stage has an LSU
+  // instruction (cnt_q != 0)
+  a_block_interrupts:
+    assert property (@(posedge clk) disable iff (!rst_n)
+                     (ex_wb_pipe_i.instr_valid && ex_wb_pipe_i.lsu_en) |-> !interrupt_allowed)
+      else `uvm_error("controller", "interrupt_allowed high while LSU is in WB")
     
   // Assert that a CSR instruction that is accepted by both eXtension interface and pipeline is
   // flagged as killed on the eXtension interface
@@ -304,5 +311,11 @@ module cv32e40x_controller_fsm_sva
       else `uvm_error("controller", "Duplicate CSR instruction not mardked as illegal")
 
 
+  // Assert that debug is not allowed when WB stage has an LSU
+  // instruction (cnt_q != 0)
+  a_block_debug:
+    assert property (@(posedge clk) disable iff (!rst_n)
+                     (ex_wb_pipe_i.instr_valid && ex_wb_pipe_i.lsu_en) |-> !debug_allowed)
+      else `uvm_error("controller", "debug_allowed high while LSU is in WB")
 endmodule // cv32e40x_controller_fsm_sva
 


### PR DESCRIPTION
Controller was checking toplevel OBI signals when checking for allowed interrupts/debug.
This causes issued when the write buffer accepted writes before the data_gnt_i was asserted.

Fix is to look at trans_ signals inside the LSU, before the MPU. Added a "interruptible" outout
from the LSU instead of looking at lsu_en i ex/wb inside the controller.

Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>