### PR TITLE
Increased SMCLIC_ID_WIDTH range. Removed wrong preemption example cod…

### DIFF
--- a/docs/user_manual/source/control_status_registers.rst
+++ b/docs/user_manual/source/control_status_registers.rst
@@ -653,18 +653,16 @@ Detailed:
 +-------------+------------+-----------------------------------------------------------------------+
 |   Bit #     |   R/W      |           Description                                                 |
 +=============+============+=======================================================================+
-| 31:7        | WARL       | **BASE[31:7]**: Trap-handler vector table base address.               |
+| 31:6        | WARL       | **BASE[31:6]**: Trap-handler vector table base address.               |
 |             |            | See note below for alignment restrictions.                            |
-+-------------+------------+-----------------------------------------------------------------------+
-| 6           | WARL (0x0) | **BASE[6]**: Trap-handler vector table base address.                  |
 +-------------+------------+-----------------------------------------------------------------------+
 | 5:0         | R (0x0)    | Reserved. Hardwired to 0.                                             |
 +-------------+------------+-----------------------------------------------------------------------+
 
 .. note::
-   The ``mtvt`` CSR holds the base address of the trap vector table, aligned on a ``2^(2+SMCLIC_ID_WIDTH)`` bytes or greater
-   power-of-two boundary. For example if ``SMCLIC_ID_WIDTH`` = 8, then 256 CLIC interrupts are supported and the trap vector table
-   is aligned to 1024 bytes, and therefore **BASE[9:7]** will be WARL (0x0).
+   The ``mtvt`` CSR holds the base address of the trap vector table, which has its alignment restricted to both at least 64-bytes and to
+   ``2^(2+SMCLIC_ID_WIDTH)`` bytes or greater power-of-two boundary. For example if ``SMCLIC_ID_WIDTH`` = 8, then 256 CLIC interrupts are supported and the trap vector table
+   is aligned to 1024 bytes, and therefore **BASE[9:6]** will be WARL (0x0).
 
 Machine Status (``mstatush``)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/user_manual/source/exceptions_interrupts.rst
+++ b/docs/user_manual/source/exceptions_interrupts.rst
@@ -3,54 +3,73 @@
 Exceptions and Interrupts
 =========================
 
-|corev| implements trap handling for interrupts and exceptions according to [RISC-V-PRIV]_.
-The ``irq_i[31:16]`` interrupts are a custom extension.
+|corev| supports one of two interrupt architectures.
+If the ``SMCLIC`` parameter is set to 0, then the basic interrupt architecture is supported (see :ref:`basic_interrupt_architecture`).
+If the ``SMCLIC`` parameter is set to 1, then the CLIC interrupt architecture is supported (see :ref:`clic_interrupt_architecture`).
+
+.. _basic_interrupt_architecture:
+
+Basic Interrupt Architecture
+----------------------------
+
+If ``SMCLIC`` == 0, then |corev| supports the basic interrupt architecture as defined in [RISC-V-PRIV]_. In this configuration only the
+basic interrupt handling modes (non-vectored basic mode and vectored basic mode) can be used. The ``irq_i[31:16]`` interrupts are a custom extension
+that can be used with the basic interrupt architecture.
 
 When entering an interrupt/exception handler, the core sets the ``mepc`` CSR to the current program counter and saves ``mstatus``.MIE to ``mstatus``.MPIE.
 All exceptions cause the core to jump to the base address of the vector table in the ``mtvec`` CSR.
-Interrupts are handled in either direct mode or vectored mode depending on the value of ``mtvec``.MODE. In direct mode the core
-jumps to the base address of the vector table in the ``mtvec`` CSR. In vectored mode the core jumps to the base address
+Interrupts are handled in either non-vectored basic mode or vectored basic mode depending on the value of ``mtvec``.MODE. In non-vectored basic mode the core
+jumps to the base address of the vector table in the ``mtvec`` CSR. In vectored basic mode the core jumps to the base address
 plus four times the interrupt ID. Upon executing an MRET instruction, the core jumps to the program counter previously saved in the
 ``mepc`` CSR and restores ``mstatus``.MPIE to ``mstatus``.MIE.
 
-The base address of the vector table must be aligned to 256 bytes (i.e., its least significant byte must be 0x00) and can be programmed
-by writing to the ``mtvec`` CSR. For more information, see the :ref:`cs-registers` documentation.
+The base address of the vector table must be aligned to 128 bytes and can be programmed
+by writing to the ``mtvec`` CSR (see :ref:`csr-mtvec`).
 
