### PR TITLE
Fix for issue #343

### DIFF
--- a/rtl/cv32e40x_controller.sv
+++ b/rtl/cv32e40x_controller.sv
@@ -57,7 +57,7 @@ module cv32e40x_controller import cv32e40x_pkg::*;
   input  logic        lsu_split_ex_i,             // LSU is splitting misaligned
   input  mpu_status_e lsu_mpu_status_wb_i,        // MPU status (WB stage)
   input  logic        data_stall_wb_i,            // WB stalled by LSU
-  input  logic        lsu_err_wb_i,               // LSU bus error in WB stage
+  input  logic [1:0]  lsu_err_wb_i,               // LSU bus error in WB stage
   input  logic [31:0] lsu_addr_wb_i,              // LSU address in WB stage
   input  logic        lsu_busy_i,                 // LSU is busy with outstanding transfers
   input  logic        lsu_interruptible_i,        // LSU may be interrupted

--- a/rtl/cv32e40x_controller_fsm.sv
+++ b/rtl/cv32e40x_controller_fsm.sv
@@ -60,7 +60,7 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
   input  logic        lsu_split_ex_i,             // LSU is splitting misaligned, first half is in EX
 
   // From WB stage
-  input  logic        lsu_err_wb_i,               // LSU caused bus_error in WB stage, gated with data_rvalid_i inside load_store_unit
+  input  logic [1:0]  lsu_err_wb_i,               // LSU caused bus_error in WB stage, gated with data_rvalid_i inside load_store_unit
   input  logic [31:0] lsu_addr_wb_i,              // LSU address in WB stage //todo: only needed if MTVAL is implemented
 
   // From LSU (WB)
@@ -741,12 +741,12 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
       nmi_pending_q <= 1'b0;
       nmi_is_store_q <= 1'b0;
     end else begin
-      if (lsu_err_wb_i && !nmi_pending_q) begin
+      if (lsu_err_wb_i[0] && !nmi_pending_q) begin
         // Set whenever an error occurs in WB for the LSU, unless we already have an NMI pending.
         // Later errors could overwrite the bit for load/store type, and with mtval the address would be overwritten.
         // todo: if mtval is implemented, address must be sticky as well
         nmi_pending_q <= 1'b1;
-        nmi_is_store_q <= !ex_wb_pipe_i.rf_we;
+        nmi_is_store_q <= lsu_err_wb_i[1];
       // Clear when the controller takes the NMI
       end else if (ctrl_fsm_o.pc_set && (ctrl_fsm_o.pc_mux == PC_TRAP_NMI)) begin
         nmi_pending_q <= 1'b0;

--- a/rtl/cv32e40x_core.sv
+++ b/rtl/cv32e40x_core.sv
@@ -177,7 +177,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
   logic        lsu_split_ex;
   mpu_status_e lsu_mpu_status_wb;
   logic [31:0] lsu_rdata_wb;
-  logic        lsu_err_wb;
+  logic [1:0]  lsu_err_wb;
   logic [31:0] lsu_addr_wb;
 
   logic        lsu_valid_0;             // Handshake with EX

--- a/rtl/cv32e40x_load_store_unit.sv
+++ b/rtl/cv32e40x_load_store_unit.sv
@@ -95,7 +95,7 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
   obi_data_req_t  filter_trans;
   logic           filter_resp_valid;
   obi_data_resp_t filter_resp;
-  logic [1:0]     filter_bus_error;
+  logic [1:0]     filter_err;
 
   // Transaction request (from cv32e40x_write_buffer to cv32e40x_data_obi_interface)
   logic           bus_trans_valid;
@@ -620,7 +620,8 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
 
   // Validate bus_error on rvalid from the bus (WB stage)
   // For bufferable transfers, this can happen many cycles after the pipeline control logic has seen the filtered resp_valid
-  assign lsu_err_1_o = filter_bus_error;
+  // Todo: This bypasses the MPU, could be merged with mpu_status_e and passed through the MPU instead
+  assign lsu_err_1_o = filter_err;
 
   //////////////////////////////////////////////////////////////////////////////
   // MPU
