### PR TITLE
Critical path improvements impacting jump, mret in decoder, bypass mo…

### DIFF
--- a/bhv/cv32e40x_rvfi.sv
+++ b/bhv/cv32e40x_rvfi.sv
@@ -38,8 +38,7 @@ module cv32e40x_rvfi
    input logic                                id_valid_i,
    input logic                                id_ready_i,
    input logic [ 1:0]                         rf_re_id_i,
-   input logic                                sys_en_id_i,
-   input logic                                sys_mret_insn_id_i,
+   input logic                                sys_mret_unqual_id_i,
    input logic                                jump_in_id_i,
    input logic [31:0]                         jump_target_id_i,
    input logic                                is_compressed_id_i,
@@ -738,12 +737,12 @@ module cv32e40x_rvfi
       end
 
       //// ID Stage ////
-      if(id_valid_i && ex_ready_i) begin
+      if (id_valid_i && ex_ready_i) begin
 
         if (jump_in_id_i) begin
           // Predicting mret/jump explicitly instead of using branch_addr_n to
-          // avoid including asynchronous traps and debug reqs in prediction
-          pc_wdata [STAGE_EX] <= (sys_en_id_i && sys_mret_insn_id_i) ? csr_mepc_q_i : jump_target_id_i;
+          // avoid including asynchronous traps and debug reqs in prediction.
+          pc_wdata [STAGE_EX] <= sys_mret_unqual_id_i ? csr_mepc_q_i : jump_target_id_i;
         end else begin
           pc_wdata [STAGE_EX] <= is_compressed_id_i ?  pc_id_i + 2 : pc_id_i + 4;
         end

--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -267,7 +267,7 @@ module cv32e40x_wrapper
                 .operand_a_id_i                   (core_i.id_stage_i.operand_a),
                 .operand_b_id_i                   (core_i.id_stage_i.operand_b),
                 .jalr_fw_id_i                     (core_i.id_stage_i.jalr_fw),
-                .alu_en_raw_id_i                  (core_i.alu_en_raw_id),
+                .alu_en_id_i                      (core_i.id_stage_i.alu_en),
                 .alu_jmpr_id_i                    (core_i.alu_jmpr_id),
                 .irq_ack                          (core_i.irq_ack),
                 .*);
@@ -389,8 +389,7 @@ module cv32e40x_wrapper
          .pc_if_i                  ( core_i.if_stage_i.pc_if_o                                            ),
          .pc_id_i                  ( core_i.id_stage_i.if_id_pipe_i.pc                                    ),
          .pc_wb_i                  ( core_i.wb_stage_i.ex_wb_pipe_i.pc                                    ),
-         .sys_en_id_i              ( core_i.id_stage_i.sys_en_o                                           ),
-         .sys_mret_insn_id_i       ( core_i.id_stage_i.sys_mret_insn_o                                    ),
+         .sys_mret_unqual_id_i     ( core_i.controller_i.controller_fsm_i.sys_mret_unqual_id              ),
          .jump_in_id_i             ( core_i.controller_i.controller_fsm_i.jump_in_id                      ),
          .jump_target_id_i         ( core_i.id_stage_i.jmp_target_o                                       ),
          .is_compressed_id_i       ( core_i.id_stage_i.if_id_pipe_i.instr_meta.compressed                 ),

--- a/rtl/cv32e40x_controller.sv
+++ b/rtl/cv32e40x_controller.sv
@@ -50,12 +50,10 @@ module cv32e40x_controller import cv32e40x_pkg::*;
 
   // from IF/ID pipeline
   input  if_id_pipe_t if_id_pipe_i,
-  input  logic        alu_en_raw_id_i,
   input  logic        alu_jmp_id_i,               // Jump (JAL, JALR)
   input  logic        alu_jmpr_id_i,              // Jump register (JALR)
-  input  logic        sys_en_id_i,
   input  logic        sys_mret_id_i,
