### PR TITLE
Adding missing zext.h instruction [B_EXT]

### DIFF
--- a/rtl/cv32e40x_alu.sv
+++ b/rtl/cv32e40x_alu.sv
@@ -366,6 +366,8 @@ module cv32e40x_alu import cv32e40x_pkg::*;
       ALU_B_SEXT_B : result_o = {{(24){operand_a_i[ 7]}}, operand_a_i[ 7:0]};
       ALU_B_SEXT_H : result_o = {{(16){operand_a_i[15]}}, operand_a_i[15:0]};
 
+      ALU_B_ZEXT_H : result_o = {16'h0000, operand_a_i[15:0]};
+
       ALU_B_CLMUL  : result_o = clmul_result;
       ALU_B_CLMULH : result_o = clmulh_result;
       ALU_B_CLMULR : result_o = clmulr_result;

--- a/rtl/cv32e40x_b_decoder.sv
+++ b/rtl/cv32e40x_b_decoder.sv
@@ -139,6 +139,7 @@ module cv32e40x_b_decoder import cv32e40x_pkg::*;
             end
           end
           {7'b0000100, 3'b100}: begin // Zero extend halfword (zext.h)
+            // NB: zext.h is a subset of the proposed pack instruction in Zbkb
             if (RV32B_ZBB) begin
               decoder_ctrl_o.illegal_insn               = 1'b0;
               decoder_ctrl_o.rf_re[1]                   = 1'b0; // rs2 is not read, but field is hardcoded to x0

--- a/rtl/cv32e40x_b_decoder.sv
+++ b/rtl/cv32e40x_b_decoder.sv
@@ -144,6 +144,9 @@ module cv32e40x_b_decoder import cv32e40x_pkg::*;
               decoder_ctrl_o.illegal_insn               = 1'b0;
               decoder_ctrl_o.rf_re[1]                   = 1'b0; // rs2 is not read, but field is hardcoded to x0
               decoder_ctrl_o.alu_operator               = ALU_B_ZEXT_H;
+              if (instr_rdata_i[24:20] != 5'b00000) begin
+                decoder_ctrl_o = DECODER_CTRL_ILLEGAL_INSN;
+              end
             end
           end
 

--- a/rtl/cv32e40x_b_decoder.sv
+++ b/rtl/cv32e40x_b_decoder.sv
@@ -138,6 +138,13 @@ module cv32e40x_b_decoder import cv32e40x_pkg::*;
               decoder_ctrl_o.alu_operator               = ALU_B_ROR;
             end
           end
+          {7'b0000100, 3'b100}: begin // Zero extend halfword (zext.h)
+            if (RV32B_ZBB) begin
+              decoder_ctrl_o.illegal_insn               = 1'b0;
+              decoder_ctrl_o.rf_re[1]                   = 1'b0; // rs2 is not read, but field is hardcoded to x0
+              decoder_ctrl_o.alu_operator               = ALU_B_ZEXT_H;
+            end
+          end
 
           // RVB Zbc
           {7'b0000101, 3'b001}: begin // Carry-less Multiply (clmul)
@@ -238,7 +245,7 @@ module cv32e40x_b_decoder import cv32e40x_pkg::*;
               decoder_ctrl_o.alu_operator = ALU_B_SEXT_B;
             end
           end
-          {7'b110_0000, 5'b0_0101, 3'b001}: begin
+          {7'b011_0000, 5'b0_0101, 3'b001}: begin
             if (RV32B_ZBB) begin
               decoder_ctrl_o.illegal_insn = 1'b0;
               decoder_ctrl_o.alu_operator = ALU_B_SEXT_H;

--- a/rtl/include/cv32e40x_pkg.sv
+++ b/rtl/include/cv32e40x_pkg.sv
@@ -127,6 +127,8 @@ typedef enum logic [ALU_OP_WIDTH-1:0]
  ALU_B_SEXT_B = 6'b110000, // (funct3 = 001)
  ALU_B_SEXT_H = 6'b111000, // (funct3 = 001)
 
+ ALU_B_ZEXT_H = 6'b110011, // (funct3 = 100)
+
  ALU_B_REV8   = 6'b110100, // (funct3 = 101)
  ALU_B_ORC_B  = 6'b110010, // (funct3 = 101)
 
@@ -134,6 +136,13 @@ typedef enum logic [ALU_OP_WIDTH-1:0]
  ALU_B_CLMUL  = 6'b100111, // (funct3 = 001)
  ALU_B_CLMULH = 6'b101011, // funct3 = 011
  ALU_B_CLMULR = 6'b101010  // funct3 = 010
+
+ // Free encodings with bit 5 set (for B_EXT):
+ // 6'b101101
+ // 6'b110110
+ // 6'b111010
+ // 6'b111011
+ // 6'b111111
 
 } alu_opcode_e;
 


### PR DESCRIPTION
Decoding of sext.h was also fixed, as bits[31:25] did not match the specification.