### PR TITLE
Removed nmi_addr_i; removed USE_DEPRECATED_FEATURE_SET parameter

### DIFF
--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -80,7 +80,6 @@ module cv32e40x_wrapper
   input  logic [31:0] mhartid_i,
   input  logic  [3:0] mimpid_patch_i,
   input  logic [31:0] dm_exception_addr_i,
-  input  logic [31:0] nmi_addr_i,
 
   // Instruction memory interface
   output logic        instr_req_o,
@@ -338,7 +337,7 @@ module cv32e40x_wrapper
       rvfi_sva(.irq_ack(core_i.irq_ack),
                .dbg_ack(core_i.dbg_ack),
                .ebreak_in_wb_i(core_i.controller_i.controller_fsm_i.ebreak_in_wb),
-               .nmi_addr_i(core_i.nmi_addr_i),
+               .mtvec_addr_i(core_i.mtvt_addr),
                .*);
 
 `endif //  `ifndef COREV_ASSERT_OFF

--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -337,7 +337,7 @@ module cv32e40x_wrapper
       rvfi_sva(.irq_ack(core_i.irq_ack),
                .dbg_ack(core_i.dbg_ack),
                .ebreak_in_wb_i(core_i.controller_i.controller_fsm_i.ebreak_in_wb),
-               .mtvec_addr_i(core_i.mtvt_addr),
+               .mtvec_addr_i(core_i.mtvec_addr),
                .*);
 
 `endif //  `ifndef COREV_ASSERT_OFF

--- a/constraints/cv32e40x_core.sdc
+++ b/constraints/cv32e40x_core.sdc
@@ -141,7 +141,6 @@ set early_input_ports [list \
     mhartid_i* \
     mimpid_i* \
     dm_exception_addr_i* \
-    nmi_addr_i* \
 ]
 
 # RISC-V OBI Input ports

--- a/rtl/cv32e40x_controller.sv
+++ b/rtl/cv32e40x_controller.sv
@@ -31,7 +31,6 @@
 
 module cv32e40x_controller import cv32e40x_pkg::*;
 #(
-  parameter bit          USE_DEPRECATED_FEATURE_SET = 1, // todo: remove once related features are supported by iss
   parameter bit          X_EXT                  = 0,
   parameter int unsigned REGFILE_NUM_READ_PORTS = 2,
   parameter bit          SMCLIC                 = 0,
@@ -119,7 +118,6 @@ module cv32e40x_controller import cv32e40x_pkg::*;
   // Main FSM and debug FSM
   cv32e40x_controller_fsm
   #(
-    .USE_DEPRECATED_FEATURE_SET  (USE_DEPRECATED_FEATURE_SET),
     .X_EXT                       ( X_EXT                    ),
     .SMCLIC                      ( SMCLIC                   ),
     .SMCLIC_ID_WIDTH             ( SMCLIC_ID_WIDTH          )

--- a/rtl/cv32e40x_controller_fsm.sv
+++ b/rtl/cv32e40x_controller_fsm.sv
@@ -31,7 +31,6 @@
 
 module cv32e40x_controller_fsm import cv32e40x_pkg::*;
 #(
-  parameter bit       USE_DEPRECATED_FEATURE_SET = 1, // todo: remove once related features are supported by iss
   parameter bit       X_EXT           = 0,
   parameter bit       SMCLIC          = 0,
   parameter int       SMCLIC_ID_WIDTH = 5
@@ -536,11 +535,7 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
 
           ctrl_fsm_o.csr_save_cause  = 1'b1;
           ctrl_fsm_o.csr_cause.irq = 1'b1;
