### PR TITLE
Updated typedefs for CSR registers to match new fields in the user manual

### DIFF
--- a/rtl/include/cv32e40x_pkg.sv
+++ b/rtl/include/cv32e40x_pkg.sv
@@ -481,17 +481,27 @@ typedef struct packed {
 } jvt_t;
 
 typedef struct packed {
-  logic [31:22] zero5;  // Reserved, hardwired zero
+  logic         sd;     // State dirty
+  logic [30:23] zero3;  // Hardwired zero
+  logic         tsr;    // Hardwired zero
   logic         tw;     // Hardwired zero
-  logic [20:18] zero4;  // Reserved, hardwired zero
+  logic         tvm;    // Hardwired zero
+  logic         mxr;    // Hardwired zero
+  logic         sum;    // Hardwired zero
   logic         mprv;   // Hardwired zero
-  logic [16:13] zero3;  // Reserved, hardwired zero
+  logic [16:15] xs;     // Other extension context
+  logic [14:13] fs;     // FPU extension context status
   logic [12:11] mpp;    // Hardwired to 2'b11
-  logic [10:8]  zero2;
+  logic [10:9]  vs;     // Vector extension context status
+  logic         spp;    // Hardwired zero
   logic         mpie;
-  logic [6:4]   zero1; // Reserved, hardwired zero
+  logic         ube;    // Hardwired zero
+  logic         spie;   // Hardwired zero
+  logic         zero2;  // Reserved, hardwired to zero.
   logic         mie;
-  logic [2:0]   zero0; // Reserved, hardwired zero
+  logic         zero1;  // Reserved, hardwired to zero.
+  logic         sie;    // Hardwired to zero
+  logic         zero0;  // Reserved, hardwired zero
 } mstatus_t;
 
 typedef struct packed {
@@ -526,7 +536,9 @@ typedef enum logic [3:0] {
 
 typedef struct packed{
     logic [31:28] xdebugver;
-    logic [27:16] zero2;
+    logic [27:18] zero2;
+    logic         ebreakvs; // Hardwired to zero
+    logic         ebreakvu; // Hardwired to zero
     logic         ebreakm;
     logic         zero1;
     logic         ebreaks;
@@ -535,7 +547,7 @@ typedef struct packed{
     logic         stopcount;
     logic         stoptime;
     logic [8:6]   cause;
-    logic         zero0;
+    logic         v;        // Hardwired to zero
     logic         mprven;
     logic         nmip;
     logic         step;
@@ -544,8 +556,13 @@ typedef struct packed{
 
 typedef struct packed {
   logic           irq;
-  logic [30:11]   zero0;
-  logic [10: 0]   exception_code;
+  logic           minhv;           // CLIC only
+  logic [29:28]   mpp;             // CLIC only, same as mstatus.mpp
+  logic           mpie;            // CLIC only, same as mstatus.mpie
+  logic [26:24]   zero1;           // Reserved, hardwired to zero.
+  logic [23:16]   mpil;            // CLIC only. Previous interrupt level
+  logic [15:12]   zero0;           // Reserved, hardwired to zero.
+  logic [11: 0]   exception_code;  // Bit 11 only used for CLIC, hardwired to zero otherwise
 } mcause_t;
 
 typedef struct packed {
@@ -589,9 +606,7 @@ parameter mintstatus_t MINTSTATUS_RESET_VAL = '{
   uil:   '0};
 
 parameter mstatus_t MSTATUS_RESET_VAL = '{
-  zero5   : 'b0,
   tw      : 1'b0,
-  zero4   : 'b0,
   mprv    : 1'b0,
   zero3   : 'b0,
   mpp     : PRIV_LVL_M,
@@ -1000,7 +1015,7 @@ typedef struct packed
   logic [31:0] id;        // ID of offloaded ins
   logic        accepted;  // Was the offloaded instruction accepted or not?
 } xif_meta_t;
-  
+
 // IF/ID pipeline
 typedef struct packed {
   logic        instr_valid;
@@ -1037,7 +1052,7 @@ typedef struct packed {
   // Operands for multiplier and divider
   logic [31:0]  muldiv_operand_a;
   logic [31:0]  muldiv_operand_b;
-  
+
   // CSR
   logic         csr_en;
   csr_opcode_e  csr_op;
@@ -1141,7 +1156,7 @@ typedef struct packed {
   logic                              wb_data_stall;
 } mhpmevent_t;
 
-  
+
 // Controller Bypass outputs
 typedef struct packed {
   op_fw_mux_e   operand_a_fw_mux_sel;   // Operand A forward mux sel


### PR DESCRIPTION
SEC clean.

Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>