### PR TITLE
Rename pma_region_t -> pma_cfg_t in RTL and SVA

### DIFF
--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -64,7 +64,7 @@ module cv32e40x_wrapper
   parameter int          SMCLIC_ID_WIDTH              = 6,
   parameter int          DBG_NUM_TRIGGERS             = 1,
   parameter int          PMA_NUM_REGIONS              = 0,
-  parameter pma_region_t PMA_CFG[PMA_NUM_REGIONS-1:0] = '{default:PMA_R_DEFAULT}
+  parameter pma_cfg_t    PMA_CFG[PMA_NUM_REGIONS-1:0] = '{default:PMA_R_DEFAULT}
 )
 (
   // Clock and Reset

--- a/rtl/cv32e40x_core.sv
+++ b/rtl/cv32e40x_core.sv
@@ -50,7 +50,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
   parameter int          SMCLIC_ID_WIDTH              = 6,
   parameter int          DBG_NUM_TRIGGERS             = 1,
   parameter int          PMA_NUM_REGIONS              = 0,
-  parameter pma_region_t PMA_CFG[PMA_NUM_REGIONS-1:0] = '{default:PMA_R_DEFAULT}
+  parameter pma_cfg_t    PMA_CFG[PMA_NUM_REGIONS-1:0] = '{default:PMA_R_DEFAULT}
 )
 (
   // Clock and Reset

--- a/rtl/cv32e40x_if_stage.sv
+++ b/rtl/cv32e40x_if_stage.sv
@@ -32,7 +32,7 @@ module cv32e40x_if_stage import cv32e40x_pkg::*;
   parameter bit          X_EXT           = 0,
   parameter int          X_ID_WIDTH      = 4,
   parameter int          PMA_NUM_REGIONS = 0,
-  parameter pma_region_t PMA_CFG[PMA_NUM_REGIONS-1:0] = '{default:PMA_R_DEFAULT}
+  parameter pma_cfg_t    PMA_CFG[PMA_NUM_REGIONS-1:0] = '{default:PMA_R_DEFAULT}
 )
 (
   input  logic          clk,

--- a/rtl/cv32e40x_load_store_unit.sv
+++ b/rtl/cv32e40x_load_store_unit.sv
@@ -29,7 +29,7 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
 #(
   parameter bit          A_EXT = 0,
   parameter int          PMA_NUM_REGIONS = 0,
-  parameter pma_region_t PMA_CFG[PMA_NUM_REGIONS-1:0] = '{default:PMA_R_DEFAULT}
+  parameter pma_cfg_t    PMA_CFG[PMA_NUM_REGIONS-1:0] = '{default:PMA_R_DEFAULT}
 )
 (
   input  logic        clk,

--- a/rtl/cv32e40x_mpu.sv
+++ b/rtl/cv32e40x_mpu.sv
@@ -30,7 +30,7 @@ module cv32e40x_mpu import cv32e40x_pkg::*;
       parameter type         CORE_RESP_TYPE               = inst_resp_t,
       parameter type         BUS_RESP_TYPE                = obi_inst_resp_t,
       parameter int          PMA_NUM_REGIONS              = 0,
-      parameter pma_region_t PMA_CFG[PMA_NUM_REGIONS-1:0] = '{default:PMA_R_DEFAULT})
+      parameter pma_cfg_t    PMA_CFG[PMA_NUM_REGIONS-1:0] = '{default:PMA_R_DEFAULT})
   (
    input logic  clk,
    input logic  rst_n,

--- a/rtl/cv32e40x_pma.sv
+++ b/rtl/cv32e40x_pma.sv
@@ -27,7 +27,7 @@ module cv32e40x_pma import cv32e40x_pkg::*;
 #(  
   parameter bit          A_EXT = 0,
   parameter int          PMA_NUM_REGIONS = 0,
-  parameter pma_region_t PMA_CFG[PMA_NUM_REGIONS-1:0] = '{default:PMA_R_DEFAULT}
+  parameter pma_cfg_t    PMA_CFG[PMA_NUM_REGIONS-1:0] = '{default:PMA_R_DEFAULT}
 )
 (
   input  logic [31:0] trans_addr_i,
@@ -42,7 +42,7 @@ module cv32e40x_pma import cv32e40x_pkg::*;
   
   parameter PMA_ADDR_LSB = 0; // TODO:OE experiment and see if this makes a difference
   
-  pma_region_t pma_cfg;
+  pma_cfg_t pma_cfg;
   logic [31:0] word_addr;
   logic pma_cfg_atomic;
 

--- a/rtl/cv32e40x_write_buffer.sv
+++ b/rtl/cv32e40x_write_buffer.sv
@@ -32,7 +32,7 @@
 module cv32e40x_write_buffer import cv32e40x_pkg::*;
 #(
   parameter int          PMA_NUM_REGIONS = 0,
-  parameter pma_region_t PMA_CFG[PMA_NUM_REGIONS-1:0] = '{default:PMA_R_DEFAULT}
+  parameter pma_cfg_t    PMA_CFG[PMA_NUM_REGIONS-1:0] = '{default:PMA_R_DEFAULT}
 )
   (
    // clock and reset

--- a/rtl/include/cv32e40x_pkg.sv
+++ b/rtl/include/cv32e40x_pkg.sv
@@ -859,23 +859,23 @@ typedef struct packed {
   logic        bufferable;
   logic        cacheable;
   logic        atomic;
-} pma_region_t;
+} pma_cfg_t;
 
 // Default attribution when PMA is not configured (PMA_NUM_REGIONS=0) (Address is don't care)
-parameter pma_region_t NO_PMA_R_DEFAULT = '{word_addr_low   : 0,
-                                            word_addr_high  : 0,
-                                            main            : 1'b1,
-                                            bufferable      : 1'b0,
-                                            cacheable       : 1'b0,
-                                            atomic          : 1'b1};
-
-// Default attribution when PMA is configured (Address is don't care)
-parameter pma_region_t PMA_R_DEFAULT = '{word_addr_low   : 0,
+parameter pma_cfg_t NO_PMA_R_DEFAULT = '{word_addr_low   : 0,
                                          word_addr_high  : 0,
-                                         main            : 1'b0,
+                                         main            : 1'b1,
                                          bufferable      : 1'b0,
                                          cacheable       : 1'b0,
-                                         atomic          : 1'b0};
+                                         atomic          : 1'b1};
+
+// Default attribution when PMA is configured (Address is don't care)
+parameter pma_cfg_t PMA_R_DEFAULT = '{word_addr_low   : 0,
+                                      word_addr_high  : 0,
+                                      main            : 1'b0,
+                                      bufferable      : 1'b0,
+                                      cacheable       : 1'b0,
+                                      atomic          : 1'b0};
 
 // MPU status. Used for PMA
 typedef enum logic [1:0] {

--- a/sva/cv32e40x_mpu_sva.sv
+++ b/sva/cv32e40x_mpu_sva.sv
@@ -25,7 +25,7 @@
 
 module cv32e40x_mpu_sva import cv32e40x_pkg::*; import uvm_pkg::*;
   #(  parameter int PMA_NUM_REGIONS              = 0,
-      parameter pma_region_t PMA_CFG[PMA_NUM_REGIONS-1:0] = '{default:PMA_R_DEFAULT},
+      parameter pma_cfg_t    PMA_CFG[PMA_NUM_REGIONS-1:0] = '{default:PMA_R_DEFAULT},
       parameter int unsigned IS_INSTR_SIDE = 0)
   (
    input logic        clk,
@@ -40,7 +40,7 @@ module cv32e40x_mpu_sva import cv32e40x_pkg::*; import uvm_pkg::*;
    // PMA signals
    input logic        pma_err,
    input logic [31:0] pma_addr,
-   input pma_region_t pma_cfg,
+   input pma_cfg_t    pma_cfg,
 
    // Core OBI signals
    input logic [ 1:0] obi_memtype,
@@ -206,7 +206,7 @@ module cv32e40x_mpu_sva import cv32e40x_pkg::*; import uvm_pkg::*;
   endgenerate
 
   // RTL vs SVA expectations
-  pma_region_t pma_expected_cfg;
+  pma_cfg_t    pma_expected_cfg;
   logic        pma_expected_err;
   always_comb begin
     pma_expected_cfg = NO_PMA_R_DEFAULT;

--- a/sva/cv32e40x_write_buffer_sva.sv
+++ b/sva/cv32e40x_write_buffer_sva.sv
@@ -28,7 +28,7 @@ module cv32e40x_write_buffer_sva
   import uvm_pkg::*;
   #(
      parameter int PMA_NUM_REGIONS = 0,
-     parameter pma_region_t PMA_CFG[PMA_NUM_REGIONS-1:0] = '{default:PMA_R_DEFAULT}
+     parameter pma_cfg_t PMA_CFG[PMA_NUM_REGIONS-1:0] = '{default:PMA_R_DEFAULT}
   )
   (input logic          clk,
    input logic          rst_n,


### PR DESCRIPTION
Rename pma_region_t to pma_cfg_t. For consistency.