@@ -680,14 +681,14 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
        .trans_i      ( filter_trans       ),
        .resp_valid_o ( filter_resp_valid  ),
        .resp_o       ( filter_resp        ),
+       .err_o        ( filter_err         ),
 
        .valid_o      ( buffer_trans_valid ),
        .ready_i      ( buffer_trans_ready ),
        .trans_o      ( buffer_trans       ),
        .resp_valid_i ( bus_resp_valid     ),
-       .resp_i       ( bus_resp           ),
+       .resp_i       ( bus_resp           )
 
-       .bus_error_o  ( filter_bus_error   )
      );
 
 

--- a/rtl/cv32e40x_load_store_unit.sv
+++ b/rtl/cv32e40x_load_store_unit.sv
@@ -53,7 +53,7 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
 
   // Stage 1 outputs (WB)
   output logic [31:0] lsu_addr_1_o,
-  output logic        lsu_err_1_o,
+  output logic [1:0]  lsu_err_1_o,
   output logic [31:0] lsu_rdata_1_o,            // LSU read data
   output mpu_status_e lsu_mpu_status_1_o,       // MPU (PMA) status, response/WB timing. To controller and wb_stage
 
@@ -83,7 +83,6 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
   // Transaction response interface (from cv32e40x_mpu)
   logic         resp_valid;
   logic [31:0]  resp_rdata;
-  logic         bus_resp_err;               // Unused for now
   data_resp_t   resp;
 
   // Transaction request (from cv32e40x_mpu to cv32e40x_write_buffer)
@@ -96,6 +95,7 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
   obi_data_req_t  filter_trans;
   logic           filter_resp_valid;
   obi_data_resp_t filter_resp;
+  logic [1:0]     filter_bus_error;
 
   // Transaction request (from cv32e40x_write_buffer to cv32e40x_data_obi_interface)
   logic           bus_trans_valid;
@@ -620,7 +620,7 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
 
   // Validate bus_error on rvalid from the bus (WB stage)
   // For bufferable transfers, this can happen many cycles after the pipeline control logic has seen the filtered resp_valid
-  assign lsu_err_1_o = bus_resp_valid && bus_resp_err;
+  assign lsu_err_1_o = filter_bus_error;
 
   //////////////////////////////////////////////////////////////////////////////
   // MPU
@@ -679,15 +679,17 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
        .ready_o      ( filter_trans_ready ),
        .trans_i      ( filter_trans       ),
        .resp_valid_o ( filter_resp_valid  ),
+       .resp_o       ( filter_resp        ),
 
        .valid_o      ( buffer_trans_valid ),
        .ready_i      ( buffer_trans_ready ),
        .trans_o      ( buffer_trans       ),
-       .resp_valid_i ( bus_resp_valid     )
+       .resp_valid_i ( bus_resp_valid     ),
+       .resp_i       ( bus_resp           ),
+
+       .bus_error_o  ( filter_bus_error   )
      );
 
-  assign filter_resp  = bus_resp; // Not used by write buffer
-  assign bus_resp_err = bus_resp.err;
 
   //////////////////////////////////////////////////////////////////////////////
   // Write Buffer

--- a/rtl/cv32e40x_lsu_response_filter.sv
+++ b/rtl/cv32e40x_lsu_response_filter.sv
@@ -79,7 +79,7 @@ module cv32e40x_lsu_response_filter
   logic                  core_resp_is_bufferable;
 
   // Shift register containing bufferable cofiguration of outstanding transfers
