### PR TITLE
Add PC mux in cv32e40x_controller_fsm. use this mux for fencei PC and exception PC

### DIFF
--- a/rtl/cv32e40x_controller.sv
+++ b/rtl/cv32e40x_controller.sv
@@ -43,6 +43,9 @@ module cv32e40x_controller import cv32e40x_pkg::*;
 
   input  logic        if_valid_i,
 
+  // From IF stage
+  input logic [31:0]  pc_if_i,
+
   // from IF/ID pipeline
   input  if_id_pipe_t if_id_pipe_i,
   input  logic        sys_mret_id_i,
@@ -126,6 +129,7 @@ module cv32e40x_controller import cv32e40x_pkg::*;
     .ctrl_byp_i                  ( ctrl_byp_o               ),
 
     .if_valid_i                  ( if_valid_i               ),
+    .pc_if_i                     ( pc_if_i                  ),
 
     // From ID stage
     .id_ready_i                  ( id_ready_i               ),

--- a/rtl/cv32e40x_controller_fsm.sv
+++ b/rtl/cv32e40x_controller_fsm.sv
@@ -558,9 +558,10 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
             ctrl_fsm_ns = SLEEP;
           end else if (fencei_in_wb) begin
 
-            ctrl_fsm_o.kill_if = 1'b1;
-            ctrl_fsm_o.kill_id = 1'b1;
-            ctrl_fsm_o.kill_ex = 1'b1;
+            // Halt the pipeline
+            ctrl_fsm_o.halt_if = 1'b1;
+            ctrl_fsm_o.halt_id = 1'b1;
+            ctrl_fsm_o.halt_ex = 1'b1;
             ctrl_fsm_o.halt_wb = 1'b1;
 
             if(fencei_ready) begin
@@ -569,10 +570,17 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
             end
             if(fencei_req_and_ack_q) begin
               // fencei req and ack were set at in the same cycle, complete handshake and jump to PC_FENCEI
-              // Unhalt wb and jump to wb.pc + 4
+
+              // Unhalt wb, kill if,id,ex
+              ctrl_fsm_o.kill_if   = 1'b1;
+              ctrl_fsm_o.kill_id   = 1'b1;
+              ctrl_fsm_o.kill_ex   = 1'b1;
+              ctrl_fsm_o.halt_wb   = 1'b0;
+
+              // Jump to wb.pc + 4
               ctrl_fsm_o.pc_set    = 1'b1;
               ctrl_fsm_o.pc_mux    = PC_FENCEI;
-              ctrl_fsm_o.halt_wb   = 1'b0;
+
               fencei_flush_req_set = 1'b0;
             end
           end else if (dret_in_wb) begin

--- a/rtl/cv32e40x_controller_fsm.sv
+++ b/rtl/cv32e40x_controller_fsm.sv
@@ -577,7 +577,15 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
               ctrl_fsm_o.kill_ex   = 1'b1;
               ctrl_fsm_o.halt_wb   = 1'b0;
 
-              // Jump to wb.pc + 4
+              // Jump to PC from oldest valid instruction, excluding WB stage
+              if (id_ex_pipe_i.instr_valid) begin
+                pipe_pc_mux_ctrl = PC_EX;
+              end else if (if_id_pipe_i.instr_valid) begin
+                pipe_pc_mux_ctrl = PC_ID;
+              end else begin
+                pipe_pc_mux_ctrl = PC_IF;
+              end
+
               ctrl_fsm_o.pc_set    = 1'b1;
               ctrl_fsm_o.pc_mux    = PC_FENCEI;
 

--- a/rtl/cv32e40x_core.sv
+++ b/rtl/cv32e40x_core.sv
@@ -349,7 +349,6 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .m_c_obi_instr_if    ( m_c_obi_instr_if         ), // Instruction bus interface
 
     .if_id_pipe_o        ( if_id_pipe               ),
-    .ex_wb_pipe_i        ( ex_wb_pipe               ),
 
     .ctrl_fsm_i          ( ctrl_fsm                 ),
     .trigger_match_i     ( trigger_match_if         ),
@@ -612,9 +611,6 @@ module cv32e40x_core import cv32e40x_pkg::*;
     // mtvec address
     .mtvec_addr_i               ( mtvec_addr_i[31:0]     ),
     .csr_mtvec_init_i           ( csr_mtvec_init_if      ),
-
-    // IF/ID pipeline
-    .if_id_pipe_i               ( if_id_pipe             ),
 
     // ID/EX pipeline
     .id_ex_pipe_i               ( id_ex_pipe             ),