-          if (USE_DEPRECATED_FEATURE_SET) begin
-            ctrl_fsm_o.csr_cause.exception_code = nmi_is_store_q ? DEPRECATED_INT_CAUSE_LSU_STORE_FAULT : DEPRECATED_INT_CAUSE_LSU_LOAD_FAULT;
-          end else begin
-            ctrl_fsm_o.csr_cause.exception_code = nmi_is_store_q ? INT_CAUSE_LSU_STORE_FAULT : INT_CAUSE_LSU_LOAD_FAULT;
-          end
+          ctrl_fsm_o.csr_cause.exception_code = nmi_is_store_q ? INT_CAUSE_LSU_STORE_FAULT : INT_CAUSE_LSU_LOAD_FAULT;
 
           // Save pc from oldest valid instruction
           if (ex_wb_pipe_i.instr_valid) begin

--- a/rtl/cv32e40x_core.sv
+++ b/rtl/cv32e40x_core.sv
@@ -45,7 +45,6 @@ module cv32e40x_core import cv32e40x_pkg::*;
   parameter logic [31:0] X_MISA                       = 32'h00000000,
   parameter logic [1:0]  X_ECS_XS                     = 2'b00,
   parameter bit          ZC_EXT                       = 0, // todo: remove once fully implemented
-  parameter bit          USE_DEPRECATED_FEATURE_SET   = 1, // todo: remove once related features are supported by iss
   parameter int          NUM_MHPMCOUNTERS             = 1,
   parameter bit          SMCLIC                       = 0,
   parameter int          SMCLIC_ID_WIDTH              = 5,
@@ -67,7 +66,6 @@ module cv32e40x_core import cv32e40x_pkg::*;
   input  logic [31:0] mhartid_i,
   input  logic  [3:0] mimpid_patch_i,
   input  logic [31:0] dm_exception_addr_i,
-  input  logic [31:0] nmi_addr_i, // todo: remove once supported by verification
 
   // Instruction memory interface
   output logic        instr_req_o,
@@ -376,7 +374,6 @@ module cv32e40x_core import cv32e40x_pkg::*;
   //////////////////////////////////////////////////
   cv32e40x_if_stage
   #(
-    .USE_DEPRECATED_FEATURE_SET (USE_DEPRECATED_FEATURE_SET),
     .A_EXT               ( A_EXT                    ),
     .X_EXT               ( X_EXT                    ),
     .X_ID_WIDTH          ( X_ID_WIDTH               ),
@@ -398,7 +395,6 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .jump_target_id_i    ( jump_target_id           ), // Jump target address
     .mepc_i              ( mepc                     ), // Exception PC (restore upon return from exception/interrupt)
     .mtvec_addr_i        ( mtvec_addr               ), // Exception/interrupt address (MSBs only)
-    .nmi_addr_i          ( nmi_addr_i               ), // NMI address
     .mtvt_addr_i         ( mtvt_addr                ), // CLIC vector base
 
     .m_c_obi_instr_if    ( m_c_obi_instr_if         ), // Instruction bus interface
@@ -655,7 +651,6 @@ module cv32e40x_core import cv32e40x_pkg::*;
 
   cv32e40x_cs_registers
   #(
-    .USE_DEPRECATED_FEATURE_SET (USE_DEPRECATED_FEATURE_SET),
     .A_EXT                      ( A_EXT                  ),
     .M_EXT                      ( M_EXT                  ),
     .X_EXT                      ( X_EXT                  ),
@@ -738,7 +733,6 @@ module cv32e40x_core import cv32e40x_pkg::*;
   ////////////////////////////////////////////////////////////////////
   cv32e40x_controller
   #(
-    .USE_DEPRECATED_FEATURE_SET     (USE_DEPRECATED_FEATURE_SET),
     .X_EXT                          ( X_EXT                  ),
     .REGFILE_NUM_READ_PORTS         ( REGFILE_NUM_READ_PORTS ),
     .SMCLIC                         ( SMCLIC                 ),

--- a/rtl/cv32e40x_cs_registers.sv
+++ b/rtl/cv32e40x_cs_registers.sv
@@ -30,7 +30,6 @@
 
 module cv32e40x_cs_registers import cv32e40x_pkg::*;
 #(
-  parameter bit          USE_DEPRECATED_FEATURE_SET = 1, // todo: remove once related features are supported by iss
   parameter bit          A_EXT            = 0,
   parameter m_ext_e      M_EXT            = M,
   parameter bit          X_EXT            = 0,