-  resp_type_t [DEPTH:0]        outstanding_bufferable_q; // Using bits 1-DEPTH for outstanding xfers, index 0 is tied low
+  resp_type_t [DEPTH:0]        outstanding_bufferable_q; // Using 1-DEPTH entries for outstanding xfers, index 0 is tied low
   resp_type_t [DEPTH:0]        outstanding_bufferable_next;
 
   assign busy_o              = ( bus_cnt_q != '0) || valid_i;
@@ -98,9 +98,8 @@ module cv32e40x_lsu_response_filter
     outstanding_bufferable_next = outstanding_bufferable_q;
 
     if (bus_trans_accepted) begin
-      // Shift in bufferable bit of accepted transfer
-      //outstanding_bufferable_next[DEPTH:1]    = outstanding_bufferable_q[DEPTH-1:0];
-      outstanding_bufferable_next = outstanding_bufferable_next << 1;
+      // Shift in bufferable bit and type of accepted transfer
+      outstanding_bufferable_next[DEPTH:1]    = outstanding_bufferable_q[DEPTH-1:0];
       outstanding_bufferable_next[1] = resp_type_t'{bufferable: trans_i.memtype[0], store: trans_i.we};
     end
 

--- a/rtl/include/cv32e40x_pkg.sv
+++ b/rtl/include/cv32e40x_pkg.sv
@@ -918,6 +918,12 @@ typedef struct packed {
   mpu_status_e                mpu_status;
 } data_resp_t;
 
+// Response type for tracking bufferable and load/store in lsu response filter
+typedef struct packed {
+  logic bufferable;
+  logic store;
+} resp_type_t;
+
 // Instruction meta data
 // TODO: consider moving other instruction meta data to this struct. e.g. xxx_insn, pc, etc
 typedef struct packed

--- a/rtl/include/cv32e40x_pkg.sv
+++ b/rtl/include/cv32e40x_pkg.sv
@@ -922,7 +922,7 @@ typedef struct packed {
 typedef struct packed {
   logic bufferable;
   logic store;
-} resp_type_t;
+} outstanding_t;
 
 // Instruction meta data
 // TODO: consider moving other instruction meta data to this struct. e.g. xxx_insn, pc, etc

--- a/sva/cv32e40x_controller_fsm_sva.sv
+++ b/sva/cv32e40x_controller_fsm_sva.sv
@@ -67,7 +67,8 @@ module cv32e40x_controller_fsm_sva
   input logic           pending_nmi,
   input logic           fencei_ready,
   input logic           xif_commit_kill,
-  input logic           xif_commit_valid
+  input logic           xif_commit_valid,
+  input logic           nmi_is_store_q
 );
 
 
@@ -413,5 +414,68 @@ endgenerate
     assert property (@(posedge clk) disable iff (!rst_n)
                       (lsu_mpu_status_wb_i == MPU_RE_FAULT) |-> (exception_cause_wb == EXC_CAUSE_LOAD_FAULT))
       else `uvm_error("controller", "Wrong exception cause for MPU read fault")
+
+
+  // Helper logic to track first occuring bus error
+  logic [1:0] outstanding_type;
+  logic [1:0] outstanding_count;
+  logic bus_error_is_write;
+  logic bus_error_latched;
+  always_ff @(posedge clk, negedge rst_n) begin
+    if (rst_n == 1'b0) begin
+      outstanding_type <= 2'b00;
+      outstanding_count <= 2'b00;
+      bus_error_latched <= 1'b0;
+      bus_error_is_write <= 1'b0;
+    end else begin
+      // Req, no rvalid
+      if( (m_c_obi_data_if.s_req && m_c_obi_data_if.s_gnt) && !m_c_obi_data_if.s_rvalid) begin
+        // Increase outstanding counter
+        outstanding_count <= outstanding_count + 2'b01;
+
+        if(outstanding_count == 2'b00) begin
+          // No outstanding, assign first entry
+          outstanding_type[0] <= m_c_obi_data_if.req_payload.we;
+        end else begin
+          // One outstanding, shift and assign first entry
+          outstanding_type[1] <= outstanding_type[0];
+          outstanding_type[0] <= m_c_obi_data_if.req_payload.we;
+        end
+
+      // rvalid, no req
+      end else if (!(m_c_obi_data_if.s_req && m_c_obi_data_if.s_gnt) && m_c_obi_data_if.s_rvalid) begin
+        // Decrease outstanding counter
+        outstanding_count <= outstanding_count - 2'b01;
+
+      // req and rvalid
+      end else if ((m_c_obi_data_if.s_req && m_c_obi_data_if.s_gnt) && m_c_obi_data_if.s_rvalid) begin
+        if (outstanding_count == 2'b10) begin
+          // Two outstanding, shift and replace index 0
+          outstanding_type[1] <= outstanding_type[0];
+          outstanding_type[0] <= m_c_obi_data_if.req_payload.we;
+        end else begin
+          // One outstanding, replate index 0
+          outstanding_type[0] <= m_c_obi_data_if.req_payload.we;
+        end
+      end
+
+
+      if(m_c_obi_data_if.s_rvalid && m_c_obi_data_if.resp_payload.err && !bus_error_latched) begin
+        bus_error_is_write <= outstanding_count == 2'b01 ? outstanding_type[0] : outstanding_type[1];
+        bus_error_latched <= 1'b1;
+      end else begin
+        if (ctrl_fsm_o.pc_set && ctrl_fsm_o.pc_mux == PC_TRAP_NMI) begin
+          bus_error_latched <= 1'b0;
+        end
+      end
+    end
+  end
+
+  // Check that controller latches correct type for bus error
+  a_latched_bus_error:
+    assert property (@(posedge clk) disable iff (!rst_n)
+                      (m_c_obi_data_if.s_rvalid && m_c_obi_data_if.resp_payload.err && !bus_error_latched)
+                      |=> (nmi_is_store_q == bus_error_is_write))
+      else `uvm_error("controller", "Wrong type for LSU bus error")
 endmodule // cv32e40x_controller_fsm_sva
 