-  input  logic        csr_en_id_i,
+  input  logic        csr_en_raw_id_i,
   input  csr_opcode_e csr_op_id_i,
 
   input  id_ex_pipe_t id_ex_pipe_i,
@@ -141,9 +139,7 @@ module cv32e40x_controller import cv32e40x_pkg::*;
     .if_id_pipe_i                ( if_id_pipe_i             ),
     .id_ready_i                  ( id_ready_i               ),
     .id_valid_i                  ( id_valid_i               ),
-    .alu_en_raw_id_i             ( alu_en_raw_id_i          ),
     .alu_jmp_id_i                ( alu_jmp_id_i             ),
-    .sys_en_id_i                 ( sys_en_id_i              ),
     .sys_mret_id_i               ( sys_mret_id_i            ),
 
     // From EX stage
@@ -209,11 +205,9 @@ module cv32e40x_controller import cv32e40x_pkg::*;
     // From ID
     .rf_re_id_i                 ( rf_re_id_i               ),
     .rf_raddr_id_i              ( rf_raddr_id_i            ),
-    .alu_en_raw_id_i            ( alu_en_raw_id_i          ),
     .alu_jmpr_id_i              ( alu_jmpr_id_i            ),
-    .sys_en_id_i                ( sys_en_id_i              ),
     .sys_mret_id_i              ( sys_mret_id_i            ),
-    .csr_en_id_i                ( csr_en_id_i              ),
+    .csr_en_raw_id_i            ( csr_en_raw_id_i          ),
     .csr_op_id_i                ( csr_op_id_i              ),
 
     // From EX

--- a/rtl/cv32e40x_controller_bypass.sv
+++ b/rtl/cv32e40x_controller_bypass.sv
@@ -45,11 +45,9 @@ module cv32e40x_controller_bypass import cv32e40x_pkg::*;
   input ex_wb_pipe_t  ex_wb_pipe_i,
 
   // From ID
-  input  logic        alu_en_raw_id_i,            // ALU enable (not gated with deassert) // todo: study area and functional impact of using alu_en_id_i instead
   input  logic        alu_jmpr_id_i,              // ALU jump register (JALR)
-  input  logic        sys_en_id_i,
   input  logic        sys_mret_id_i,              // mret in ID
-  input  logic        csr_en_id_i,                // CSR in ID
+  input  logic        csr_en_raw_id_i,            // CSR in ID (not gated with deassert)
   input  csr_opcode_e csr_op_id_i,                // CSR opcode (ID) // todo: Not used (is this on purpose or should it be used here?)
 
   // From EX
@@ -70,34 +68,45 @@ module cv32e40x_controller_bypass import cv32e40x_pkg::*;
   logic [REGFILE_NUM_READ_PORTS-1:0] rf_rd_ex_hz;
   logic [REGFILE_NUM_READ_PORTS-1:0] rf_rd_wb_hz;
 
-  // Detect CSR read in ID (implicit and explicit)
-  logic csr_read_in_id;
+  logic                              csr_write_in_ex_wb;        // Detect CSR write in EX or WB (implicit and explicit)
 
-  // Detect CSR write in EX or WB (implicit and explicit)
-  logic csr_write_in_ex_wb;
+  logic                              rf_we_ex;                  // EX register file write enable
+  logic                              rf_we_wb;                  // WB register file write enable
+  logic                              lsu_en_wb;                 // WB lsu_en
 
-  // EX register file write enable
-  logic rf_we_ex;
-  assign rf_we_ex = id_ex_pipe_i.rf_we && id_ex_pipe_i.instr_valid;
+  rf_addr_t                          rf_waddr_ex;               // EX rf_waddr
+  rf_addr_t                          rf_waddr_wb;               // WB rf_waddr
 
