### PR TITLE
Add XIF memory interface

### DIFF
--- a/rtl/cv32e40x_core.sv
+++ b/rtl/cv32e40x_core.sv
@@ -525,6 +525,8 @@ module cv32e40x_core import cv32e40x_pkg::*;
   cv32e40x_load_store_unit
   #(
     .A_EXT                 (A_EXT               ),
+    .X_EXT                 (X_EXT               ),
+    .X_ID_WIDTH            (X_ID_WIDTH          ),
     .PMA_NUM_REGIONS       (PMA_NUM_REGIONS     ),
     .PMA_CFG               (PMA_CFG             )
   )

--- a/rtl/cv32e40x_load_store_unit.sv
+++ b/rtl/cv32e40x_load_store_unit.sv
@@ -147,7 +147,7 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
   logic                  xif_res_q;     // The next memory result is for the XIF interface
   logic [X_ID_WIDTH-1:0] xif_id_q;      // Instruction ID of an XIF memory transaction
 
-  assign xif_req = X_EXT & xif_mem_if.mem_valid;
+  assign xif_req = X_EXT && xif_mem_if.mem_valid;
 
   // Transaction (before aligner)
   // Generate address from operands (atomic memory transactions do not use an address offset computation)
@@ -496,7 +496,7 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
 
   // LSU second stage is valid when resp_valid (typically data_rvalid_i) is received. For a misaligned/split
   // load/store only its second phase is marked as valid (last_q == 1'b1)
-  assign valid_1_o                          = last_q && resp_valid && valid_1_i && ~xif_res_q;
+  assign valid_1_o                          = last_q && resp_valid && valid_1_i && !xif_res_q;
   assign xif_mem_result_if.mem_result_valid = last_q && resp_valid &&               xif_res_q;
 
   // LSU EX stage readyness requires two criteria to be met:
@@ -657,7 +657,7 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
     .misaligned_access_i  ( misaligned_access  ),
 
     .core_one_txn_pend_n  ( cnt_is_one_next    ),
-    .core_mpu_err_wait_i  ( ~xif_req           ),
+    .core_mpu_err_wait_i  ( !xif_req           ),
     .core_mpu_err_o       ( xif_mpu_err        ),
     .core_trans_valid_i   ( trans_valid        ),
     .core_trans_ready_o   ( trans_ready        ),

--- a/rtl/if_xif.sv
+++ b/rtl/if_xif.sv
@@ -79,14 +79,14 @@ interface if_xif import cv32e40x_pkg::*;
   } x_commit_t;
 
   typedef struct packed {
-    logic [X_ID_WIDTH -1:0] id;       // Identification of the offloaded instruction
-    logic [           31:0] addr;     // Virtual address of the memory transaction
-    logic [            1:0] mode;     // Privilege level
-    logic                   we;       // Write enable of the memory transaction
-    logic [            1:0] size;     // Size of the memory transaction
-    logic [X_MEM_WIDTH-1:0] wdata;    // Write data of a store memory transaction
-    logic                   last;     // Is this the last memory transaction for the offloaded instruction?
-    logic                   spec;     // Is the memory transaction speculative?
+    logic [X_ID_WIDTH   -1:0] id;    // Identification of the offloaded instruction
+    logic [             31:0] addr;  // Virtual address of the memory transaction
+    logic [              1:0] mode;  // Privilege level
+    logic                     we;    // Write enable of the memory transaction
+    logic [X_MEM_WIDTH/8-1:0] be;    // Size of the memory transaction
+    logic [X_MEM_WIDTH  -1:0] wdata; // Write data of a store memory transaction
+    logic                     last;  // Is this the last memory transaction for the offloaded instruction?
+    logic                     spec;  // Is the memory transaction speculative?
   } x_mem_req_t;
 
   typedef struct packed {


### PR DESCRIPTION
This PR adds the XIF memory interfaces (i.e., the [memory request/response](https://docs.openhwgroup.org/projects/openhw-group-core-v-xif/x_ext.html#memory-request-response-interface) and the [memory result](https://docs.openhwgroup.org/projects/openhw-group-core-v-xif/x_ext.html#memory-result-interface) interfaces) to CV32E40X.

The first commit replaces the [`size` field in the XIF interface definitions](https://github.com/openhwgroup/cv32e40x/blob/380b9fd6dff586d332886e0eaa875e9aafa54ca6/rtl/if_xif.sv#L86) with a byte enable mask as discussed here: https://github.com/openhwgroup/core-v-xif/issues/17

The second commit implements the base functionality required to handle memory requests by a coprocessor. Memory requests received via the XIF memory interface are converted into memory transactions. The aligner performs alignment for XIF memory data based on the lower bits of the address as usual, with the assumption that an XIF request always uses the entire width of the memory interface (i.e., is always 32 bits wide). Note that the byte enable mask received via the XIF interface is aligned as well. Split accesses are performed if required (as is done for internal memory transactions).

The third commit forwards MPU errors and bus errors resulting from XIF memory transactions to the coprocessor. MPU errors must be reported immediately via the XIF memory response interface, rather than being buffered as is done for internal transactions. This required some changes to the MPU, which has now the option to issue MPU errors via the new `core_mpu_err_o` port immediately.

As with previous patches related to the XIF interface, the new functionality is only enabled when `X_EXT` is 1. In particular, if `X_EXT` is 0, then the functionality of CV32E40X is not modified.

Acknowledgements: The changes in this PR have been inspired by earlier work by Kunal Dalal, Oana Lazar, Yu Xia, and Adomas Lebedys from the University of Southampton in the context of the AVA vector accelerator project, see: https://github.com/AI-Vector-Accelerator