### PR TITLE
Fix for issue #398.

### DIFF
--- a/rtl/cv32e40x_controller_fsm.sv
+++ b/rtl/cv32e40x_controller_fsm.sv
@@ -272,12 +272,12 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
   // or single stepping with dcsr.stepie==0 would stall ID stage and we would never get out of debug, resulting in a deadlock.
   assign pending_nmi = nmi_pending_q && !debug_mode_q && !(dcsr_i.step && !dcsr_i.stepie);
 
-  // Early version of the pending_nmi signal, including the unflopped lsu_err_wb_i[0]
-  // This signal is used for halting the ID stage in the same cycle as the bus error arrives, and any coming cycles where
-  // an NMI is pending but not allowed to be taken.
+  // Early version of the pending_nmi signal, using the unflopped lsu_err_wb_i[0]
+  // This signal is used for halting the ID stage in the same cycle as the bus error arrives.
   // This ensures that any instruction in the ID stage that may depend on the result of the faulted load
-  // will not get executed using invalid data.
-  assign pending_nmi_early = (nmi_pending_q || lsu_err_wb_i[0]) && !debug_mode_q && !(dcsr_i.step && !dcsr_i.stepie);
+  // will not propagate to the EX stage. For cycles after lsu_err_wb_i[0] is
+  // high, ID stage will be halted due to pending_nmi and !nmi_allowed.
+  assign pending_nmi_early =  lsu_err_wb_i[0] && !debug_mode_q && !(dcsr_i.step && !dcsr_i.stepie);
 
   // todo: Halting ID and killing it later will not work for Zce (push/pop)
 
@@ -349,13 +349,8 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
 
   assign interrupt_allowed = lsu_interruptible_i && !fencei_ongoing && !xif_in_wb;
 
-  // Factoring in nmi_pending_q to be able to halt the ID stage during the
-  // same cycle as the NMI is visible to the core. If we leave it out,
-  // nmi_allowed may be 1 in the same cycle as the error comes in, and the ID
-  // stage will not be halted. This may cause the instruction in ID to
-  // propagate to EX, and possible retire three instructions before the NMI is
-  // taken (instructions in WB, EX and ID at the time of the bus error).
-  assign nmi_allowed = interrupt_allowed && nmi_pending_q;
+  // Allowing NMI's follow the same rule as regular interrupts.
+  assign nmi_allowed = interrupt_allowed;
 
   // Do not count if we have an exception in WB, trigger match in WB (we do not execute the instruction at trigger address),
   // or WB stage is killed or halted.
@@ -421,7 +416,8 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
     ctrl_fsm_o.halt_id = ctrl_byp_i.jalr_stall || ctrl_byp_i.load_stall || ctrl_byp_i.csr_stall || ctrl_byp_i.wfi_stall ||
                          (pending_interrupt && !interrupt_allowed) ||
                          (pending_debug && !debug_allowed) ||
-                         (pending_nmi_early && !nmi_allowed);
+                         (pending_nmi && !nmi_allowed) ||
+                         (pending_nmi_early);
     // Halting EX if minstret_stall occurs. Otherwise we would read the wrong minstret value
     // Also halting EX if an offloaded instruction in WB may cause an exception, such that a following offloaded
     // instruction can correctly receive commit_kill.

--- a/sva/cv32e40x_controller_fsm_sva.sv
+++ b/sva/cv32e40x_controller_fsm_sva.sv
@@ -494,11 +494,12 @@ endgenerate
     end
   end
 
