### PR TITLE
Changed fetching of CLIC pointers to use instruction instead of data …

### DIFF
--- a/rtl/cv32e40x_alignment_buffer.sv
+++ b/rtl/cv32e40x_alignment_buffer.sv
@@ -39,7 +39,7 @@ module cv32e40x_alignment_buffer import cv32e40x_pkg::*;
   input  logic           fetch_ready_i,
   output logic           fetch_branch_o,
   output logic [31:0]    fetch_branch_addr_o,
-  output logic           fetch_data_access_o,
+  output logic           fetch_ptr_access_o,
   input  logic           fetch_ptr_access_i,
 
   // Resp interface
@@ -561,10 +561,10 @@ module cv32e40x_alignment_buffer import cv32e40x_pkg::*;
 
   // Signal that result is a pointer
   // CLIC vectoring or Zc table jump
+  // todo: probably need to differentiate between CLIC and Zc as they will be handled differently by the pipeline/controller.
   assign instr_is_ptr_o = is_ptr_q;
 
-  // Fetch is treated as a data access for CLIC vector fetch
-  // Only set for the initial pc_set_clicv point fetch and qualified with fetch_branch_o
-  // Prefetcher will remember the state of data_access in case of stalls.
-  assign fetch_data_access_o = (ctrl_fsm_i.pc_set && ctrl_fsm_i.pc_set_clicv);
+  // Signal that a pointer is about to be fetched
+  // todo: factor in Zc cm.jt/cm.jalt
+  assign fetch_ptr_access_o = (ctrl_fsm_i.pc_set && ctrl_fsm_i.pc_set_clicv);
 endmodule

--- a/rtl/cv32e40x_controller_fsm.sv
+++ b/rtl/cv32e40x_controller_fsm.sv
@@ -824,7 +824,7 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
           // todo: deal with integrity related faults for E40S.
           if(!((if_id_pipe_i.instr.mpu_status != MPU_OK) || if_id_pipe_i.instr.bus_resp.err)) begin
             ctrl_fsm_o.pc_set = 1'b1;
-            ctrl_fsm_o.pc_mux = PC_TRAP_CLICV_TGT;
+            ctrl_fsm_o.pc_mux = PC_POINTER;
             ctrl_fsm_o.kill_if = 1'b1;
             ctrl_fsm_o.csr_clear_minhv = 1'b1;
 

--- a/rtl/cv32e40x_prefetch_unit.sv
+++ b/rtl/cv32e40x_prefetch_unit.sv
@@ -48,7 +48,6 @@ module cv32e40x_prefetch_unit import cv32e40x_pkg::*;
   output logic        trans_valid_o,
   input  logic        trans_ready_i,
   output logic [31:0] trans_addr_o,
-  output logic        trans_data_access_o,
 
   input  logic        resp_valid_i,
   input  inst_resp_t  resp_i,
@@ -66,6 +65,7 @@ module cv32e40x_prefetch_unit import cv32e40x_pkg::*;
   logic [31:0] fetch_branch_addr;
   logic        fetch_data_access;
   logic        fetch_ptr_access;
+  logic        fetch_ptr_access_resp;
 
 
 
@@ -86,14 +86,12 @@ module cv32e40x_prefetch_unit import cv32e40x_pkg::*;
     .fetch_branch_addr_i      ( fetch_branch_addr    ),
     .fetch_valid_i            ( fetch_valid          ),
     .fetch_ready_o            ( fetch_ready          ),
-    .fetch_data_access_i      ( fetch_data_access    ),
-    .fetch_ptr_access_o       ( fetch_ptr_access     ),
+    .fetch_ptr_access_i       ( fetch_ptr_access     ),
+    .fetch_ptr_access_o       ( fetch_ptr_resp       ),
 
     .trans_valid_o            ( trans_valid_o        ),
     .trans_ready_i            ( trans_ready_i        ),
-    .trans_addr_o             ( trans_addr_o         ),
-    .trans_data_access_o      ( trans_data_access_o  )
-
+    .trans_addr_o             ( trans_addr_o         )
   );
 
 
@@ -113,8 +111,8 @@ module cv32e40x_prefetch_unit import cv32e40x_pkg::*;
     .fetch_ready_i        ( fetch_ready            ),
     .fetch_branch_o       ( fetch_branch           ),
     .fetch_branch_addr_o  ( fetch_branch_addr      ),
-    .fetch_data_access_o  ( fetch_data_access      ),
-    .fetch_ptr_access_i   ( fetch_ptr_access       ),
+    .fetch_ptr_access_o   ( fetch_ptr_access       ),
+    .fetch_ptr_access_i   ( fetch_ptr_resp         ),
 
     .resp_valid_i         ( resp_valid_i           ),
     .resp_i               ( resp_i                 ),

--- a/rtl/include/cv32e40x_pkg.sv
+++ b/rtl/include/cv32e40x_pkg.sv
@@ -843,7 +843,7 @@ typedef enum logic[3:0] {
   PC_TRAP_DBE = 4'b1011,
   PC_TRAP_NMI = 4'b1100,
   PC_TRAP_CLICV = 4'b1101,
-  PC_TRAP_CLICV_TGT = 4'b1110
+  PC_POINTER    = 4'b1110
 } pc_mux_e;
 
 // Exception Cause
