### PR TITLE
Decoder interface change

### DIFF
--- a/rtl/cv32e40x_id_stage.sv
+++ b/rtl/cv32e40x_id_stage.sv
@@ -389,9 +389,6 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
   //                                           //
   ///////////////////////////////////////////////
 
-  logic [31:0] instr_merged;
-  assign instr_merged = if_id_pipe_i.use_merged_dec ? {16'b0, c_instr} : instr; // todo: temporary hack while merging decoder
-
   cv32e40x_decoder
   #(
     .A_EXT                           ( A_EXT                     ),
@@ -415,8 +412,7 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
     .sys_fencei_insn_o               ( sys_fencei_insn           ),
 
     // from IF/ID pipeline
-    .instr_rdata_i                   ( instr_merged              ), // todo: temporary hack while merging decoders
-    .illegal_c_insn_i                ( if_id_pipe_i.illegal_c_insn ),
+    .if_id_pipe_i                    ( if_id_pipe_i              ),
 
     // ALU
     .alu_en_o                        ( alu_en                    ),

--- a/sva/cv32e40x_decoder_sva.sv
+++ b/sva/cv32e40x_decoder_sva.sv
@@ -37,7 +37,7 @@ module cv32e40x_decoder_sva
   input decoder_ctrl_t  decoder_i_ctrl,
   input decoder_ctrl_t  decoder_b_ctrl,
   input decoder_ctrl_t  decoder_ctrl_mux,
-  input logic [31:0]    instr_rdata_i,
+  input logic [31:0]    instr_rdata,
   input if_id_pipe_t    if_id_pipe
 );
 
@@ -58,7 +58,7 @@ module cv32e40x_decoder_sva
   // Exclude CLIC pointers
   property p_uncompressed_lsb;
     @(posedge clk) disable iff(!rst_n)
-      !if_id_pipe.instr_meta.clic_ptr |-> (instr_rdata_i[1:0] == 2'b11);
+      !if_id_pipe.instr_meta.clic_ptr |-> (instr_rdata[1:0] == 2'b11);
   endproperty
 
 
@@ -69,7 +69,7 @@ module cv32e40x_decoder_sva
       // Check that A extension opcodes are decoded as illegal when A extension not enabled
       a_illegal_0 :
         assert property (@(posedge clk) disable iff (!rst_n)
-          (instr_rdata_i[6:0] == OPCODE_AMO) |-> (decoder_ctrl_mux.illegal_insn == 'b1))
+          (instr_rdata[6:0] == OPCODE_AMO) |-> (decoder_ctrl_mux.illegal_insn == 'b1))
         else `uvm_error("decoder", "AMO instruction should be illegal")
     end
   endgenerate


### PR DESCRIPTION
Changed interface of cv32e40x_decoder to be in line with the one used in cv32e40s.

Moved (temporary) instruction merge code from ID stage to the decoder.
Trailing whitespace removal.

Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>