-  // valid_cnt will start counting one cycle after the faulted LSU instruction has been retired, allowing for one more retirement before
-  // NMI is taken.
+  // valid_cnt will start counting one cycle after the LSU bus error has become visible to the core, allowing for two retirements before
+  // NMI is taken (bus error may come in between instructions, if the response
+  // is associated with a buffered write).
   a_nmi_handler_max_retire:
     assert property (@(posedge clk) disable iff (!rst_n)
-                    (valid_cnt < 2'b10)) // 0 or 1 instructions are allowed to retire, thus the counter must always be less than 2.
+                    (valid_cnt < 2'b11)) // Max two instructions are allowed to retire, thus the counter must always be less than 3.
     else `uvm_error("controller", "NMI handler not taken within two instruction retirements")
 endmodule // cv32e40x_controller_fsm_sva
 

--- a/sva/cv32e40x_controller_fsm_sva.sv
+++ b/sva/cv32e40x_controller_fsm_sva.sv
@@ -500,13 +500,13 @@ endgenerate
   // valid_cnt will start counting one cycle after the LSU bus error has
   // become visible to the core. If an instruction was retired (wb_valid=1)
   // when the bus error arrived, we will allow one more instruction to retire
-  // before the NMI is taken. If we didn't retire at the same time as the bus
-  // error, we allow two instructions to retire. In any case, max two
+  // before the NMI is taken (counter < 2). If we didn't retire at the same time as the bus
+  // error, we allow two instructions to retire (counter < 3). In any case, max two
   // instructions will retire after the bus error has become visible to the
   // core.
   a_nmi_handler_max_retire:
     assert property (@(posedge clk) disable iff (!rst_n)
-                    (valid_cnt < (retire_at_error ? 2'b10 : 2'b11))) // Max two instructions are allowed to retire, thus the counter must always be less than 3.
+                    (valid_cnt < (retire_at_error ? 2'b10 : 2'b11)))
     else `uvm_error("controller", "NMI handler not taken within two instruction retirements")
 endmodule // cv32e40x_controller_fsm_sva
 

--- a/sva/cv32e40x_controller_fsm_sva.sv
+++ b/sva/cv32e40x_controller_fsm_sva.sv
@@ -418,12 +418,14 @@ endgenerate
   logic [1:0] outstanding_count;
   logic bus_error_is_write;
   logic bus_error_latched;
+  logic retire_at_error; // 1 if wb_valid_i is high when the bus error is active
   always_ff @(posedge clk, negedge rst_n) begin
     if (rst_n == 1'b0) begin
       outstanding_type <= 2'b00;
       outstanding_count <= 2'b00;
       bus_error_latched <= 1'b0;
       bus_error_is_write <= 1'b0;
+      retire_at_error <= 1'b0;
     end else begin
       // Req, no rvalid
       if( (m_c_obi_data_if.s_req && m_c_obi_data_if.s_gnt) && !m_c_obi_data_if.s_rvalid) begin
@@ -460,6 +462,7 @@ endgenerate
       if(m_c_obi_data_if.s_rvalid && m_c_obi_data_if.resp_payload.err && !bus_error_latched) begin
         bus_error_is_write <= outstanding_count == 2'b01 ? outstanding_type[0] : outstanding_type[1];
         bus_error_latched <= 1'b1;
+        retire_at_error <= wb_valid_i;
       end else begin
         if (ctrl_fsm_o.pc_set && ctrl_fsm_o.pc_mux == PC_TRAP_NMI) begin
           bus_error_latched <= 1'b0;
@@ -494,12 +497,16 @@ endgenerate
     end
   end
 
-  // valid_cnt will start counting one cycle after the LSU bus error has become visible to the core, allowing for two retirements before
-  // NMI is taken (bus error may come in between instructions, if the response
-  // is associated with a buffered write).
+  // valid_cnt will start counting one cycle after the LSU bus error has
+  // become visible to the core. If an instruction was retired (wb_valid=1)
+  // when the bus error arrived, we will allow one more instruction to retire
+  // before the NMI is taken. If we didn't retire at the same time as the bus
+  // error, we allow two instructions to retire. In any case, max two
+  // instructions will retire after the bus error has become visible to the
+  // core.
   a_nmi_handler_max_retire:
     assert property (@(posedge clk) disable iff (!rst_n)
-                    (valid_cnt < 2'b11)) // Max two instructions are allowed to retire, thus the counter must always be less than 3.
+                    (valid_cnt < (retire_at_error ? 2'b10 : 2'b11))) // Max two instructions are allowed to retire, thus the counter must always be less than 3.
     else `uvm_error("controller", "NMI handler not taken within two instruction retirements")
 endmodule // cv32e40x_controller_fsm_sva
 


### PR DESCRIPTION
Three instructions could be retired between a bus error and the taken NMI.
Fixed RTL to halt ID stage earlier, and updated the associated assertion
to take into account that bus errors for bufferable writes may come between
instructions.

Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>