### PR TITLE
Suppressing csr_en for nullified instructions 

### DIFF
--- a/rtl/cv32e40x_decoder.sv
+++ b/rtl/cv32e40x_decoder.sv
@@ -98,6 +98,7 @@ module cv32e40x_decoder import cv32e40x_pkg::*;
 
   csr_opcode_e csr_op;
 
+  logic       csr_en;
   logic       alu_en;
   logic       mul_en;
   logic       div_en;
@@ -207,7 +208,7 @@ module cv32e40x_decoder import cv32e40x_pkg::*;
   assign div_operator_o     = decoder_ctrl_mux.div_operator;
   assign rf_re_o            = decoder_ctrl_mux.rf_re;                         
   assign rf_we              = decoder_ctrl_mux.rf_we;                           
-  assign csr_en_o           = decoder_ctrl_mux.csr_en;
+  assign csr_en             = decoder_ctrl_mux.csr_en;
   assign csr_op             = decoder_ctrl_mux.csr_op;                          
   assign lsu_en             = decoder_ctrl_mux.lsu_en;                        
   assign lsu_we_o           = decoder_ctrl_mux.lsu_we;                       
@@ -229,6 +230,7 @@ module cv32e40x_decoder import cv32e40x_pkg::*;
   assign div_en_o = deassert_we_i ? 1'b0        : div_en;
   assign lsu_en_o = deassert_we_i ? 1'b0        : lsu_en;
 
+  assign csr_en_o = deassert_we_i ? 1'b0        : csr_en;
   assign csr_op_o = deassert_we_i ? CSR_OP_READ : csr_op; // Gating csr_en introduces tight timing path, gate csr_op instead
   assign rf_we_o  = deassert_we_i ? 1'b0        : rf_we;
 

--- a/rtl/cv32e40x_decoder.sv
+++ b/rtl/cv32e40x_decoder.sv
@@ -96,8 +96,6 @@ module cv32e40x_decoder import cv32e40x_pkg::*;
   logic       rf_we;
   logic       lsu_en;
 
-  csr_opcode_e csr_op;
-
   logic       csr_en;
   logic       alu_en;
   logic       mul_en;
@@ -209,7 +207,7 @@ module cv32e40x_decoder import cv32e40x_pkg::*;
   assign rf_re_o            = decoder_ctrl_mux.rf_re;                         
   assign rf_we              = decoder_ctrl_mux.rf_we;                           
   assign csr_en             = decoder_ctrl_mux.csr_en;
-  assign csr_op             = decoder_ctrl_mux.csr_op;                          
+  assign csr_op_o           = decoder_ctrl_mux.csr_op;
   assign lsu_en             = decoder_ctrl_mux.lsu_en;                        
   assign lsu_we_o           = decoder_ctrl_mux.lsu_we;                       
   assign lsu_size_o         = decoder_ctrl_mux.lsu_size;                     
@@ -231,7 +229,6 @@ module cv32e40x_decoder import cv32e40x_pkg::*;
   assign lsu_en_o = deassert_we_i ? 1'b0        : lsu_en;
 
   assign csr_en_o = deassert_we_i ? 1'b0        : csr_en;
-  assign csr_op_o = deassert_we_i ? CSR_OP_READ : csr_op; // Gating csr_en introduces tight timing path, gate csr_op instead
   assign rf_we_o  = deassert_we_i ? 1'b0        : rf_we;
 
   // Suppress special instruction/illegal instruction bits

--- a/rtl/cv32e40x_id_stage.sv
+++ b/rtl/cv32e40x_id_stage.sv
@@ -552,7 +552,9 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
         end
 
         id_ex_pipe_o.csr_en                 <= csr_en;
-        id_ex_pipe_o.csr_op                 <= csr_op;
+        if (csr_en) begin
+          id_ex_pipe_o.csr_op               <= csr_op;
+        end
 
         id_ex_pipe_o.lsu_en                 <= lsu_en;
         if (lsu_en) begin


### PR DESCRIPTION
Suppressing csr_en for nullified instructions instead of csr_op to avoid affecting stall cycles with nullified instructions.
This no longer results in timing issues.

Fix for #156 