### PR TITLE
Moved two instructions from predecoder to decoder

### DIFF
--- a/rtl/cv32e40x_compressed_decoder.sv
+++ b/rtl/cv32e40x_compressed_decoder.sv
@@ -30,6 +30,7 @@ module cv32e40x_compressed_decoder import cv32e40x_pkg::*;
   input  logic        instr_is_ptr_i,
   output inst_resp_t  instr_o,
   output logic        is_compressed_o,
+  output logic        use_merged_dec_o, // todo: remove this temporary signal once done merging decoder
   output logic        illegal_instr_o
 );
 
@@ -51,6 +52,7 @@ module cv32e40x_compressed_decoder import cv32e40x_pkg::*;
   begin
     illegal_instr_o  = 1'b0;
     instr_o          = instr_i;
+    use_merged_dec_o = 1'b0;
 
     if (instr_is_ptr_i) begin
       is_compressed_o = 1'b0;
@@ -62,12 +64,14 @@ module cv32e40x_compressed_decoder import cv32e40x_pkg::*;
           unique case (instr[15:13])
             3'b000: begin
               // c.addi4spn -> addi rd', x2, imm
+              use_merged_dec_o = 1'b1;
               instr_o.bus_resp.rdata = {2'b0, instr[10:7], instr[12:11], instr[5], instr[6], 2'b00, 5'h02, 3'b000, 2'b01, instr[4:2], OPCODE_OPIMM};
               if (instr[12:5] == 8'b0)  illegal_instr_o = 1'b1;
             end
 
             3'b010: begin
               // c.lw -> lw rd', imm(rs1')
+              use_merged_dec_o = 1'b1;
               instr_o.bus_resp.rdata = {5'b0, instr[5], instr[12:10], instr[6], 2'b00, 2'b01, instr[9:7], 3'b010, 2'b01, instr[4:2], OPCODE_LOAD};
             end
 

--- a/rtl/cv32e40x_id_stage.sv
+++ b/rtl/cv32e40x_id_stage.sv
@@ -106,6 +106,7 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
   localparam REG_D_LSB  = 7;
 
   logic [31:0] instr;
+  logic [15:0] c_instr;                         // Compressed instruction
 
   // Register Read/Write Control
   logic [1:0]           rf_re;                  // Decoder only supports rs1, rs2
@@ -173,6 +174,8 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
   logic [31:0]          imm_u_type;
   logic [31:0]          imm_uj_type;
   logic [31:0]          imm_z_type;
+  logic [31:0]          imm_ciw_type;
+  logic [31:0]          imm_cl_type;
 
   // Branch target address
   logic [31:0]          bch_target;
@@ -201,13 +204,35 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
   assign sys_mret_insn_o = sys_mret_insn;
 
   assign instr = if_id_pipe_i.instr.bus_resp.rdata;
+  assign c_instr = if_id_pipe_i.compressed_instr;
 
   // Immediate extraction and sign extension
-  assign imm_i_type  = { {20 {instr[31]}}, instr[31:20] };
-  assign imm_s_type  = { {20 {instr[31]}}, instr[31:25], instr[11:7] };
-  assign imm_sb_type = { {19 {instr[31]}}, instr[31], instr[7], instr[30:25], instr[11:8], 1'b0 };
-  assign imm_u_type  = { instr[31:12], 12'b0 };
-  assign imm_uj_type = { {12 {instr[31]}}, instr[19:12], instr[20], instr[30:21], 1'b0 };
+  assign imm_i_type   = { {20 {instr[31]}}, instr[31:20] };
+  assign imm_s_type   = { {20 {instr[31]}}, instr[31:25], instr[11:7] };
+  assign imm_sb_type  = { {19 {instr[31]}}, instr[31], instr[7], instr[30:25], instr[11:8], 1'b0 };
+  assign imm_u_type   = { instr[31:12], 12'b0 };
+  assign imm_uj_type  = { {12 {instr[31]}}, instr[19:12], instr[20], instr[30:21], 1'b0 };
+
+  // Immediate extraction and sign extension (compressed instructions)
+  assign imm_ciw_type = { 22'b0, c_instr[10:7], c_instr[12:11], c_instr[5], c_instr[6], 2'b0 };
+  assign imm_cl_type  = { 25'b0, c_instr[5], c_instr[12:10], c_instr[6], 2'b0 };
+
+/*
+  assign imm_cfldsp_type = {22'b0, c_instr[4:2], c_instr[12], c_instr[6:5], 3'b0};
+  assign imm_caddi_type  = {{22{c_instr[12]}}, c_instr[12:12], c_instr[4:3], c_instr[5:5], c_instr[2:2], c_instr[6:6], 4'b0};
+  assign imm_clwsp_type  = {24'b0, c_instr[3:2], c_instr[12:12], c_instr[6:4], 2'b0};
+  assign imm_cld_type    = {24'b0, c_instr[6:5], c_instr[12:10], 3'b0};
+  assign imm_cswsp_type  = {24'b0, c_instr[8:7], c_instr[12:9], 2'b0};
+  assign imm_fsdp_type   = {24'b0, c_instr[9:7], c_instr[12:10], 2'b0};
+  assign imm_csrli_type  = {26'b0, c_instr[12:12], c_instr[6:2]};
+  assign imm_candi_type  = {{26{c_instr[12]}}, c_instr[12:12], c_instr[6:2]};
+  assign imm_cbeq_type   = {{23{c_instr[12]}}, c_instr[12:12], c_instr[6:5], c_instr[2:2], c_instr[11:10], c_instr[4:3], 1'b0};
+  assign imm_clui_type   = {{14{c_instr[12]}}, c_instr[12:12], c_instr[6:2], 12'b0};
+  assign imm_clsb_type   = {28'd0, c_instr[10], c_instr[6:5], c_instr[11]};
+  assign imm_clsh_type   = {27'd0, c_instr[11:10], c_instr[6:5], 1'b0};
+*/
+
+
 
   // Immediate for CSR manipulation (zero extended)
   assign imm_z_type  = { 27'b0, instr[REG_S1_MSB:REG_S1_LSB] };
@@ -311,6 +336,8 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
       IMMB_S:      imm_b = imm_s_type;
       IMMB_U:      imm_b = imm_u_type;
       IMMB_PCINCR: imm_b = if_id_pipe_i.instr_meta.compressed ? 32'h2 : 32'h4;
+      IMMB_CIW:    imm_b = imm_ciw_type;
+      IMMB_CL:     imm_b = imm_cl_type;
       default:     imm_b = imm_i_type;
     endcase
   end
@@ -362,6 +389,9 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
   //                                           //
   ///////////////////////////////////////////////
 
+  logic [31:0] instr_merged;
+  assign instr_merged = if_id_pipe_i.use_merged_dec ? {16'b0, c_instr} : instr; // todo: temporary hack while merging decoder
+
   cv32e40x_decoder
   #(
     .A_EXT                           ( A_EXT                     ),
@@ -385,7 +415,7 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
     .sys_fencei_insn_o               ( sys_fencei_insn           ),
     
     // from IF/ID pipeline
-    .instr_rdata_i                   ( instr                     ),
+    .instr_rdata_i                   ( instr_merged              ), // todo: temporary hack while merging decoders
     .illegal_c_insn_i                ( if_id_pipe_i.illegal_c_insn ),
 
     // ALU

--- a/rtl/cv32e40x_if_stage.sv
+++ b/rtl/cv32e40x_if_stage.sv
@@ -89,6 +89,7 @@ module cv32e40x_if_stage import cv32e40x_pkg::*;
 
   inst_resp_t        instr_decompressed;
   logic              instr_compressed_int;
+  logic              use_merged_dec;
 
   // Transaction signals to/from obi interface
   logic              prefetch_resp_valid;
@@ -263,6 +264,7 @@ module cv32e40x_if_stage import cv32e40x_pkg::*;
     if (rst_n == 1'b0) begin
       if_id_pipe_o.instr_valid      <= 1'b0;
       if_id_pipe_o.instr            <= INST_RESP_RESET_VAL;
+      if_id_pipe_o.use_merged_dec   <= 1'b0;
       if_id_pipe_o.instr_meta       <= '0;
       if_id_pipe_o.pc               <= '0;
       if_id_pipe_o.illegal_c_insn   <= 1'b0;
@@ -276,6 +278,7 @@ module cv32e40x_if_stage import cv32e40x_pkg::*;
         if_id_pipe_o.instr_valid      <= 1'b1;
         // instr_decompressed may be a pointer in case of CLIC or Zc, handled within the compressed decoder.
         if_id_pipe_o.instr            <= instr_decompressed;
+        if_id_pipe_o.use_merged_dec   <= use_merged_dec;
         if_id_pipe_o.instr_meta       <= instr_meta_n;
         if_id_pipe_o.illegal_c_insn   <= illegal_c_insn;
         if_id_pipe_o.pc               <= pc_if_o;
@@ -295,6 +298,7 @@ module cv32e40x_if_stage import cv32e40x_pkg::*;
     .instr_is_ptr_i     ( prefetch_is_ptr         ),
     .instr_o            ( instr_decompressed      ),
     .is_compressed_o    ( instr_compressed_int    ),
+    .use_merged_dec_o   ( use_merged_dec          ),
     .illegal_instr_o    ( illegal_c_insn          )
   );
 

--- a/rtl/include/cv32e40x_pkg.sv
+++ b/rtl/include/cv32e40x_pkg.sv
@@ -711,11 +711,13 @@ typedef enum logic[1:0] {
                     } alu_op_b_mux_e;
 
 // Immediate b selection
-typedef enum logic[1:0] {
-                         IMMB_I      = 2'b00,
-                         IMMB_S      = 2'b01,
-                         IMMB_U      = 2'b10,
-                         IMMB_PCINCR = 2'b11
+typedef enum logic[2:0] {
+                         IMMB_I      = 3'b000,
+                         IMMB_S      = 3'b001,
+                         IMMB_U      = 3'b010,
+                         IMMB_PCINCR = 3'b011,
+                         IMMB_CIW    = 3'b100,
+                         IMMB_CL    = 3'b101
                          } imm_b_mux_e;
 
 // Operand c selection
@@ -1031,6 +1033,7 @@ typedef struct packed
 typedef struct packed {
   logic        instr_valid;
   inst_resp_t  instr;
+  logic        use_merged_dec; // todo: remove once done with decoder merge
   instr_meta_t instr_meta;
   logic [31:0] pc;
   logic [15:0] compressed_instr;


### PR DESCRIPTION
Moved first two isntructions from predecoder to main decoder.
Predecoder is still used to cause the register file operand reads.
SEC clean
Signed-off-by: Arjan Bink <Arjan.Bink@silabs.com>