@@ -580,10 +579,6 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
     mstatus_we               = 1'b0;
 
     mtvec_n.addr             = csr_mtvec_init_i ? mtvec_addr_i[31:7] : csr_wdata_int[31:7];
-    if (USE_DEPRECATED_FEATURE_SET) begin
-      mtvec_n.addr[7]        = 1'b0; // todo : remove
-    end
-
     mtvec_n.zero0            = mtvec_q.zero0;
     mtvec_we                 = csr_mtvec_init_i;
 

--- a/rtl/cv32e40x_if_stage.sv
+++ b/rtl/cv32e40x_if_stage.sv
@@ -28,7 +28,6 @@
 
 module cv32e40x_if_stage import cv32e40x_pkg::*;
 #(
-  parameter bit          USE_DEPRECATED_FEATURE_SET = 1, // todo: remove once related features are supported by iss
   parameter bit          A_EXT           = 0,
   parameter bit          X_EXT           = 0,
   parameter int          X_ID_WIDTH      = 4,
@@ -50,7 +49,6 @@ module cv32e40x_if_stage import cv32e40x_pkg::*;
   input  logic [31:0]   jump_target_id_i,       // Jump target address
   input  logic [31:0]   mepc_i,                 // Exception PC (restore upon return from exception/interrupt)
   input  logic [24:0]   mtvec_addr_i,           // Exception/interrupt address (MSBs)
-  input  logic [31:0]   nmi_addr_i,             // NMI address
 
   input  logic [MTVT_ADDR_WIDTH-1:0]   mtvt_addr_i,            // Base address for CLIC vectoring
 
