### PR TITLE
Implemented cm.lbu and cm.lhu from Zc C2.

### DIFF
--- a/rtl/cv32e40x_compressed_decoder.sv
+++ b/rtl/cv32e40x_compressed_decoder.sv
@@ -119,6 +119,8 @@ module cv32e40x_compressed_decoder import cv32e40x_pkg::*;
                   3'b011: begin
                     // c.sh -> sh rs2', imm(rs1')
                     instr_o.bus_resp.rdata = {7'b0, 2'b01, instr[4:2], 2'b01, instr[9:7], 3'b001, 3'b000, instr[5], 1'b0, OPCODE_STORE};
+
+                    if (instr[6]) illegal_instr_o = 1'b1;
                   end
                   default: begin
                     illegal_instr_o = 1'b1;
@@ -339,12 +341,34 @@ module cv32e40x_compressed_decoder import cv32e40x_pkg::*;
               end
             end
 
+            3'b001: begin
+              if (ZC_EXT) begin
+                // cm.lbu rd', uimm(rs1') -> lbu rd', uimm(rs1')
+                instr_o.bus_resp.rdata = {8'h00, instr[10], instr[6:5], instr[11], 2'b01, instr[9:7], 3'b100, 2'b01, instr[4:2], OPCODE_LOAD};
+
+                if (instr[12]) illegal_instr_o = 1'b1;
+              end else begin
+                instr_o.bus_resp.rdata = {4'b0, instr[3:2], instr[12], instr[6:4], 2'b00, 5'h02, 3'b010, instr[11:7], OPCODE_LOAD};
+                illegal_instr_o = 1'b1;
+              end
+            end
             3'b010: begin
               // c.lwsp -> lw rd, imm(x2)
               instr_o.bus_resp.rdata = {4'b0, instr[3:2], instr[12], instr[6:4], 2'b00, 5'h02, 3'b010, instr[11:7], OPCODE_LOAD};
               if (instr[11:7] == 5'b0)  illegal_instr_o = 1'b1;
             end
 
+            3'b011: begin
+              if (ZC_EXT) begin
+                // cm.lhu rd', uimm(rs1') -> lhu rd', uimm(rs1')
+                instr_o.bus_resp.rdata = {7'b0000000, instr[11:10], instr[6:5], 1'b0, 2'b01, instr[9:7], 3'b101, 2'b01, instr[4:2], OPCODE_LOAD};
+
+                if (!instr[12]) illegal_instr_o = 1'b1;
+              end else begin
+                instr_o.bus_resp.rdata = {4'b0, instr[3:2], instr[12], instr[6:4], 2'b00, 5'h02, 3'b010, instr[11:7], OPCODE_LOAD};
+                illegal_instr_o = 1'b1;
+              end
+            end
             3'b100: begin
               if (instr[12] == 1'b0) begin
                 if (instr[6:2] == 5'b0) begin
@@ -391,8 +415,6 @@ module cv32e40x_compressed_decoder import cv32e40x_pkg::*;
               instr_o.bus_resp.rdata = {4'b0, instr[8:7], instr[12], instr[6:2], 5'h02, 3'b010, instr[11:9], 2'b00, OPCODE_STORE};
             end
 
-            3'b001,        // c.fldsp -> fld rd, imm(x2)
-            3'b011,        // c.flwsp -> flw rd, imm(x2)
             3'b101,        // c.fsdsp -> fsd rs2, imm(x2)
             3'b111: begin  // c.fswsp -> fsw rs2, imm(x2)
               instr_o.bus_resp.rdata = {4'b0, instr[3:2], instr[12], instr[6:4], 2'b00, 5'h02, 3'b010, instr[11:7], OPCODE_LOAD};


### PR DESCRIPTION
+ Bugfix for c.sh, did not flag illegal instruction if bit 6 was set.

SEC clean when ZC_EXT=0
Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>