### PR TITLE
mtvec.mode is a 2-bit WARL bitfield. Require write buffer flush before retiring fence.i

### DIFF
--- a/docs/user_manual/source/control_status_registers.rst
+++ b/docs/user_manual/source/control_status_registers.rst
@@ -621,7 +621,7 @@ Detailed:
 +---------+------------------+---------------------------------------------------------------------------------------------------------------+
 | 6:2     | WARL (0x0)       | **BASE[6:2]**: Trap-handler base address, always aligned to 128 bytes. ``mtvec[6:2]`` is hardwired to 0x0.    |
 +---------+------------------+---------------------------------------------------------------------------------------------------------------+
-| 1:0     | WARL (0x0, 0x1)  | **MODE[0]**: Interrupt handling mode. 0x0 = non-vectored basic mode, 0x1 = vectored basic mode.               |
+| 1:0     | WARL (0x0, 0x1)  | **MODE**: Interrupt handling mode. 0x0 = non-vectored basic mode, 0x1 = vectored basic mode.                  |
 +---------+------------------+---------------------------------------------------------------------------------------------------------------+
 
 The initial value of ``mtvec`` is equal to {**mtvec_addr_i[31:7]**, 5'b0, 2'b01}.

--- a/docs/user_manual/source/load_store_unit.rst
+++ b/docs/user_manual/source/load_store_unit.rst
@@ -151,5 +151,6 @@ The write buffer (when not full) allows |corev| to proceed executing instruction
 Bus transfers will occur in program order, no matter if transfers are bufferable and non-bufferable.
 Transactions in the write buffer must be completed before the |corev| is able to:
  
- * Retire a fence instruction
+ * Retire a ``fence`` instruction
+ * Retire a ``fence.i`` instruction
  * Enter SLEEP mode


### PR DESCRIPTION
Signed-off-by: Arjan Bink <Arjan.Bink@silabs.com>