### PR TITLE
Increased allowed SMCLIC_ID_WIDTH range. Moved to OBI v1.4

### DIFF
--- a/docs/user_manual/source/control_status_registers.rst
+++ b/docs/user_manual/source/control_status_registers.rst
@@ -651,18 +651,18 @@ Detailed:
 +-------------+------------+-----------------------------------------------------------------------+
 |   Bit #     |   R/W      |           Description                                                 |
 +=============+============+=======================================================================+
-| 31:8        | WARL       | **BASE[31:8]**: Trap-handler vector table base address.               |
+| 31:7        | WARL       | **BASE[31:7]**: Trap-handler vector table base address.               |
 |             |            | See note below for alignment restrictions.                            |
 +-------------+------------+-----------------------------------------------------------------------+
-| 7:6         | WARL (0x0) | **BASE[7:6]**: Trap-handler vector table base address.                |
+| 6           | WARL (0x0) | **BASE[6]**: Trap-handler vector table base address.                  |
 +-------------+------------+-----------------------------------------------------------------------+
-|  5:0        | R (0x0)    | Reserved. Hardwired to 0.                                             |
+| 5:0         | R (0x0)    | Reserved. Hardwired to 0.                                             |
 +-------------+------------+-----------------------------------------------------------------------+
 
 .. note::
    The ``mtvt`` CSR holds the base address of the trap vector table, aligned on a ``2^(2+SMCLIC_ID_WIDTH)`` bytes or greater
    power-of-two boundary. For example if ``SMCLIC_ID_WIDTH`` = 8, then 256 CLIC interrupts are supported and the trap vector table
-   is aligned to 1024 bytes, and therefore **BASE[9:8]** will be WARL (0x0).
+   is aligned to 1024 bytes, and therefore **BASE[9:7]** will be WARL (0x0).
 
 Machine Status (``mstatush``)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/user_manual/source/exceptions_interrupts.rst
+++ b/docs/user_manual/source/exceptions_interrupts.rst
@@ -110,7 +110,7 @@ Interrupts - ``SMCLIC`` == 1
 ----------------------------
 
 Although the [RISC-V-SMCLIC]_ specification supports up to 4096 interrupts, |corev| itself supports at most 1024 interrupts. The
-maximum number of supported CLIC interrupts is equal to ``2^SMCLIC_ID_WIDTH``, which can range from 64 to 1024. The ``SMCLIC_ID_WIDTH`` parameter
+maximum number of supported CLIC interrupts is equal to ``2^SMCLIC_ID_WIDTH``, which can range from 32 to 1024. The ``SMCLIC_ID_WIDTH`` parameter
 also dictates the minimum alignment requirement for the trap vector table to ``2^(2+SMCLIC_ID_WIDTH)`` byte boundaries, see :ref:`csr-mtvt`.
 
 Non Maskable Interrupts

--- a/docs/user_manual/source/integration.rst
+++ b/docs/user_manual/source/integration.rst
@@ -181,7 +181,7 @@ Parameters
 +--------------------------------+----------------+---------------+--------------------------------------------------------------------+
 | ``SMCLIC``                     | int (0..1 )    | 0             | Is Smclic supported?                                               |
 +--------------------------------+----------------+---------------+--------------------------------------------------------------------+
-| ``SMCLIC_ID_WIDTH``            | int (6..10 )   | 6             | Width of ``clic_irq_id_i`` and ``clic_irq_id_o``. The maximum      |
+| ``SMCLIC_ID_WIDTH``            | int (5..10 )   | 5             | Width of ``clic_irq_id_i`` and ``clic_irq_id_o``. The maximum      |
 |                                |                |               | number of supported interrupts in CLIC mode is                     |
 |                                |                |               | ``2^SMCLIC_ID_WIDTH``. Trap vector table alignment is restricted   |
 |                                |                |               | to at least ``2^(2+SMCLIC_ID_WIDTH)``, see :ref:`csr-mtvt`.        |

--- a/docs/user_manual/source/intro.rst
+++ b/docs/user_manual/source/intro.rst
@@ -54,8 +54,8 @@ It follows these specifications:
 .. [RISC-V-CRYPTO] RISC-V Cryptography Extensions Volume I, Scalar & Entropy Source Instructions, Version v1.0.0, 2'nd December, 2021: Ratified,
    https://github.com/riscv/riscv-crypto/releases/download/v1.0.0-scalar/riscv-crypto-spec-scalar-v1.0.0.pdf
 
-.. [OPENHW-OBI] OpenHW Open Bus Interface (OBI) protocol, version 1.3,
-   https://github.com/openhwgroup/core-v-docs/blob/master/cores/obi/OBI-v1.3.pdf
+.. [OPENHW-OBI] OpenHW Open Bus Interface (OBI) protocol, version 1.4,
+   https://github.com/openhwgroup/core-v-docs/blob/master/cores/obi/OBI-v1.4.pdf
 
 .. [OPENHW-XIF] OpenHW eXtension Interface, revision 458c8a73,
    https://docs.openhwgroup.org/projects/openhw-group-core-v-xif/


### PR DESCRIPTION
Signed-off-by: Arjan Bink <Arjan.Bink@silabs.com>