### PR TITLE
add explicit interface connections in dot-star in wrapper

### DIFF
--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -472,6 +472,13 @@ bind cv32e40x_sleep_unit:
           .X_MISA                ( X_MISA                ),
           .PMA_NUM_REGIONS       ( PMA_NUM_REGIONS       ),
           .PMA_CFG               ( PMA_CFG               ))
-    core_i (.*);
+    core_i (
+            .xif_compressed_if(xif_compressed_if),
+            .xif_issue_if(xif_issue_if),
+            .xif_commit_if(xif_commit_if),
+            .xif_mem_if(xif_mem_if),
+            .xif_mem_result_if(xif_mem_result_if),
+            .xif_result_if(xif_result_if),
+            .*);
 
 endmodule


### PR DESCRIPTION
No functional change, but this is needed for JasperGold UNR compile.  Otherwise the cv32e40x_core instance is black-boxed and UNR analysis fails.
