### PR TITLE
Made jumps and mrets depend on alu_en and sys_en, as this change led …

### DIFF
--- a/rtl/cv32e40x_controller.sv
+++ b/rtl/cv32e40x_controller.sv
@@ -52,6 +52,8 @@ module cv32e40x_controller import cv32e40x_pkg::*;
   input  if_id_pipe_t if_id_pipe_i,
   input  logic        alu_jmp_id_i,               // Jump (JAL, JALR)
   input  logic        alu_jmpr_id_i,              // Jump register (JALR)
+  input  logic        alu_en_id_i,
+  input  logic        sys_en_id_i,
   input  logic        sys_mret_id_i,
   input  logic        csr_en_raw_id_i,
   input  csr_opcode_e csr_op_id_i,
@@ -141,6 +143,8 @@ module cv32e40x_controller import cv32e40x_pkg::*;
     .id_valid_i                  ( id_valid_i               ),
     .alu_jmp_id_i                ( alu_jmp_id_i             ),
     .sys_mret_id_i               ( sys_mret_id_i            ),
+    .alu_en_id_i                 ( alu_en_id_i              ),
+    .sys_en_id_i                 ( sys_en_id_i              ),
 
     // From EX stage
     .id_ex_pipe_i                ( id_ex_pipe_i             ),

--- a/rtl/cv32e40x_controller_fsm.sv
+++ b/rtl/cv32e40x_controller_fsm.sv
@@ -53,6 +53,8 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
   input  if_id_pipe_t if_id_pipe_i,
   input  logic        alu_jmp_id_i,               // Jump in ID
   input  logic        sys_mret_id_i,              // mret in ID
+  input  logic        alu_en_id_i,                // alu_en qualifier for jumps
+  input  logic        sys_en_id_i,                // sys_en qualifier for mret
 
   // From EX stage
   input  id_ex_pipe_t id_ex_pipe_i,
@@ -132,8 +134,8 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
   logic single_step_halt_if_q; // Halting IF after issuing one insn in single step mode
 
   // ID signals
-  logic sys_mret_unqual_id;             // MRET in ID (not qualified with sys_en)
-  logic jmp_unqual_id;                  // JAL, JALR in ID (not qualified with alu_en)
+  logic sys_mret_id;             // MRET in ID
+  logic jmp_id;                  // JAL, JALR in ID
   logic jump_in_id;
   logic jump_taken_id;
 
@@ -166,6 +168,7 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
   // Flags for allowing interrupt and debug
   logic exception_allowed;
   logic interrupt_allowed;
+  logic nmi_allowed;
   logic debug_allowed;
   logic single_step_allowed;
 
@@ -221,19 +224,16 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
   // ID stage
 
   // A jump is taken in ID for jump instructions, and also for mret instructions
-  // Checking validity of jump/mret instruction with if_id_pipe_i.instr_valid.
+  // Checking validity of jump/mret instruction with if_id_pipe_i.instr_valid and the respective alu_en/sys_en.
   // Using the ID stage local instr_valid would bring halt_id and kill_id into the equation
   // causing a path from data_rvalid to instr_addr_o/instr_req_o/instr_memtype_o via pc_set.
-  //
-  // Note that alu_jmp_id_i and sys_mret_id_i are used in a non-qualified manner (i.e. not
-  // gated with the corresponding enable signals). This can lead to jumps being taken from
-  // ID when the actual jump/mret is not really enabled. The instructions fetched from such
-  // jump/mret will get flushed.
 
-  assign sys_mret_unqual_id = sys_mret_id_i && if_id_pipe_i.instr_valid;
-  assign jmp_unqual_id = alu_jmp_id_i && if_id_pipe_i.instr_valid;
 
-  assign jump_in_id = (jmp_unqual_id && !ctrl_byp_i.jalr_stall) || (sys_mret_unqual_id && !ctrl_byp_i.csr_stall);
+
+  assign sys_mret_id = sys_en_id_i && sys_mret_id_i && if_id_pipe_i.instr_valid;
+  assign jmp_id      = alu_en_id_i && alu_jmp_id_i  && if_id_pipe_i.instr_valid;
+
+  assign jump_in_id = (jmp_id && !ctrl_byp_i.jalr_stall) || (sys_mret_id && !ctrl_byp_i.csr_stall);
 
   // Blocking on branch_taken_q, as a jump has already been taken
   assign jump_taken_id = jump_in_id && !branch_taken_q;
@@ -707,13 +707,10 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
           end else if (jump_taken_id) begin
             // Jumps in ID (JAL, JALR, mret)
 
-            // False positives can occur here because the signals
-            // feeding into jump_taken_id are not qualified.
-
             // kill_if
             ctrl_fsm_o.kill_if = 1'b1;
 
-            if (sys_mret_unqual_id) begin
+            if (sys_mret_id) begin
               ctrl_fsm_o.pc_mux = debug_mode_q ? PC_TRAP_DBE : PC_MRET;
               ctrl_fsm_o.pc_set = 1'b1;
               // Todo: if mcause.minhv

--- a/rtl/cv32e40x_core.sv
+++ b/rtl/cv32e40x_core.sv
@@ -255,6 +255,8 @@ module cv32e40x_core import cv32e40x_pkg::*;
   // Controller <-> decoder
   logic        alu_jmp_id;
   logic        alu_jmpr_id;
+  logic        alu_en_id;
+  logic        sys_en_id;
   logic        sys_mret_insn_id;
   logic        csr_en_raw_id;
   csr_opcode_e csr_op_id;
@@ -468,6 +470,8 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .sys_mret_insn_o              ( sys_mret_insn_id          ),
     .csr_en_raw_o                 ( csr_en_raw_id             ),
     .csr_op_o                     ( csr_op_id                 ),
+    .alu_en_o                     ( alu_en_id                 ),
+    .sys_en_o                     ( sys_en_id                 ),
 
     .rf_re_o                      ( rf_re_id                  ),
     .rf_raddr_o                   ( rf_raddr_id               ),
@@ -768,6 +772,8 @@ module cv32e40x_core import cv32e40x_pkg::*;
 
     .alu_jmp_id_i                   ( alu_jmp_id             ),
     .alu_jmpr_id_i                  ( alu_jmpr_id            ),
+    .alu_en_id_i                    ( alu_en_id              ),
+    .sys_en_id_i                    ( sys_en_id              ),
     .sys_mret_id_i                  ( sys_mret_insn_id       ),
     .csr_en_raw_id_i                ( csr_en_raw_id          ),
     .csr_op_id_i                    ( csr_op_id              ),

--- a/rtl/cv32e40x_id_stage.sv
+++ b/rtl/cv32e40x_id_stage.sv
@@ -74,6 +74,9 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
   output logic        csr_en_raw_o,
   output csr_opcode_e csr_op_o,
 
+  output logic        alu_en_o,
+  output logic        sys_en_o,
+
   // RF interface -> controller
   output logic [REGFILE_NUM_READ_PORTS-1:0] rf_re_o,
   output rf_addr_t    rf_raddr_o[REGFILE_NUM_READ_PORTS],
@@ -640,6 +643,9 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
 
   assign csr_en_raw_o = csr_en_raw;
   assign csr_op_o = csr_op;
+
+  assign alu_en_o     = alu_en;
+  assign sys_en_o     = sys_en;
 
   // stall control for multicyle ID instructions (currently only misaligned LSU)
   assign multi_cycle_id_stall = 1'b0; //todo:ok Zce push/pop will use this


### PR DESCRIPTION
…to issues when merging to E40S. We might want to revisit this feature on the E40S in the future.

Not SEC clean. Formal is clean.

Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>