### PR TITLE
Optimize predecoder/decoder for illegal compressed instructions

### DIFF
--- a/rtl/cv32e40x_compressed_decoder.sv
+++ b/rtl/cv32e40x_compressed_decoder.sv
@@ -76,8 +76,10 @@ module cv32e40x_compressed_decoder import cv32e40x_pkg::*;
           3'b101,       // c.fsd -> fsd rs2', imm(rs1')
           3'b111: begin // c.fsw -> fsw rs2', imm(rs1')
             illegal_instr_o = 1'b1;
+            instr_o.bus_resp.rdata = {5'b0, instr[5], instr[12:10], instr[6], 2'b00, 2'b01, instr[9:7], 3'b010, 2'b01, instr[4:2], OPCODE_LOAD};
           end
           default: begin
+            instr_o.bus_resp.rdata = {5'b0, instr[5], instr[12:10], instr[6], 2'b00, 2'b01, instr[9:7], 3'b010, 2'b01, instr[4:2], OPCODE_LOAD};
             illegal_instr_o = 1'b1;
           end
         endcase
@@ -111,6 +113,7 @@ module cv32e40x_compressed_decoder import cv32e40x_pkg::*;
 
           3'b011: begin
             if ({instr[12], instr[6:2]} == 6'b0) begin
+              instr_o.bus_resp.rdata = {{15 {instr[12]}}, instr[6:2], instr[11:7], OPCODE_LUI};
               illegal_instr_o = 1'b1;
             end else begin
               if (instr[11:7] == 5'h02) begin
@@ -179,6 +182,7 @@ module cv32e40x_compressed_decoder import cv32e40x_pkg::*;
                   3'b111: begin
                     // 100: c.subw
                     // 101: c.addw
+                    instr_o.bus_resp.rdata = {7'b0, 2'b01, instr[4:2], 2'b01, instr[9:7], 3'b111, 2'b01, instr[9:7], OPCODE_OP};
                     illegal_instr_o = 1'b1;
                   end
                 endcase
@@ -265,6 +269,7 @@ module cv32e40x_compressed_decoder import cv32e40x_pkg::*;
           3'b011,        // c.flwsp -> flw rd, imm(x2)
           3'b101,        // c.fsdsp -> fsd rs2, imm(x2)
           3'b111: begin  // c.fswsp -> fsw rs2, imm(x2)
+            instr_o.bus_resp.rdata = {4'b0, instr[3:2], instr[12], instr[6:4], 2'b00, 5'h02, 3'b010, instr[11:7], OPCODE_LOAD};
             illegal_instr_o = 1'b1;
           end
         endcase

--- a/rtl/include/cv32e40x_pkg.sv
+++ b/rtl/include/cv32e40x_pkg.sv
@@ -907,7 +907,9 @@ typedef struct packed {
 
 // Reset value for the inst_resp_t type
 parameter inst_resp_t INST_RESP_RESET_VAL = '{
-  bus_resp    : '{rdata: 32'h0, err: 1'b0},
+  // Setting rdata[1:0] to 2'b11 to easily assert that all
+  // instructions in ID are uncompressed
+  bus_resp    : '{rdata: 32'h3, err: 1'b0},
   mpu_status  : MPU_OK
 };
 

--- a/sva/cv32e40x_decoder_sva.sv
+++ b/sva/cv32e40x_decoder_sva.sv
@@ -31,7 +31,8 @@ module cv32e40x_decoder_sva
    input logic rst_n,
    input decoder_ctrl_t decoder_i_ctrl,
    input decoder_ctrl_t decoder_m_ctrl,
-   input decoder_ctrl_t decoder_a_ctrl
+   input decoder_ctrl_t decoder_a_ctrl,
+   input logic [31:0] instr_rdata_i
    );
 
   
@@ -45,6 +46,14 @@ module cv32e40x_decoder_sva
   a_a_dec_idle : assert property(p_idle_dec(decoder_a_ctrl)) else `uvm_error("decoder", "Assertion a_a_dec_idle failed")
   a_i_dec_idle : assert property(p_idle_dec(decoder_i_ctrl)) else `uvm_error("decoder", "Assertion a_i_dec_idle failed")
   
+  // Check that the two LSB of the incoming instructions word is always 2'b11
+  // Predecoder should always emit uncompressed instructions
+  property p_uncompressed_lsb;
+    @(posedge clk) disable iff(!rst_n)
+      (instr_rdata_i[1:0] == 2'b11);
+  endproperty
+
+  a_uncompressed_lsb: assert property(p_uncompressed_lsb) else `uvm_error("decoder", "2LSB not 2'b11")
 
 endmodule : cv32e40x_decoder_sva
 


### PR DESCRIPTION
Not all illegal compressed instructions generated an uncompressed instruction word. Fixing this hole enables synthesis to optimize
the decoder in ID stage by removing two LSBs.

Not SEC clean due to stalls caused by rs1/rs2 fields in illegal compressed instructions.
SEC clean if compressed instruction word is passed through predecoder with two LSB set to 1.

Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>