### PR TITLE
Todo removal 2

### DIFF
--- a/rtl/cv32e40x_core.sv
+++ b/rtl/cv32e40x_core.sv
@@ -58,7 +58,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
   input  logic [31:0] dm_halt_addr_i,
   input  logic [31:0] hart_id_i,
   input  logic [31:0] dm_exception_addr_i,
-  input  logic [31:0] nmi_addr_i,               // TODO:OK:low use
+  input  logic [31:0] nmi_addr_i,
 
   // Instruction memory interface
   output logic        instr_req_o,
@@ -733,7 +733,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .irq_wu_ctrl_i                  ( irq_wu_ctrl            ),
     .irq_req_ctrl_i                 ( irq_req_ctrl           ),
     .irq_id_ctrl_i                  ( irq_id_ctrl            ),
-    .current_priv_lvl_i             ( current_priv_lvl       ), // TODO:OK:low Needs bypass for 40S?
+    .current_priv_lvl_i             ( current_priv_lvl       ),
 
     // From CSR registers
     .mtvec_mode_i                   ( mtvec_mode             ),

--- a/rtl/cv32e40x_cs_registers.sv
+++ b/rtl/cv32e40x_cs_registers.sv
@@ -680,7 +680,7 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
   assign csr_rdata_o = csr_rdata_int;
 
   // directly output some registers
-  assign m_irq_enable_o  = mstatus_q.mie && !(dcsr_q.step && !dcsr_q.stepie);
+  assign m_irq_enable_o  = mstatus_q.mie;
   assign priv_lvl_o      = priv_lvl_q;
   
   assign mtvec_addr_o    = mtvec_q.addr;


### PR DESCRIPTION
Removed two obsolete TODOs from toplevel.
Refactored usage of dcsr.step and dcsr.stepie from cs_registers to the controller_fsm.

SEC clean.

Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>