-The core starts fetching at the address defined by ``boot_addr_i``. It is assumed that the boot address is supplied via a register
-to avoid long paths to the instruction fetch unit.
+Interrupt Interface
+~~~~~~~~~~~~~~~~~~~
 
-Interrupt Interface - ``SMCLIC`` == 0
--------------------------------------
+:numref:`Basic interrupt architecture interface signals` describes the interrupt interface used for the basic interrupt architecture.
 
-If the ``SMCLIC`` parameter is set to 0, then |corev| is configured to support the basic (a.k.a. CLINT) interrupt architecture. In this configuration only the
-basic interrupt handling modes (non-vectored basic mode and vectored basic mode) can be used.
-
-:numref:`Interrupt interface signals` describes the interrupt interface.
-
-.. table:: Interrupt interface signals
-  :name: Interrupt interface signals
+.. table:: Basic interrupt architecture interface signals
+  :name: Basic interrupt architecture interface signals
 
   +-------------------------+-----------+--------------------------------------------------+
   | Signal                  | Direction | Description                                      |
   +=========================+===========+==================================================+
-  | ``irq_i[31:0]``         | input     | Active high, level sensistive interrupt inputs.  |
-  |                         |           | Not all interrupt inputs can be used on          |
-  |                         |           | |corev|. Specifically irq_i[15:12],              |
-  |                         |           | irq_i[10:8], irq_i[6:4] and irq_i[2:0] shall be  |
-  |                         |           | tied to 0 externally as they are reserved for    |
-  |                         |           | future standard use (or for cores which are not  |
-  |                         |           | Machine mode only) in the RISC-V Privileged      |
-  |                         |           | specification. irq_i[11], irq_i[7], and irq_i[3] |
-  |                         |           | correspond to the Machine External               |
-  |                         |           | Interrupt (MEI), Machine Timer Interrupt (MTI),  |
-  |                         |           | and Machine Software Interrupt (MSI)             |
-  |                         |           | respectively. The irq_i[31:16] interrupts        |
-  |                         |           | are a |corev| specific extension to the RISC-V   |
-  |                         |           | Basic (a.k.a. CLINT) interrupt scheme.           |
+  | ``irq_i[31:16]``        | input     | Active high, level sensistive interrupt inputs.  |
+  |                         |           | Custom extension.                                |
+  +-------------------------+-----------+--------------------------------------------------+
+  | ``irq_i[15:12]``        | input     | Reserved. Tie to 0.                              |
+  +-------------------------+-----------+--------------------------------------------------+
+  | ``irq_i[11]``           | input     | Active high, level sensistive interrupt input.   |
+  |                         |           | Referred to as Machine External Interrupt (MEI), |
+  |                         |           | but integrator can assign a different purpose if |
+  |                         |           | desired.                                         |
+  +-------------------------+-----------+--------------------------------------------------+
+  | ``irq_i[10:8]``         | input     |  Reserved. Tie to 0.                             |
+  +-------------------------+-----------+--------------------------------------------------+
+  | ``irq_i[7]``            | input     | Active high, level sensistive interrupt input.   |
+  |                         |           | Referred to as Machine Timer Interrupt (MTI),    |
+  |                         |           | but integrator can assign a different purpose if |
+  |                         |           | desired.                                         |
+  +-------------------------+-----------+--------------------------------------------------+
+  | ``irq_i[6:4]``          | input     |  Reserved. Tie to 0.                             |
+  +-------------------------+-----------+--------------------------------------------------+
+  | ``irq_i[3]``            | input     | Active high, level sensistive interrupt input.   |
+  |                         |           | Referred to as Machine Software Interrupt (MSI), |
+  |                         |           | but integrator can assign a different purpose if |
+  |                         |           | desired.                                         |
+  +-------------------------+-----------+--------------------------------------------------+
+  | ``irq_i[2:0]``          | input     |  Reserved. Tie to 0.                             |
   +-------------------------+-----------+--------------------------------------------------+
 
-Interrupts - ``SMCLIC`` == 0
-----------------------------
+.. note::
+
+  The ``clic_*_i`` pins are ignored in basic mode and should be tied to 0.
+
+Interrupts
+~~~~~~~~~~
 
 The ``irq_i[31:0]`` interrupts are controlled via the ``mstatus``, ``mie`` and ``mip`` CSRs. |corev| uses the upper 16 bits of ``mie`` and ``mip`` for custom interrupts (``irq_i[31:16]``),
 which reflects an intended custom extension in the RISC-V basic (a.k.a. CLINT) interrupt architecture.
