### PR TITLE
Remove TODO's

### DIFF
--- a/rtl/cv32e40x_ex_stage.sv
+++ b/rtl/cv32e40x_ex_stage.sv
@@ -330,8 +330,6 @@ module cv32e40x_ex_stage import cv32e40x_pkg::*;
         end
 
         // Propagate signals needed for exception handling in WB
-        // TODO:OK:low Clock gating of pc if no existing exceptions
-        //          and LSU it not in use
         ex_wb_pipe_o.pc             <= id_ex_pipe_i.pc;
         ex_wb_pipe_o.instr          <= id_ex_pipe_i.instr;
         ex_wb_pipe_o.instr_meta     <= instr_meta_n;

--- a/rtl/cv32e40x_id_stage.sv
+++ b/rtl/cv32e40x_id_stage.sv
@@ -580,8 +580,6 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
         id_ex_pipe_o.branch_in_ex           <= ctrl_transfer_insn_o == BRANCH_COND;
 
         // Propagate signals needed for exception handling in WB
-        // TODO:OK:low Clock gating of pc if no existing exceptions
-        //          and LSU it not in use
         id_ex_pipe_o.pc                     <= if_id_pipe_i.pc;
 
         if (if_id_pipe_i.instr_meta.compressed) begin


### PR DESCRIPTION
Removed TODO's suggesting not to propagate PC to EX and WB if there are no exceptions.

We can't do this because asynchronous events (e.g. interrupt or debug req) need valid PC's in all stages to store in mepc or dpc.

Signed-off-by: Oivind Ekelund <oivind.ekelund@silabs.com>