### PR TITLE
Removal of todo's and currently unused logic

### DIFF
--- a/rtl/cv32e40x_controller.sv
+++ b/rtl/cv32e40x_controller.sv
@@ -58,7 +58,6 @@ module cv32e40x_controller import cv32e40x_pkg::*;
   input  mpu_status_e lsu_mpu_status_wb_i,        // MPU status (WB stage)
   input  logic        data_stall_wb_i,            // WB stalled by LSU
   input  logic [1:0]  lsu_err_wb_i,               // LSU bus error in WB stage
-  input  logic [31:0] lsu_addr_wb_i,              // LSU address in WB stage
   input  logic        lsu_busy_i,                 // LSU is busy with outstanding transfers
   input  logic        lsu_interruptible_i,        // LSU may be interrupted
 
@@ -148,7 +147,6 @@ module cv32e40x_controller import cv32e40x_pkg::*;
 
     // From WB stage
     .lsu_err_wb_i                ( lsu_err_wb_i             ),
-    .lsu_addr_wb_i               ( lsu_addr_wb_i            ),
     .lsu_mpu_status_wb_i         ( lsu_mpu_status_wb_i      ),
     .data_stall_wb_i             ( data_stall_wb_i          ),
     .wb_ready_i                  ( wb_ready_i               ),

--- a/rtl/cv32e40x_core.sv
+++ b/rtl/cv32e40x_core.sv
@@ -176,7 +176,6 @@ module cv32e40x_core import cv32e40x_pkg::*;
   mpu_status_e lsu_mpu_status_wb;
   logic [31:0] lsu_rdata_wb;
   logic [1:0]  lsu_err_wb;
-  logic [31:0] lsu_addr_wb;
 
   logic        lsu_valid_0;             // Handshake with EX
   logic        lsu_ready_ex;
@@ -545,7 +544,6 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .lsu_mpu_status_1_o    ( lsu_mpu_status_wb  ),
 
     // Stage 1 outputs (WB)
-    .lsu_addr_1_o          ( lsu_addr_wb        ), // To controller (has WB timing, but does not pass through WB stage)
     .lsu_err_1_o           ( lsu_err_wb         ), // To controller (has WB timing, but does not pass through WB stage)
     .lsu_rdata_1_o         ( lsu_rdata_wb       ),
 
@@ -712,7 +710,6 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .lsu_split_ex_i                 ( lsu_split_ex           ),
     .lsu_mpu_status_wb_i            ( lsu_mpu_status_wb      ),
     .data_stall_wb_i                ( data_stall_wb          ),
-    .lsu_addr_wb_i                  ( lsu_addr_wb            ),
     .lsu_err_wb_i                   ( lsu_err_wb             ),
     .lsu_busy_i                     ( lsu_busy               ),
     .lsu_interruptible_i            ( lsu_interruptible      ),


### PR DESCRIPTION
Removed logic intended for preserving address of a faulted load or store for use in mtval CSR.

This code was not used, and it would not work in the current state as it could overwrite the
faulted address.

Added assertion to check max number of retired instructions after an NMI becomes pending.
This uncovered a case where the result of a faulted load may actually be used.

Bugfix: Halting ID stage in the same cycle as the bus error arrives, allowing max 1 extra retirement
after the faulted LSU instruction..

Non-SEC due to the bugfix.

Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>