@@ -102,21 +121,83 @@ In Debug Mode, all interrupts are ignored independent of ``mstatus.MIE`` and the
 
 .. note::
 
-   The NMI vector location is at index 15 of the machine trap vector table for both direct mode and vectored mode (i.e. at {**mtvec[31:7]**, 5'hF, 2'b00}).
+   The NMI vector location is at index 15 of the machine trap vector table for both non-vectored basic mode and vectored basic mode (i.e. at {**mtvec[31:7]**, 5'hF, 2'b00}).
    The NMI vector location therefore does **not** match its exception code.
 
-Interrupt Interface - ``SMCLIC`` == 1
--------------------------------------
+Nested Interrupt Handling
+~~~~~~~~~~~~~~~~~~~~~~~~~
+Within the basic interrupt architecture there is no hardware support for nested interrupt handling. Nested interrupt handling can however still be supported via software.
 
-If the ``SMCLIC`` parameter is set to 1, then |corev| is configured to support the CLIC interrupt architecture. In this configuration only the
-CLIC interrupt handling mode can be used and the ``irq_i[31:0]`` pins are ignored and should be tied to 0.
+The hardware automatically disables interrupts upon entering an interrupt/exception handler.
+Otherwise, interrupts during the critical part of the handler, i.e. before software has saved the ``mepc`` and ``mstatus`` CSRs, would cause those CSRs to be overwritten.
+If desired, software can explicitly enable interrupts by setting ``mstatus``.MIE to 1 from within the handler.
+However, software should only do this after saving ``mepc`` and ``mstatus``.
+There is no limit on the maximum number of nested interrupts.
+Note that, after enabling interrupts by setting ``mstatus``.MIE to 1, the current handler will be interrupted also by lower priority interrupts.
+To allow higher priority interrupts only, the handler must configure ``mie`` accordingly.
 
-Interrupts - ``SMCLIC`` == 1
-----------------------------
+.. _clic_interrupt_architecture:
 
+CLIC Interrupt Architecture
+---------------------------
+
+If ``SMCLIC`` == 1, then |corev| supports the Core-Local Interrupt Controller (CLIC) Privileged Architecture Extension defined in [RISC-V-SMCLIC]_. In this
+configuration only the CLIC interrupt handling mode can be used (i.e. ``mtvec[1:0]`` = 0x3).
+
+The CLIC implementation is split into a part internal to the core (containing CSRs and related logic) and a part external to the core (containing memory mapped registers and arbitration logic). |corev| only
+provides the core internal part of CLIC. The external part can be added on the interface described in :ref:`clic-interrupt-interface`. CLIC provides low-latency, vectored, pre-emptive interrupts.
+
+.. _clic-interrupt-interface:
+
+Interrupt Interface
+~~~~~~~~~~~~~~~~~~~
+
+:numref:`CLIC interrupt architecture interface signals` describes the interrupt interface used for the CLIC interrupt architecture.
+
+.. table:: CLIC interrupt architecture interface signals
+  :name: CLIC interrupt architecture interface signals
+
+  +----------------------------------------+-----------+--------------------------------------------------+
+  | Signal                                 | Direction | Description                                      |
+  +========================================+===========+==================================================+
+  | ``clic_irq_i``                         | input     | Is there any pending-and-enabled interrupt?      |
+  +----------------------------------------+-----------+--------------------------------------------------+
+  | ``clic_irq_id_i[SMCLIC_ID_WIDTH-1:0]`` | input     | Index of the most urgent pending-and-enabled     |
+  |                                        |           | interrupt.                                       |
+  +----------------------------------------+-----------+--------------------------------------------------+
+  | ``clic_irq_level_i[7:0]``              | input     | Interrupt level of the most urgent               |
+  |                                        |           | pending-and-enabled interrupt.                   |
+  +----------------------------------------+-----------+--------------------------------------------------+
+  | ``clic_irq_priv_i[1:0]``               | input     | Associated privilege mode of the most urgent     |
+  |                                        |           | pending-and-enabled interrupt.                   |
+  +----------------------------------------+-----------+--------------------------------------------------+
+  | ``clic_irq_shv_i``                     | input     | Selective hardware vectoring enabled for the     |
+  |                                        |           | most urgent pending-and-enabled interrupt?       |
+  +----------------------------------------+-----------+--------------------------------------------------+
+
+The term *pending-and-enabled* interrupt in above table refers to *pending-and-locally-enabled*, i.e. based on the ``CLICINTIP`` and
+``CLICINTIE`` memory mapped registers from [RISC-V-SMCLIC]_.
+
+.. note::
+
+   Edge triggered interrupts are not supported.
+
+.. note::
+
+  The ``irq_i[31:0]`` pins are ignored in CLIC mode and should be tied to 0.
+
+Interrupts
+~~~~~~~~~~
 Although the [RISC-V-SMCLIC]_ specification supports up to 4096 interrupts, |corev| itself supports at most 1024 interrupts. The