-  // WB register file write enable
-  logic rf_we_wb;
-  assign rf_we_wb = ex_wb_pipe_i.rf_we && ex_wb_pipe_i.instr_valid;
-
-  // WB lsu_en
-  logic lsu_en_wb;
-  assign lsu_en_wb = ex_wb_pipe_i.lsu_en && ex_wb_pipe_i.instr_valid;
-
-  // EX rf_waddr
-  rf_addr_t  rf_waddr_ex;
-  assign rf_waddr_ex = id_ex_pipe_i.rf_waddr;
-
-  // WB rf_waddr
-  // TODO: If XIF OoO is allowed, we need to look at WB stage outputs instead
-  rf_addr_t  rf_waddr_wb;
-  assign rf_waddr_wb = ex_wb_pipe_i.rf_waddr;
+  logic                              sys_mret_unqual_id;        // MRET in ID (not qualified with sys_en)
+  logic                              csr_exp_unqual_id;         // Explicit CSR in ID (not qualified with csr_en)
+  logic                              csr_unqual_id;             // Explicit or implicit CSR in ID (not qualified)
+  logic                              jmpr_unqual_id;            // JALR in ID (not qualified with alu_en)
 
   // todo: make all qualifiers here, and use those signals later in the file
+
+  assign rf_we_ex = id_ex_pipe_i.rf_we && id_ex_pipe_i.instr_valid;
+  assign rf_we_wb = ex_wb_pipe_i.rf_we && ex_wb_pipe_i.instr_valid;
+  assign lsu_en_wb = ex_wb_pipe_i.lsu_en && ex_wb_pipe_i.instr_valid;
+
+  assign rf_waddr_ex = id_ex_pipe_i.rf_waddr;
+  assign rf_waddr_wb = ex_wb_pipe_i.rf_waddr; // TODO: If XIF OoO is allowed, we need to look at WB stage outputs instead
+
+  // The following unqualified signals are such that they can have a false positive (but no false negative).
+  //
+  // There are two reasons why these signals are considered unqualified:
+  // - The corresponding _en signal is not used
+  // - A raw _en signal is used (i.e. deassert_we is ignored)
+  //
+  // This can lead to stall cycles (via jalr_stall or csr_stall) when they should not actually be needed.
+  // Such cases are however rare as the difference between qualified and unqualified signals will only
+  // occur in case that deassert_we = 1. Permanent stalls are avoided because the EX, WB stages will
+  // eventually empty out removing that reasons for stall conditions.
+
+  assign sys_mret_unqual_id = sys_mret_id_i && if_id_pipe_i.instr_valid;
+  assign csr_exp_unqual_id = csr_en_raw_id_i && if_id_pipe_i.instr_valid;
+  assign jmpr_unqual_id = alu_jmpr_id_i && if_id_pipe_i.instr_valid;
+
+  assign csr_unqual_id = csr_exp_unqual_id || sys_mret_unqual_id;
 
   /////////////////////////////////////////////////////////////
   //  ____  _        _ _    ____            _             _  //
@@ -116,8 +125,6 @@ module cv32e40x_controller_bypass import cv32e40x_pkg::*;
   // instr_valid signals would lead to a combinatorial loop via the halt signal.
 
   // todo:low:Above loop reasoning only applies to halt_id; for other pipeline stages a local instr_valid signal can maybe be used.
-
-  assign csr_read_in_id = (csr_en_id_i || (sys_en_id_i && sys_mret_id_i)) && if_id_pipe_i.instr_valid;
 
   // Detect when a CSR insn  in in EX or WB
   // mret and dret implicitly writes to CSR. (dret is killing IF/ID/EX once it is in WB and can be disregarded here.
@@ -151,8 +158,8 @@ module cv32e40x_controller_bypass import cv32e40x_pkg::*;
     end
   endgenerate
 
-  // JALR rs1 match (rf_re_id_i[0] implied by alu_jmpr_id_i).
-  // Not qualified yet with JALR (alu_jmpr_id_i && alu_en_raw_id_i) nor with read enable (implied by JALR)
+  // JALR rs1 match (rf_re_id_i[0] implied by JALR).
+  // Not qualified yet with JALR instruction nor with read enable (implied by JALR)
   assign rf_rd_ex_jalr_match = (rf_waddr_ex == rf_raddr_id_i[0]) && |rf_raddr_id_i[0];
   assign rf_rd_wb_jalr_match = (rf_waddr_wb == rf_raddr_id_i[0]) && |rf_raddr_id_i[0];
 
