### PR TITLE
Fix XIF ID increment logic (#393)

### DIFF
--- a/rtl/cv32e40x_core.sv
+++ b/rtl/cv32e40x_core.sv
@@ -235,7 +235,10 @@ module cv32e40x_core import cv32e40x_pkg::*;
   logic        irq_ack;
   logic [4:0]  irq_id;
   logic        dbg_ack;
-  
+
+  // eXtension interface signals
+  logic        xif_offloading_id_if;
+
   // Internal OBI interfaces
   if_c_obi #(.REQ_TYPE(obi_inst_req_t), .RESP_TYPE(obi_inst_resp_t))  m_c_obi_instr_if();
   if_c_obi #(.REQ_TYPE(obi_data_req_t), .RESP_TYPE(obi_data_resp_t))  m_c_obi_data_if();
@@ -360,7 +363,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
 
     // eXtension interface
     .xif_compressed_if   ( xif_compressed_if        ),
-    .xif_issue_valid_i   ( xif_issue_if.issue_valid )
+    .xif_offloading_i    ( xif_offloading_id_if     )
   );
 
   /////////////////////////////////////////////////
@@ -422,7 +425,8 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .ex_ready_i                   ( ex_ready                  ),
 
     // eXtension interface
-    .xif_issue_if                 ( xif_issue_if              )
+    .xif_issue_if                 ( xif_issue_if              ),
+    .xif_offloading_o             ( xif_offloading_id_if      )
   );
 
 

--- a/rtl/cv32e40x_core.sv
+++ b/rtl/cv32e40x_core.sv
@@ -237,7 +237,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
   logic        dbg_ack;
 
   // eXtension interface signals
-  logic        xif_offloading_id_if;
+  logic        xif_offloading_id;
 
   // Internal OBI interfaces
   if_c_obi #(.REQ_TYPE(obi_inst_req_t), .RESP_TYPE(obi_inst_resp_t))  m_c_obi_instr_if();
@@ -363,7 +363,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
 
     // eXtension interface
     .xif_compressed_if   ( xif_compressed_if        ),
-    .xif_offloading_i    ( xif_offloading_id_if     )
+    .xif_offloading_id_i ( xif_offloading_id        )
   );
 
   /////////////////////////////////////////////////
@@ -426,7 +426,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
 
     // eXtension interface
     .xif_issue_if                 ( xif_issue_if              ),
-    .xif_offloading_o             ( xif_offloading_id_if      )
+    .xif_offloading_o             ( xif_offloading_id         )
   );
 
 

--- a/rtl/cv32e40x_id_stage.sv
+++ b/rtl/cv32e40x_id_stage.sv
@@ -88,7 +88,8 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
   input  logic        ex_ready_i,     // EX stage is ready for new data
 
   // eXtension interface
-  if_xif.cpu_issue  xif_issue_if
+  if_xif.cpu_issue    xif_issue_if,
+  output logic        xif_offloading_o
 );
 
   // Source/Destination register instruction index
@@ -664,6 +665,10 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
       // Instructions with deassert_we set to 1 from the controller bypass logic will not be attempted offloaded.
       assign xif_issue_if.issue_valid     = instr_valid && (illegal_insn || csr_en) &&
                                             !(xif_accepted_q || xif_rejected_q || ctrl_byp_i.deassert_we);
+
+      // Keep xif_offloading_o high after an offloaded instruction was accepted or rejected to get
+      // a new instruction ID from the IF stage
+      assign xif_offloading_o             = xif_issue_if.issue_valid || xif_accepted_q || xif_rejected_q;
 
       assign xif_issue_if.issue_req.instr = instr;
       assign xif_issue_if.issue_req.mode  = PRIV_LVL_M;

--- a/rtl/cv32e40x_if_stage.sv
+++ b/rtl/cv32e40x_if_stage.sv
@@ -66,7 +66,7 @@ module cv32e40x_if_stage import cv32e40x_pkg::*;
 
   // eXtension interface
   if_xif.cpu_compressed xif_compressed_if,      // XIF compressed interface
-  input  logic          xif_offloading_i        // ID stage attempts to offload an instruction
+  input  logic          xif_offloading_id_i     // ID stage attempts to offload an instruction
 );
 
   logic              if_ready;
@@ -289,7 +289,7 @@ module cv32e40x_if_stage import cv32e40x_pkg::*;
       assign xif_compressed_if.compressed_req   = '0;
 
       // TODO: assert that the oustanding IDs are unique
-      assign xif_id = xif_offloading_i ? if_id_pipe_o.xif_id + 1 : if_id_pipe_o.xif_id;
+      assign xif_id = xif_offloading_id_i ? if_id_pipe_o.xif_id + 1 : if_id_pipe_o.xif_id;
 
     end else begin : no_x_ext
 

--- a/rtl/cv32e40x_if_stage.sv
+++ b/rtl/cv32e40x_if_stage.sv
@@ -66,7 +66,7 @@ module cv32e40x_if_stage import cv32e40x_pkg::*;
 
   // eXtension interface
   if_xif.cpu_compressed xif_compressed_if,      // XIF compressed interface
-  input  logic          xif_issue_valid_i       // ID stage attempts to offload an instruction
+  input  logic          xif_offloading_i        // ID stage attempts to offload an instruction
 );
 
   logic              if_ready;
@@ -289,7 +289,7 @@ module cv32e40x_if_stage import cv32e40x_pkg::*;
       assign xif_compressed_if.compressed_req   = '0;
 
       // TODO: assert that the oustanding IDs are unique
-      assign xif_id = xif_issue_valid_i ? if_id_pipe_o.xif_id + 1 : if_id_pipe_o.xif_id;
+      assign xif_id = xif_offloading_i ? if_id_pipe_o.xif_id + 1 : if_id_pipe_o.xif_id;
 
     end else begin : no_x_ext
 


### PR DESCRIPTION
This is a patch for issue #393.

The IF stage increments XIF instruction IDs when the `issue_valid`
signal of the XIF issue interface is asserted.  However, if the ID stage
is stalled but the instruction currently held in it has been offloaded
and already accepted by the coprocessor, then `issue_valid` signal is no
longer asserted and thus the same instruction ID is reused for the next
offloaded instruction.

This patch fixes the problem by introducing a new signal that indicates
whether the instruction currently held in the ID stage is being
offloaded, with that signal remaining asserted if the coprocessor has
already accepted an instruction. The new signal informs the IF stage
whether the instruction currently in ID is being offloaded, in which
case the instruction ID is incremented.