--- a/rtl/cv32e40x_core.sv
+++ b/rtl/cv32e40x_core.sv
@@ -677,7 +677,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .ex_wb_pipe_i                   ( ex_wb_pipe             ),
 
     .if_valid_i                     ( if_valid               ),
-
+    .pc_if_i                        ( pc_if                  ),
     // from IF/ID pipeline
     .if_id_pipe_i                   ( if_id_pipe             ),
     .sys_mret_id_i                  ( sys_mret_insn_id       ),

--- a/rtl/cv32e40x_cs_registers.sv
+++ b/rtl/cv32e40x_cs_registers.sv
@@ -47,9 +47,6 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
   input  logic [31:0]     mtvec_addr_i,
   input  logic            csr_mtvec_init_i,
 
-  // IF/ID pipeline
-  input if_id_pipe_t      if_id_pipe_i,
-
   // ID/EX pipeline 
   input id_ex_pipe_t      id_ex_pipe_i,
 

--- a/rtl/cv32e40x_if_stage.sv
+++ b/rtl/cv32e40x_if_stage.sv
@@ -118,7 +118,7 @@ module cv32e40x_if_stage import cv32e40x_pkg::*;
       PC_BRANCH:   branch_addr_n = branch_target_ex_i;
       PC_MRET:     branch_addr_n = mepc_i;                                                      // PC is restored when returning from IRQ/exception
       PC_DRET:     branch_addr_n = dpc_i;
-      PC_FENCEI:   branch_addr_n = ex_wb_pipe_i.pc + 4;                                         // Jump to next instruction forces prefetch buffer reload // TODO:OK:low Can avoid adder, PC should already be in pipeline
+      PC_FENCEI:   branch_addr_n = ctrl_fsm_i.pipe_pc;                                          // Jump to next instruction forces prefetch buffer reload
       PC_TRAP_EXC: branch_addr_n = {mtvec_addr_i, 8'h0 };                                       // All the exceptions go to base address
       PC_TRAP_IRQ: branch_addr_n = {mtvec_addr_i, 1'b0, ctrl_fsm_i.m_exc_vec_pc_mux, 2'b0};     // interrupts are vectored
       PC_TRAP_DBD: branch_addr_n = {dm_halt_addr_i[31:2], 2'b0};

--- a/rtl/cv32e40x_if_stage.sv
+++ b/rtl/cv32e40x_if_stage.sv
@@ -49,7 +49,6 @@ module cv32e40x_if_stage import cv32e40x_pkg::*;
   input  logic [23:0]   mtvec_addr_i,           // Exception/interrupt address (MSBs)
   input  logic [31:0]   nmi_addr_i,             // NMI address
 
-  input  ex_wb_pipe_t   ex_wb_pipe_i,           // EX/WB pipeline stage
   input ctrl_fsm_t      ctrl_fsm_i,
   input  logic          trigger_match_i,
 

--- a/rtl/include/cv32e40x_pkg.sv
+++ b/rtl/include/cv32e40x_pkg.sv
@@ -1125,10 +1125,7 @@ typedef struct packed {
   logic        wake_from_sleep;       // Wakeup (due to irq or debug)
 
   // CSR signals
-  logic        csr_save_if;         // Save PC from IF stage
-  logic        csr_save_id;         // Save PC from ID stage
-  logic        csr_save_ex;         // Save PC from EX stage (currently unused)
-  logic        csr_save_wb;         // Save PC from WB stage
+  logic [31:0] pipe_pc;             // PC from pipeline
   mcause_t     csr_cause;           // CSR cause (saves to mcause CSR)
   logic        csr_restore_mret;    // Restore CSR due to mret
   logic        csr_save_cause;      // Update CSRs
@@ -1170,5 +1167,13 @@ typedef struct packed {
 
   // Enum used for configuration of B extension
   typedef enum logic [1:0] {NONE, ZBA_ZBB_ZBS, ZBA_ZBB_ZBC_ZBS} b_ext_e;
+
+  // Pipe PC mux selector defines. Used to control PC mux in control FSM
+  typedef enum logic[1:0] {
+    PC_IF,
+    PC_ID,
+    PC_EX,
+    PC_WB
+  } pipe_pc_mux_e;
 
 endpackage


### PR DESCRIPTION
PR consists of 3 commits:
ccd2871: SEC clean. Move PC mux from CS registers to controller FSM
f743203: Not SEC clean. Update the halt/kill behavior upon fencei. This is not SEC clean because the previous implementation would try to fetch an (unneeded) instruction when IF was killed when fencei entered WB. Halting IF (not killing) prevents this redundant instruction fetch.
5069951: SEC clean. Use output from PC mux in controller FSM upon fencei.