@@ -181,11 +188,11 @@ module cv32e40x_controller_bypass import cv32e40x_pkg::*;
     end
 
     // Stall because of jalr path. Stall if a result is to be forwarded to the PC except if result from WB is an ALU result.
-    // No need to deassert anything in ID as ID stage is stalled anyway. alu_jmpr_id_i implies rf_re_id_i[0].
+    // No need to deassert anything in ID as ID stage is stalled anyway. JALR implies rf_re_id_i[0].
     // Also stalling when a CSR access to MNXTI is in WB. This is because the jalr forward uses the ex_wb_pipe.rf_wdata as data,
     // and forwarding the CSR result (pointer address for mnxti) would need the forward mux to also include the pointer address from cs_registers.
     // Cannot use wb_stage.rf_wdata_o due to the timing path from the data OBI.
-    if ((alu_jmpr_id_i && alu_en_raw_id_i) &&
+    if (jmpr_unqual_id &&
          ((rf_we_wb && rf_rd_wb_jalr_match && lsu_en_wb) ||
           (rf_we_wb && rf_rd_wb_jalr_match && (ex_wb_pipe_i.csr_mnxti_access && ex_wb_pipe_i.csr_en)) ||
           (rf_we_ex && rf_rd_ex_jalr_match))) begin
@@ -195,7 +202,7 @@ module cv32e40x_controller_bypass import cv32e40x_pkg::*;
     end
 
     // Stall because of CSR read (direct or implied) in ID while CSR (implied or direct) is written in EX/WB
-    if (csr_read_in_id && csr_write_in_ex_wb) begin
+    if (csr_unqual_id && csr_write_in_ex_wb) begin
       ctrl_byp_o.csr_stall = 1'b1;
     end
 
@@ -236,7 +243,7 @@ module cv32e40x_controller_bypass import cv32e40x_pkg::*;
 
     // Forwarding WB->ID for the jump register path
     // Only used if WB is writing back an ALU result. No forwarding for load result because of timing reasons.
-    // Non qualified rf_rd_wb_jalr_match is used as it is a don't care if alu_jmpr_id_i = 0 or jalr_stall = 1.
+    // Non qualified rf_rd_wb_jalr_match is used as it is a don't care if jmpr_unqual_id = 0 or jalr_stall = 1.
     if (rf_we_wb) begin
       if (rf_rd_wb_jalr_match) begin
         ctrl_byp_o.jalr_fw_mux_sel = SELJ_FW_WB;

--- a/rtl/cv32e40x_core.sv
+++ b/rtl/cv32e40x_core.sv
@@ -253,12 +253,10 @@ module cv32e40x_core import cv32e40x_pkg::*;
   logic        trigger_match_if;
 
   // Controller <-> decoder
-  logic        alu_en_raw_id;
   logic        alu_jmp_id;
   logic        alu_jmpr_id;
-  logic        sys_en_id;
   logic        sys_mret_insn_id;
-  logic        csr_en_id;
+  logic        csr_en_raw_id;
   csr_opcode_e csr_op_id;
   logic        csr_illegal;
 
@@ -462,12 +460,10 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .rf_wdata_ex_i                ( rf_wdata_ex               ),
     .rf_wdata_wb_i                ( rf_wdata_wb               ),
 
-    .alu_en_raw_o                 ( alu_en_raw_id             ),
     .alu_jmp_o                    ( alu_jmp_id                ),
     .alu_jmpr_o                   ( alu_jmpr_id               ),
-    .sys_en_o                     ( sys_en_id                 ),
     .sys_mret_insn_o              ( sys_mret_insn_id          ),
-    .csr_en_o                     ( csr_en_id                 ),
+    .csr_en_raw_o                 ( csr_en_raw_id             ),
     .csr_op_o                     ( csr_op_id                 ),
 
     .rf_re_o                      ( rf_re_id                  ),
@@ -767,12 +763,10 @@ module cv32e40x_core import cv32e40x_pkg::*;
     // from IF/ID pipeline
     .if_id_pipe_i                   ( if_id_pipe             ),
 
-    .alu_en_raw_id_i                ( alu_en_raw_id          ),
     .alu_jmp_id_i                   ( alu_jmp_id             ),
     .alu_jmpr_id_i                  ( alu_jmpr_id            ),
-    .sys_en_id_i                    ( sys_en_id              ),
     .sys_mret_id_i                  ( sys_mret_insn_id       ),
-    .csr_en_id_i                    ( csr_en_id              ),
+    .csr_en_raw_id_i                ( csr_en_raw_id          ),
     .csr_op_id_i                    ( csr_op_id              ),
 
     // LSU

--- a/rtl/cv32e40x_decoder.sv
+++ b/rtl/cv32e40x_decoder.sv
@@ -50,7 +50,6 @@ module cv32e40x_decoder import cv32e40x_pkg::*;
 
   // ALU signals
   output logic          alu_en_o,               // ALU enable
-  output logic          alu_en_raw_o,           // ALU enable without deassert
   output logic          alu_bch_o,              // ALU branch (ALU used for comparison)
   output logic          alu_jmp_o,              // ALU jump (JALR, JALR) (ALU used to compute LR)
   output logic          alu_jmpr_o,             // ALU jump register (JALR) (ALU used to compute LR)
@@ -68,7 +67,8 @@ module cv32e40x_decoder import cv32e40x_pkg::*;
   output logic          div_en_o,               // Perform division
 
   // CSR
-  output logic          csr_en_o,               // Enable access to CSR
+  output logic          csr_en_o,               // CSR enable
+  output logic          csr_en_raw_o,           // CSR enable without deassert
   output csr_opcode_e   csr_op_o,               // Operation to perform on CSR
 
   // LSU
@@ -237,6 +237,6 @@ module cv32e40x_decoder import cv32e40x_pkg::*;
   // Suppress special instruction/illegal instruction bits
   assign illegal_insn_o = deassert_we_i ? 1'b0 : decoder_ctrl_mux.illegal_insn;
 
-  assign alu_en_raw_o = alu_en;
+  assign csr_en_raw_o = csr_en;
 
 endmodule // cv32e40x_decoder

--- a/rtl/cv32e40x_id_stage.sv
+++ b/rtl/cv32e40x_id_stage.sv
@@ -65,14 +65,12 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
   // Register file write data from EX stage
   input  logic [31:0] rf_wdata_ex_i,
 
-  output logic        alu_en_raw_o,
   output logic        alu_jmp_o,        // Jump (JAL, JALR)
   output logic        alu_jmpr_o,       // Jump register (JALR)
 
-  output logic        sys_en_o,
   output logic        sys_mret_insn_o,
 
-  output logic        csr_en_o,
+  output logic        csr_en_raw_o,
   output csr_opcode_e csr_op_o,
 
   // RF interface -> controller
@@ -116,7 +114,6 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
 
   // ALU Control
   logic                 alu_en;
-  logic                 alu_en_raw;
   logic                 alu_bch;
   logic                 alu_jmp;
   logic                 alu_jmpr;
@@ -140,6 +137,7 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
 
   // CSR
   logic                 csr_en;
+  logic                 csr_en_raw;
   csr_opcode_e          csr_op;
 
   // SYS
@@ -200,7 +198,6 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
 
   assign instr_valid = if_id_pipe_i.instr_valid && !ctrl_fsm_i.kill_id && !ctrl_fsm_i.halt_id;
 
-  assign sys_en_o = sys_en;
   assign sys_mret_insn_o = sys_mret_insn;
 
   assign instr = if_id_pipe_i.instr.bus_resp.rdata;
@@ -416,7 +413,6 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
 
     // ALU
     .alu_en_o                        ( alu_en                    ),
-    .alu_en_raw_o                    ( alu_en_raw                ),
     .alu_bch_o                       ( alu_bch                   ),
     .alu_jmp_o                       ( alu_jmp                   ),
     .alu_jmpr_o                      ( alu_jmpr                  ),
@@ -435,6 +431,7 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
 
     // CSR
     .csr_en_o                        ( csr_en                    ),
+    .csr_en_raw_o                    ( csr_en_raw                ),
     .csr_op_o                        ( csr_op                    ),
 
     // LSU
@@ -636,11 +633,10 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
     end
   end
 
-  assign alu_en_raw_o = alu_en_raw;
   assign alu_jmp_o    = alu_jmp;
   assign alu_jmpr_o   = alu_jmpr;
 
-  assign csr_en_o = csr_en;
+  assign csr_en_raw_o = csr_en_raw;
   assign csr_op_o = csr_op;
 
   // stall control for multicyle ID instructions (currently only misaligned LSU)

--- a/sva/cv32e40x_controller_fsm_sva.sv
+++ b/sva/cv32e40x_controller_fsm_sva.sv
@@ -493,7 +493,7 @@ endgenerate
     end else begin
       if(bus_error_latched) begin
         if(wb_valid_i && !ctrl_fsm_o.debug_mode && !(dcsr_i.step && !dcsr_i.stepie)) begin
-          valid_cnt <= valid_cnt + 1;
+          valid_cnt <= valid_cnt + 1'b1;
         end
       end else begin
         valid_cnt <= '0;

--- a/sva/cv32e40x_id_stage_sva.sv
+++ b/sva/cv32e40x_id_stage_sva.sv
@@ -59,11 +59,6 @@ module cv32e40x_id_stage_sva
   input logic           xif_insn_accept
 );
 