-maximum number of supported CLIC interrupts is equal to ``2^SMCLIC_ID_WIDTH``, which can range from 32 to 1024. The ``SMCLIC_ID_WIDTH`` parameter
-also dictates the minimum alignment requirement for the trap vector table to ``2^(2+SMCLIC_ID_WIDTH)`` byte boundaries, see :ref:`csr-mtvt`.
+maximum number of supported CLIC interrupts is equal to ``2^SMCLIC_ID_WIDTH``, which can range from 2 to 1024. The ``SMCLIC_ID_WIDTH`` parameter
+also impacts the alignment requirement for the trap vector table, see :ref:`csr-mtvt`.
+
+Nested Interrupt Handling
+~~~~~~~~~~~~~~~~~~~~~~~~~
+|corev| offers hardware support for nested interrupt handling when ``SMCLIC`` == 1. 
+
+CLIC extends interrupt preemption to support up to 256 interrupt levels for each privilege mode,
+where higher-numbered interrupt levels can preempt lower-numbered interrupt levels. See [RISC-V-SMCLIC]_ for details.
 
 Non Maskable Interrupts
 -----------------------
@@ -129,14 +210,13 @@ Non Maskable Interrupts (NMIs) update ``mepc``, ``mcause`` and ``mstatus`` simil
    ``mstatus`` in response to NMIs, see https://github.com/riscv/riscv-isa-manual/issues/756. If this behavior is
    specified at a future date, then we will reconsider our implementation.
 
-The NMI vector location is at index 15 of the machine trap vector table for both direct mode and vectored mode (i.e. {**mtvec[31:7]**, 5'hF, 2'b00}).
+The NMI vector location is at index 15 of the machine trap vector table for non-vectored basic mode, vectored basic mode and CLIC mode (i.e. {**mtvec[31:7]**, 5'hF, 2'b00}).
 
 An NMI will occur when a load or store instruction experiences a bus fault. The fault resulting in an NMI is handled in an imprecise manner, meaning that the instruction that causes the fault is allowed to retire and the associated NMI is taken afterwards.
 NMIs are never masked by the ``MIE`` bit. NMIs are masked however while in debug mode or while single stepping with ``STEPIE`` = 0 in the ``dcsr`` CSR.
-This means that many instructions may retire before the NMI is visible to the core if debugging is taking place. Once the NMI is visible to the core, at most two instructions may retire before the NMI is taken.
-This is guaranteed, as the core will stop issuing new instructions when any interrupt, including NMI, is pending. This will eventually cause an interruptible time slot.
+This means that many instructions may retire before the NMI is visible to the core if debugging is taking place. Once the NMI is visible to the core, at most two instructions will retire before the NMI is taken.
 
-If an NMI becomes pending while in debug mode as described above, the NMI will be taken in the first available cycle after debug mode has been exited.
+If an NMI becomes pending while in debug mode as described above, the NMI will be taken immediately after debug mode has been exited.
 
 In case of bufferable stores, the NMI is allowed to become visible an arbitrary time after the instruction retirement. As for the case with debugging, this can cause several instructions to retire
 before the NMI becomes visible to the core.
@@ -190,48 +270,3 @@ illegal according to the ISA implemented by the core, as well as for any instruc
 is configured as a custom |corev| instruction for specific parameter settings as defined in (see :ref:`custom-isa-extensions`).
 An instruction bus error leads to a precise instruction interface bus fault if an attempt is made to execute the instruction that has an associated bus error.
 Similarly an instruction fetch with a failing PMA check only leads to an instruction access exception if an actual execution attempt is made for it.
