### PR TITLE
Fixed connection to sys_mret_id to rvfi inside wrapper.

### DIFF
--- a/bhv/cv32e40x_rvfi.sv
+++ b/bhv/cv32e40x_rvfi.sv
@@ -38,7 +38,7 @@ module cv32e40x_rvfi
    input logic                                id_valid_i,
    input logic                                id_ready_i,
    input logic [ 1:0]                         rf_re_id_i,
-   input logic                                sys_mret_unqual_id_i,
+   input logic                                sys_mret_id_i,
    input logic                                jump_in_id_i,
    input logic [31:0]                         jump_target_id_i,
    input logic                                is_compressed_id_i,
@@ -742,7 +742,7 @@ module cv32e40x_rvfi
         if (jump_in_id_i) begin
           // Predicting mret/jump explicitly instead of using branch_addr_n to
           // avoid including asynchronous traps and debug reqs in prediction.
-          pc_wdata [STAGE_EX] <= sys_mret_unqual_id_i ? csr_mepc_q_i : jump_target_id_i;
+          pc_wdata [STAGE_EX] <= sys_mret_id_i ? csr_mepc_q_i : jump_target_id_i;
         end else begin
           pc_wdata [STAGE_EX] <= is_compressed_id_i ?  pc_id_i + 2 : pc_id_i + 4;
         end

--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -389,7 +389,7 @@ module cv32e40x_wrapper
          .pc_if_i                  ( core_i.if_stage_i.pc_if_o                                            ),
          .pc_id_i                  ( core_i.id_stage_i.if_id_pipe_i.pc                                    ),
          .pc_wb_i                  ( core_i.wb_stage_i.ex_wb_pipe_i.pc                                    ),
-         .sys_mret_unqual_id_i     ( core_i.controller_i.controller_fsm_i.sys_mret_unqual_id              ),
+         .sys_mret_id_i            ( core_i.controller_i.controller_fsm_i.sys_mret_id_i                   ),
          .jump_in_id_i             ( core_i.controller_i.controller_fsm_i.jump_in_id                      ),
          .jump_target_id_i         ( core_i.id_stage_i.jmp_target_o                                       ),
          .is_compressed_id_i       ( core_i.id_stage_i.if_id_pipe_i.instr_meta.compressed                 ),


### PR DESCRIPTION
Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>