@@ -130,8 +128,7 @@ module cv32e40x_if_stage import cv32e40x_pkg::*;
       PC_TRAP_IRQ: branch_addr_n = {mtvec_addr_i, ctrl_fsm_i.mtvec_pc_mux, 2'b00};     // interrupts are vectored
       PC_TRAP_DBD: branch_addr_n = {dm_halt_addr_i[31:2], 2'b0};
       PC_TRAP_DBE: branch_addr_n = {dm_exception_addr_i[31:2], 2'b0};
-      PC_TRAP_NMI: branch_addr_n = USE_DEPRECATED_FEATURE_SET ? {nmi_addr_i[31:2], 2'b00} :
-                                                                {mtvec_addr_i, NMI_MTVEC_INDEX, 2'b00};
+      PC_TRAP_NMI: branch_addr_n = {mtvec_addr_i, NMI_MTVEC_INDEX, 2'b00};
       PC_TRAP_CLICV:     branch_addr_n = {mtvt_addr_i, ctrl_fsm_i.mtvt_pc_mux[SMCLIC_ID_WIDTH-1:0], 2'b00};
       // CLIC spec requires to clear bit 0. This clearing is done in the alignment buffer.
       PC_TRAP_CLICV_TGT: branch_addr_n = if_id_pipe_o.instr.bus_resp.rdata;

--- a/rtl/include/cv32e40x_pkg.sv
+++ b/rtl/include/cv32e40x_pkg.sv
@@ -858,10 +858,6 @@ parameter EXC_CAUSE_INSTR_BUS_FAULT = 11'h30;
 parameter INT_CAUSE_LSU_LOAD_FAULT  = 11'h400;
 parameter INT_CAUSE_LSU_STORE_FAULT = 11'h401;
 
-// todo: remove once 11bit cause is supported by iss
-parameter DEPRECATED_INT_CAUSE_LSU_LOAD_FAULT  = 11'h80;
-parameter DEPRECATED_INT_CAUSE_LSU_STORE_FAULT = 11'h81;
-
 // Interrupt mask
 parameter IRQ_MASK = 32'hFFFF0888;
 

--- a/sva/cv32e40x_rvfi_sva.sv
+++ b/sva/cv32e40x_rvfi_sva.sv
@@ -176,7 +176,7 @@ module cv32e40x_rvfi_sva
                      (no_debug && $stable(mtvec_addr_i)) throughout s_goto_next_rvfi_valid(rvfi_csr_dcsr_rdata[3]) |->
                      rvfi_intr.intr &&
                      (rvfi_pc_rdata == {mtvec_addr_i, NMI_MTVEC_INDEX, 2'b00}) &&
-                     ((rvfi_csr_mcause_rdata[7:0] == INT_CAUSE_LSU_LOAD_FAULT) || (rvfi_csr_mcause_rdata[7:0] == INT_CAUSE_LSU_STORE_FAULT)))
+                     ((rvfi_csr_mcause_rdata[10:0] == INT_CAUSE_LSU_LOAD_FAULT) || (rvfi_csr_mcause_rdata[10:0] == INT_CAUSE_LSU_STORE_FAULT)))
       else `uvm_error("rvfi", "dcsr.nmip not followed by rvfi_intr and NMI handler")
 
 endmodule : cv32e40x_rvfi_sva

--- a/sva/cv32e40x_rvfi_sva.sv
+++ b/sva/cv32e40x_rvfi_sva.sv
@@ -43,7 +43,7 @@ module cv32e40x_rvfi_sva
    input logic [31:0]      rvfi_csr_dcsr_rdata,
    input logic [31:0]      rvfi_csr_mcause_rdata,
    input logic [31:0]      rvfi_pc_rdata,
-   input logic [31:0]      nmi_addr_i,
+   input logic [31:0]      mtvec_addr_i,
    input logic [31:0]      rvfi_csr_mie_rdata,
    input logic [31:0]      rvfi_csr_mip_rdata,
    input logic             irq_ack,
@@ -173,9 +173,9 @@ module cv32e40x_rvfi_sva
   // rvfi_intr should also be set.
   a_rvfi_nmip_nmi_handler:
     assert property (@(posedge clk_i) disable iff (!rst_ni)
-                     (no_debug && $stable(nmi_addr_i)) throughout s_goto_next_rvfi_valid(rvfi_csr_dcsr_rdata[3]) |->
+                     (no_debug && $stable(mtvec_addr_i)) throughout s_goto_next_rvfi_valid(rvfi_csr_dcsr_rdata[3]) |->
                      rvfi_intr.intr &&
-                     (rvfi_pc_rdata == {nmi_addr_i[31:2], 2'b00}) &&
+                     (rvfi_pc_rdata == {mtvec_addr_i, NMI_MTVEC_INDEX, 2'b00}) &&
                      ((rvfi_csr_mcause_rdata[7:0] == INT_CAUSE_LSU_LOAD_FAULT) || (rvfi_csr_mcause_rdata[7:0] == INT_CAUSE_LSU_STORE_FAULT)))
       else `uvm_error("rvfi", "dcsr.nmip not followed by rvfi_intr and NMI handler")
 

--- a/sva/cv32e40x_rvfi_sva.sv
+++ b/sva/cv32e40x_rvfi_sva.sv
@@ -43,7 +43,7 @@ module cv32e40x_rvfi_sva
    input logic [31:0]      rvfi_csr_dcsr_rdata,
    input logic [31:0]      rvfi_csr_mcause_rdata,
    input logic [31:0]      rvfi_pc_rdata,
-   input logic [31:0]      mtvec_addr_i,
+   input logic [24:0]      mtvec_addr_i,
    input logic [31:0]      rvfi_csr_mie_rdata,
    input logic [31:0]      rvfi_csr_mip_rdata,
    input logic             irq_ack,


### PR DESCRIPTION
SEC equivalent if USE_DEPRECATED_FEATURE_SET = 0.
Did not run assertion check flow as that is currently not compiling. 
Note that the a_rvfi_nmip_nmi_handler was fixed as well. It was not correct for either setting of USE_DEPRECATED_FEATURE_SET. I don't know why these assertions are excluded from formal runs (I will check with Halfdan).
Signed-off-by: Arjan Bink <Arjan.Bink@silabs.com>