-    // the instruction delivered to the ID stage should always be valid
-    a_valid_instr :
-      assert property (@(posedge clk)
-                       (if_id_pipe_i.instr_valid & (~if_id_pipe_i.illegal_c_insn)) |-> (!$isunknown(instr)) )
-        else `uvm_error("id_stage", $sformatf("%t, Instruction is valid, but has at least one X", $time));
 /* todo: check and fix/remove
       // Check that instruction after taken branch is flushed (more should actually be flushed, but that is not checked here)
       // and that EX stage is ready to receive flushed instruction immediately

--- a/sva/cv32e40x_load_store_unit_sva.sv
+++ b/sva/cv32e40x_load_store_unit_sva.sv
@@ -101,19 +101,6 @@ module cv32e40x_load_store_unit_sva
   a_no_spurious_rvalid :
     assert property(p_no_spurious_rvalid) else `uvm_error("load_store_unit", "Assertion a_no_spurious_rvalid failed")
 
-  // Check that the address/we/be/atop does not contain X when request is sent
-  property p_address_phase_signals_defined;
-      @(posedge clk) (m_c_obi_data_if.s_req.req == 1'b1) |->
-                     (!($isunknown(m_c_obi_data_if.req_payload.addr) ||
-                        $isunknown(m_c_obi_data_if.req_payload.we)   ||
-                        $isunknown(m_c_obi_data_if.req_payload.be)   ||
-                        $isunknown(m_c_obi_data_if.req_payload.atop)));
-  endproperty
-
-  a_address_phase_signals_defined :
-    assert property(p_address_phase_signals_defined)
-      else `uvm_error("load_store_unit", "Assertion a_address_phase_signals_defined failed")
-
   // No transaction allowd if EX is halted or killed
   a_lsu_halt_kill:
     assert property (@(posedge clk) disable iff (!rst_n)


### PR DESCRIPTION
…dule and controller

Not SEC clean.
Jumps, mret that are killed (e.g. due to bus error, breakpoint) will behave differently on the OBI instruction bus.
Various assertion (warning) fixes
Signed-off-by: Arjan Bink <Arjan.Bink@silabs.com>