### PR TITLE
RVFI bugfixes

### DIFF
--- a/bhv/cv32e40x_rvfi.sv
+++ b/bhv/cv32e40x_rvfi.sv
@@ -552,7 +552,11 @@ module cv32e40x_rvfi
   assign pc_mux_nmi             = (ctrl_fsm_i.pc_mux == PC_TRAP_NMI);
   assign pc_mux_debug           = (ctrl_fsm_i.pc_mux == PC_TRAP_DBD);
   assign pc_mux_exception       = (ctrl_fsm_i.pc_mux == PC_TRAP_EXC) || pc_mux_debug_exception ;
-  assign pc_mux_debug_exception = (ctrl_fsm_i.pc_mux == PC_TRAP_DBE) && !dret_in_ex_i; // Ignore exceptions from instructons that will never be executed
+  // The debug exception for mret is taken in ID (contrary to all other exceptions). In the case where we have a dret in the EX stage at the same time,
+  // this can lead to a situation we take the exception for the mret even though it never reaches the WB stage.
+  // This works in rtl because the exception handler instructions will get killed.
+  // In rvfi this exception needs to be ignored as it comes from an instruction that does not retire.
+  assign pc_mux_debug_exception = (ctrl_fsm_i.pc_mux == PC_TRAP_DBE) && !dret_in_ex_i;
   assign pc_mux_dret            = (ctrl_fsm_i.pc_mux == PC_DRET);
 
   assign branch_taken_ex = branch_in_ex_i && branch_decision_ex_i;

--- a/bhv/cv32e40x_rvfi.sv
+++ b/bhv/cv32e40x_rvfi.sv
@@ -52,6 +52,7 @@ module cv32e40x_rvfi
 
    //// EX probes ////
    input logic                                branch_in_ex_i,
+   input logic                                dret_in_ex_i,
    // LSU
    input logic                                lsu_en_ex_i,
    input logic                                lsu_pmp_err_ex_i,
@@ -517,6 +518,7 @@ module cv32e40x_rvfi
   logic         pc_mux_debug;
   logic         pc_mux_dret;
   logic         pc_mux_exception;
+  logic         pc_mux_debugs_exception;
   logic         pc_mux_interrupt;
   logic         pc_mux_nmi;
 
@@ -543,11 +545,13 @@ module cv32e40x_rvfi
   // The pc_mux signals probe the MUX in the IF stage to extract information about events in the WB stage.
   // These signals are therefore used both in the WB stage to see effects of the executed instruction (e.g. rvfi_trap), and
   // in the IF stage to see the reason for executing the instruction (e.g. rvfi_intr).
-  assign pc_mux_interrupt = (ctrl_fsm_i.pc_mux == PC_TRAP_IRQ);
-  assign pc_mux_nmi       = (ctrl_fsm_i.pc_mux == PC_TRAP_NMI);
-  assign pc_mux_debug     = (ctrl_fsm_i.pc_mux == PC_TRAP_DBD);
-  assign pc_mux_exception = (ctrl_fsm_i.pc_mux == PC_TRAP_EXC) || (ctrl_fsm_i.pc_mux == PC_TRAP_DBE);
-  assign pc_mux_dret      = (ctrl_fsm_i.pc_mux == PC_DRET);
+  assign pc_mux_interrupt       = (ctrl_fsm_i.pc_mux == PC_TRAP_IRQ);
+  assign pc_mux_nmi             = (ctrl_fsm_i.pc_mux == PC_TRAP_NMI);
+  assign pc_mux_debug           = (ctrl_fsm_i.pc_mux == PC_TRAP_DBD);
+  assign pc_mux_exception       = (ctrl_fsm_i.pc_mux == PC_TRAP_EXC) || pc_mux_debug_exception ;
+  assign pc_mux_debug_exception = (ctrl_fsm_i.pc_mux == PC_TRAP_DBE) && !dret_in_ex_i; // Ignore exceptions from instructons that will never be executed
+  assign pc_mux_dret            = (ctrl_fsm_i.pc_mux == PC_DRET);
+
 
   // Assign rvfi channels
   assign rvfi_halt = 1'b0; // No intruction causing halt in cv32e40x

--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -386,6 +386,7 @@ module cv32e40x_wrapper
          .lsu_we_id_i              ( core_i.id_stage_i.lsu_we                                             ),
 
          .branch_in_ex_i           ( core_i.controller_i.controller_fsm_i.branch_in_ex                    ),
+         .branch_decision_ex_i     ( core_i.ex_stage_i.branch_decision_o                                  ),
          .dret_in_ex_i             ( core_i.ex_stage_i.id_ex_pipe_i.sys_dret_insn                         ),
          .lsu_en_ex_i              ( core_i.ex_stage_i.id_ex_pipe_i.lsu_en                                ),
 

--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -386,6 +386,7 @@ module cv32e40x_wrapper
          .lsu_we_id_i              ( core_i.id_stage_i.lsu_we                                             ),
 
          .branch_in_ex_i           ( core_i.controller_i.controller_fsm_i.branch_in_ex                    ),
+         .dret_in_ex_i             ( core_i.ex_stage_i.id_ex_pipe_i.sys_dret_insn                         ),
          .lsu_en_ex_i              ( core_i.ex_stage_i.id_ex_pipe_i.lsu_en                                ),
 
          .instr_pmp_err_if_i       ( 1'b0                          /* PMP not implemented in cv32e40x */  ),

--- a/rtl/cv32e40x_load_store_unit.sv
+++ b/rtl/cv32e40x_load_store_unit.sv
@@ -267,7 +267,7 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
 
   logic [31:0] rdata_ext;
   logic [63:0] rdata_full;
-  logic [31:0] rdata_aligned;
+  logic [63:0] rdata_aligned; // [63:32] unsused
   logic        rdata_is_split;
 
   // Check if rdata is split over two accesses


### PR DESCRIPTION
Fixed rvfi issue where rvfi_intr could get set due to an mret that is killed before getting to writeback. 
Fixed rvfi branch handing (#452 )

Also fixed formal warning in load-store unit.