### PR TITLE
Fix for issue #342

### DIFF
--- a/bhv/cv32e40x_rvfi.sv
+++ b/bhv/cv32e40x_rvfi.sv
@@ -491,17 +491,22 @@ module cv32e40x_rvfi
       // Special case for debug entry from debug mode caused by EBREAK as it is not captured by ctrl_fsm_i.debug_cause
       rvfi_trap_next[11:9] = ebreak_in_wb_i ? DBG_CAUSE_EBREAK : ctrl_fsm_i.debug_cause;
     end
+
     if (pc_mux_exception) begin
       // Indicate synchronous (non-debug entry) trap
       rvfi_trap_next[2:0] = 3'b011;
       rvfi_trap_next[8:3] = ctrl_fsm_i.csr_cause.exception_code;
     end
-    if(pc_mux_exception && (pending_single_step_i && single_step_allowed_i)) begin
-      // Special case, exception in WB and pending single step.
-      // Indicate both non-debug trap and trap into debug mode
-      rvfi_trap_next[2:0]  = 3'b111;
-      rvfi_trap_next[8:3]  = ctrl_fsm_i.csr_cause.exception_code;
+
+    if(pending_single_step_i && single_step_allowed_i) begin
+      // The timing of the single step debug entry does not allow using pc_mux for detection
+      rvfi_trap_next[2:0]  = 3'b101;
       rvfi_trap_next[11:9] = DBG_CAUSE_STEP;
+      if (pc_mux_exception) begin
+        // Special case, exception in WB and pending single step.
+        // Indicate both non-debug trap and trap into debug mode
+        rvfi_trap_next[2:0]  = 3'b111;
+      end
     end
   end
 

--- a/sva/cv32e40x_rvfi_sva.sv
+++ b/sva/cv32e40x_rvfi_sva.sv
@@ -149,6 +149,12 @@ module cv32e40x_rvfi_sva
                      rvfi_trap[1] && rvfi_trap[2] |-> rvfi_trap[11:9] == DBG_CAUSE_STEP)
      else `uvm_error("rvfi", "rvfi_trap[2:1] == 2'b11, but debug cause bits do not indicate single stepping")
 
+  // Check that the trap is always signalled on the instruction before single step debug entry (unless killed by interrupt)
+  a_rvfi_single_step_no_trap_no_dbg_entry:
+    assert property (@(posedge clk_i) disable iff (!rst_ni)
+                     s_goto_next_rvfi_valid(rvfi_trap[11:9] != DBG_CAUSE_STEP) |-> ((rvfi_dbg != DBG_CAUSE_STEP) || rvfi_intr))
+     else `uvm_error("rvfi", "Single step debug entry without correct rvfi_trap first")
+
   // Check that dcsr.cause and mcause exception align with rvfi_trap when rvfi_trap[2:1] == 2'b11
   // rvfi_intr should also always be set in this case
   a_rvfi_trap_step_exception:


### PR DESCRIPTION
This is a fix for #342
Added missing support for reporting single step with rvfi_trap.
Added assertion that would have caught this missing feature

Signed-off-by: Halfdan Bechmann <halfdan.bechmann@silabs.com>