-
-Nested Interrupt/Exception Handling
------------------------------------
-
-|corev| does support nested interrupt/exception handling in software.
-The hardware automatically disables interrupts upon entering an interrupt/exception handler.
-Otherwise, interrupts/exceptions during the critical part of the handler, i.e. before software has saved the ``mepc`` and ``mstatus`` CSRs, would cause those CSRs to be overwritten.
-If desired, software can explicitly enable interrupts by setting ``mstatus``.MIE to 1 from within the handler.
-However, software should only do this after saving ``mepc`` and ``mstatus``.
-There is no limit on the maximum number of nested interrupts.
-Note that, after enabling interrupts by setting ``mstatus``.MIE to 1, the current handler will be interrupted also by lower priority interrupts.
-To allow higher priority interrupts only, the handler must configure ``mie`` accordingly.
-
-The following pseudo-code snippet visualizes how to perform nested interrupt handling in software.
-
-.. code-block:: c
-   :linenos:
-
-   isr_handle_nested_interrupts(id) {
-     // Save mpec and mstatus to stack
-     mepc_bak = mepc;
-     mstatus_bak = mstatus;
-
-     // Save mie to stack (optional)
-     mie_bak = mie;
-
-     // Keep lower-priority interrupts disabled (optional)
-     mie = mie & ~((1 << (id + 1)) - 1);
-
-     // Re-enable interrupts
-     mstatus.MIE = 1;
-
-     // Handle interrupt
-     // This code block can be interrupted by other interrupts.
-     // ...
-
-     // Restore mstatus (this disables interrupts) and mepc
-     mstatus = mstatus_bak;
-     mepc = mepc_bak;
-
-     // Restore mie (optional)
-     mie = mie_bak;
-   }
-
-Nesting of interrupts/exceptions in hardware is not supported.

--- a/docs/user_manual/source/integration.rst
+++ b/docs/user_manual/source/integration.rst
@@ -31,7 +31,7 @@ Instantiation Template
       .PMA_NUM_REGIONS            (         1 ),
       .PMA_CFG                    ( PMA_CFG[] ),
       .SMCLIC                     (         0 ),
-      .SMCLIC_ID_WIDTH            (         0 )
+      .SMCLIC_ID_WIDTH            (         5 )
   ) u_core (
       // Clock and reset
       .clk_i                    (),
@@ -89,12 +89,9 @@ Instantiation Template
 
       .clic_irq_i               (),
       .clic_irq_id_i            (),
-      .clic_irq_il_i            (),
+      .clic_irq_level_i         (),
       .clic_irq_priv_i          (),
-      .clic_irq_hv_i            (),
-      .clic_irq_id_o            (),
-      .clic_irq_mode_o          (),
-      .clic_irq_exit_o          (),
+      .clic_irq_shv_i           (),
 
       // Fencei flush handshake
       .fencei_flush_req_o       (),
@@ -174,10 +171,10 @@ Parameters
 +--------------------------------+----------------+---------------+--------------------------------------------------------------------+
 | ``SMCLIC``                     | int (0..1 )    | 0             | Is Smclic supported?                                               |
 +--------------------------------+----------------+---------------+--------------------------------------------------------------------+
-| ``SMCLIC_ID_WIDTH``            | int (5..10 )   | 5             | Width of ``clic_irq_id_i`` and ``clic_irq_id_o``. The maximum      |
+| ``SMCLIC_ID_WIDTH``            | int (1..10 )   | 5             | Width of ``clic_irq_id_i`` and ``clic_irq_id_o``. The maximum      |
 |                                |                |               | number of supported interrupts in CLIC mode is                     |
 |                                |                |               | ``2^SMCLIC_ID_WIDTH``. Trap vector table alignment is restricted   |
-|                                |                |               | to at least ``2^(2+SMCLIC_ID_WIDTH)``, see :ref:`csr-mtvt`.        |
+|                                |                |               | as described ub :ref:`csr-mtvt`.                                   |
 +--------------------------------+----------------+---------------+--------------------------------------------------------------------+
 
 
@@ -235,7 +232,7 @@ Interfaces
 +-------------------------+----------------------------------------------------------------------------+
 | ``irq_*``               | Interrupt inputs, see :ref:`exceptions-interrupts`                         |
 +-------------------------+----------------------------------------------------------------------------+
-| ``clic_*``              | CLIC interface, see :ref:`exceptions-interrupts`                           |
+| ``clic_*_i``            | CLIC interface, see :ref:`exceptions-interrupts`                           |
 +-------------------------+----------------------------------------------------------------------------+
 | ``debug_*``             | Debug interface, see :ref:`debug-support`                                  |
 +-------------------------+-------------------------+-----+--------------------------------------------+


### PR DESCRIPTION
…e. Fixed and documented CLIC pins

Signed-off-by: Arjan Bink <Arjan.Bink@silabs.com>