--- a/sva/cv32e40x_controller_fsm_sva.sv
+++ b/sva/cv32e40x_controller_fsm_sva.sv
@@ -68,7 +68,8 @@ module cv32e40x_controller_fsm_sva
   input logic           fencei_ready,
   input logic           xif_commit_kill,
   input logic           xif_commit_valid,
-  input logic           nmi_is_store_q
+  input logic           nmi_is_store_q,
+  input logic           nmi_pending_q
 );
 
 
@@ -417,6 +418,7 @@ endgenerate
 
 
   // Helper logic to track first occuring bus error
+  // Note: Supports max two outstanding transactions
   logic [1:0] outstanding_type;
   logic [1:0] outstanding_count;
   logic bus_error_is_write;
@@ -475,7 +477,8 @@ endgenerate
   a_latched_bus_error:
     assert property (@(posedge clk) disable iff (!rst_n)
                       (m_c_obi_data_if.s_rvalid && m_c_obi_data_if.resp_payload.err && !bus_error_latched)
-                      |=> (nmi_is_store_q == bus_error_is_write))
+                      |=> (nmi_is_store_q == bus_error_is_write) &&
+                          (nmi_pending_q == bus_error_latched) && bus_error_latched)
       else `uvm_error("controller", "Wrong type for LSU bus error")
 endmodule // cv32e40x_controller_fsm_sva
 

--- a/sva/cv32e40x_controller_fsm_sva.sv
+++ b/sva/cv32e40x_controller_fsm_sva.sv
@@ -54,7 +54,7 @@ module cv32e40x_controller_fsm_sva
   input logic           csr_illegal_i,
   input logic           pending_single_step,
   input logic           trigger_match_in_wb,
-  input logic           lsu_err_wb_i,
+  input logic [1:0]     lsu_err_wb_i,
   input logic           wb_valid_i,
   input logic           fencei_in_wb,
   input logic           fencei_flush_req_o,
@@ -202,7 +202,7 @@ module cv32e40x_controller_fsm_sva
   // Todo: Modify to account for response filter (bufferable writes)
   //a_lsu_err_wb :
   //  assert property (@(posedge clk) disable iff (!rst_n)
-  //          lsu_err_wb_i |-> ex_wb_pipe_i.instr_valid && ex_wb_pipe_i.lsu_en)
+  //          lsu_err_wb_i[0] |-> ex_wb_pipe_i.instr_valid && ex_wb_pipe_i.lsu_en)
   //    else `uvm_error("controller", "lsu_error in WB with no valid LSU instruction")
 
   // Check that fencei handshake is only exersiced when there's a fencei in the writeback stage


### PR DESCRIPTION
LSU response filter is now outputting what type of load/store is associated with a bus error.
Also routing the bus_resp through the filter for cleaner code.
Controller now gets two bits from the load_store_unit, one for qualifying an NMI and one for
signaling if it is for a load or store.

Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>