### PR TITLE
CLIC: Spec chapter 5.3

### DIFF
--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -244,7 +244,8 @@ module cv32e40x_wrapper
   bind cv32e40x_core:
     core_i cv32e40x_core_sva
       #(.A_EXT(A_EXT),
-        .PMA_NUM_REGIONS(PMA_NUM_REGIONS))
+        .PMA_NUM_REGIONS(PMA_NUM_REGIONS),
+        .SMCLIC(SMCLIC))
       core_sva (// probed cs_registers signals
                 .cs_registers_mie_q               (core_i.cs_registers_i.mie_q),
                 .cs_registers_mepc_n              (core_i.cs_registers_i.mepc_n),

--- a/rtl/cv32e40x_core.sv
+++ b/rtl/cv32e40x_core.sv
@@ -758,7 +758,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
     // Register File read, write back and forwards
     .rf_re_id_i                     ( rf_re_id               ),
     .rf_raddr_id_i                  ( rf_raddr_id            ),
-    
+
     // Fencei flush handshake
     .fencei_flush_ack_i             ( fencei_flush_ack_i     ),
     .fencei_flush_req_o             ( fencei_flush_req_o     ),
@@ -790,26 +790,36 @@ module cv32e40x_core import cv32e40x_pkg::*;
   //  \___/_| |_|\__(_)  \____/\___/|_| |_|\__|_|  \___/|_|_|\___|_|    //
   //                                                                    //
   ////////////////////////////////////////////////////////////////////////
+  generate
+    if (SMCLIC) begin : gen_clic_interrupt
+      // Todo: instantiate cv32e40x_clic_int_controller
+      // For now just tie off outputs
+      assign irq_req_ctrl = '0;
+      assign irq_id_ctrl  = '0;
+      assign irq_wu_ctrl  = '0;
+      assign mip          = '0;
+    end else begin : gen_basic_interrupt
+      cv32e40x_int_controller
+      int_controller_i
+      (
+        .clk                  ( clk                ),
+        .rst_n                ( rst_ni             ),
 
-  cv32e40x_int_controller
-  int_controller_i
-  (
-    .clk                  ( clk                ),
-    .rst_n                ( rst_ni             ),
+        // External interrupt lines
+        .irq_i                ( irq_i              ),
 
-    // External interrupt lines
-    .irq_i                ( irq_i              ),
+        // To cv32e40x_controller
+        .irq_req_ctrl_o       ( irq_req_ctrl       ),
+        .irq_id_ctrl_o        ( irq_id_ctrl        ),
+        .irq_wu_ctrl_o        ( irq_wu_ctrl        ),
 
-    // To cv32e40x_controller
-    .irq_req_ctrl_o       ( irq_req_ctrl       ),
-    .irq_id_ctrl_o        ( irq_id_ctrl        ),
-    .irq_wu_ctrl_o        ( irq_wu_ctrl        ),
-
-    // To/from with cv32e40x_cs_registers
-    .mie_i                ( mie                ),
-    .mip_o                ( mip                ),
-    .m_ie_i               ( m_irq_enable       )
-  );
+        // To/from with cv32e40x_cs_registers
+        .mie_i                ( mie                ),
+        .mip_o                ( mip                ),
+        .m_ie_i               ( m_irq_enable       )
+      );
+    end
+  endgenerate
 
     /////////////////////////////////////////////////////////
   //  ____  _____ ____ ___ ____ _____ _____ ____  ____   //

--- a/rtl/cv32e40x_cs_registers.sv
+++ b/rtl/cv32e40x_cs_registers.sv
@@ -284,7 +284,14 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
       CSR_MISA: csr_rdata_int = MISA_VALUE;
 
       // mie: machine interrupt enable
-      CSR_MIE: csr_rdata_int = mie_q;
+      CSR_MIE: begin
+        if (SMCLIC) begin
+          // CLIC mode is assumed when SMCLIC = 1
+          csr_rdata_int = '0;
+        end else begin
+         csr_rdata_int = mie_q;
+        end
+      end
 
       // mtvec: machine trap-handler base address
       CSR_MTVEC: csr_rdata_int = mtvec_q;
@@ -323,7 +330,14 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
       end
 
       // mip: interrupt pending
-      CSR_MIP: csr_rdata_int = mip;
+      CSR_MIP: begin
+        // CLIC mode is assumed when SMCLIC = 1
+        if (SMCLIC) begin
+          csr_rdata_int = '0;
+        end else begin
+          csr_rdata_int = mip;
+        end
+      end
 
       // mnxti: Next Interrupt Handler Address and Interrupt Enable
       CSR_MNXTI: begin
@@ -605,7 +619,10 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
         end
         // mie: machine interrupt enable
         CSR_MIE: begin
-              mie_we = 1'b1;
+          // CLIC mode is assumed when SMCLIC = 1
+          if (!SMCLIC) begin
+            mie_we = 1'b1;
+          end
         end
         // mtvec: machine trap-handler base address
         CSR_MTVEC: begin

--- a/rtl/cv32e40x_cs_registers.sv
+++ b/rtl/cv32e40x_cs_registers.sv
@@ -857,19 +857,6 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
   cv32e40x_csr #(
     .WIDTH      (32),
     .SHADOWCOPY (1'b0),
-    .RESETVALUE (32'd0)
-  ) mie_csr_i (
-    .clk      (clk),
-    .rst_n     (rst_n),
-    .wr_data_i  (mie_n),
-    .wr_en_i    (mie_we),
-    .rd_data_o  (mie_q),
-    .rd_error_o (mie_rd_error)
-  );
-
-  cv32e40x_csr #(
-    .WIDTH      (32),
-    .SHADOWCOPY (1'b0),
     .RESETVALUE (MSTATUS_RESET_VAL)
   ) mstatus_csr_i (
     .clk      (clk),
@@ -986,7 +973,22 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
         .rd_error_o (mclicbase_rd_error)
       );
 
+      assign mie_q  = 32'h0;
+
     end else begin
+      // Only include mie CSR when SMCLIC = 0
+      cv32e40x_csr #(
+        .WIDTH      (32),
+        .SHADOWCOPY (1'b0),
+        .RESETVALUE (32'd0)
+      ) mie_csr_i (
+        .clk      (clk),
+        .rst_n     (rst_n),
+        .wr_data_i  (mie_n),
+        .wr_en_i    (mie_we),
+        .rd_data_o  (mie_q),
+        .rd_error_o (mie_rd_error)
+      );
       assign mtvt_q              = 32'h0;
       assign mtvt_rd_error       = 1'b0;
       assign mnxti_q             = 32'h0;


### PR DESCRIPTION
CSRs mie and mip appear as hardwired to zero when SMCLIC = 1.
Writes are ignored.

SEC clean when SMCLIC = 0

Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>