@@ -1035,6 +1035,7 @@ typedef struct packed {
   logic        illegal_c_insn;
   logic        trigger_match;
   logic [31:0] xif_id;  // ID of offloaded instruction
+  logic [31:0] ptr;  // Flops to hold 32-bit pointer
 } if_id_pipe_t;
 
 // ID/EX pipeline

--- a/sva/cv32e40x_alignment_buffer_sva.sv
+++ b/sva/cv32e40x_alignment_buffer_sva.sv
@@ -31,7 +31,6 @@ module cv32e40x_alignment_buffer_sva
    input logic [31:0]              fetch_branch_addr_o,
    input logic                     fetch_valid_o,
    input logic                     fetch_ready_i,
-   input logic                     fetch_data_access_o,
    input logic [2:0] instr_cnt_n,
    input logic [2:0] instr_cnt_q,
    input logic                     instr_valid_o,

--- a/sva/cv32e40x_controller_fsm_sva.sv
+++ b/sva/cv32e40x_controller_fsm_sva.sv
@@ -521,13 +521,13 @@ if (SMCLIC) begin
     else `uvm_error("controller", "LSU write buffer not empty when fetching CLIC pointer")
 
   // After a pc_set to PC_TRAP_CLICV, only the following jump targets are allowed:
-  // PC_TRAP_CLICV_TGT: Normal execution, the pointer target is being fetched
-  // PC_TRAP_EXC:       The pointer fetch has a synchronous exception
-  // PC_TRAP_NMI:       The pointer fetch has a bus error. Todo: Change if CLIC spec stops using data access for pointer fetch.
+  // PC_POINTER : Normal execution, the pointer target is being fetched
+  // PC_TRAP_EXC: The pointer fetch has a synchronous exception
+  // PC_TRAP_NMI: The pointer fetch has a bus error. Todo: Change if CLIC spec stops using data access for pointer fetch.
   a_clicv_next_pc_set:
   assert property (@(posedge clk) disable iff (!rst_n)
                   (ctrl_fsm_o.pc_set && (ctrl_fsm_o.pc_mux == PC_TRAP_CLICV))
-                  |=> !ctrl_fsm_o.pc_set until (ctrl_fsm_o.pc_set && ((ctrl_fsm_o.pc_mux == PC_TRAP_CLICV_TGT) ||
+                  |=> !ctrl_fsm_o.pc_set until (ctrl_fsm_o.pc_set && ((ctrl_fsm_o.pc_mux == PC_POINTER)        ||
                                                                       (ctrl_fsm_o.pc_mux == PC_TRAP_EXC)       ||
                                                                       (ctrl_fsm_o.pc_mux == PC_TRAP_NMI))))
     else `uvm_error("controller", "Illegal pc_mux after pointer fetch")

--- a/sva/cv32e40x_prefetch_unit_sva.sv
+++ b/sva/cv32e40x_prefetch_unit_sva.sv
@@ -32,7 +32,7 @@ module cv32e40x_prefetch_unit_sva import cv32e40x_pkg::*;
    input logic        prefetch_ready_i,
    input logic        trans_valid_o,
    input logic        trans_ready_i,
-   input logic        trans_data_access_o
+   input logic        fetch_ptr_resp
 
   );
 
@@ -59,7 +59,7 @@ if (SMCLIC) begin
   // based on the pointer.
   property p_single_ptr_fetch;
     @(posedge clk) disable iff (!rst_n)
-    (trans_valid_o && trans_ready_i && trans_data_access_o) |=> !trans_valid_o until ctrl_fsm_i.pc_set;
+    (trans_valid_o && trans_ready_i && fetch_ptr_resp) |=> !trans_valid_o until ctrl_fsm_i.pc_set;
   endproperty
 
   a_single_ptr_fetch:

--- a/sva/cv32e40x_prefetcher_sva.sv
+++ b/sva/cv32e40x_prefetcher_sva.sv
@@ -44,7 +44,7 @@ module cv32e40x_prefetcher_sva import cv32e40x_pkg::*;
   input  logic        trans_ready_i,            // Transaction request ready (transaction gets accepted when trans_valid_o and trans_ready_i are both 1)
   input  logic [31:0] trans_addr_o,             // Transaction address (only valid when trans_valid_o = 1). No stability requirements.
 
-  input  logic        trans_data_access_q,
+  input  logic        trans_ptr_access_q,
 
   // Fetch interface is ready/valid
   input  logic        fetch_ready_o,
@@ -174,7 +174,7 @@ module cv32e40x_prefetcher_sva import cv32e40x_pkg::*;
 
 if (SMCLIC) begin
   property p_data_q_no_branch;
-    @(posedge clk) disable iff (!rst_n) (((state_q == BRANCH_WAIT) && trans_data_access_q) |-> !fetch_branch_i);
+    @(posedge clk) disable iff (!rst_n) (((state_q == BRANCH_WAIT) && trans_ptr_access_q) |-> !fetch_branch_i);
   endproperty
 
   a_p_data_q_no_branch:


### PR DESCRIPTION
…fetches through the intruction interface.

Non SEC as this affects the prot bits and PMA results based on the prot bits.

Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>