### PR TITLE
Fixed dependency between Zc and Zbb

### DIFF
--- a/rtl/cv32e40x_compressed_decoder.sv
+++ b/rtl/cv32e40x_compressed_decoder.sv
@@ -27,7 +27,8 @@
 module cv32e40x_compressed_decoder import cv32e40x_pkg::*;
 #(
     parameter bit          ZC_EXT    = 0,
-    parameter m_ext_e      M_EXT     = M
+    parameter b_ext_e      B_EXT     = B_NONE,
+    parameter m_ext_e      M_EXT     = M_NONE
  )
 (
   input  inst_resp_t  instr_i,
@@ -287,16 +288,31 @@ module cv32e40x_compressed_decoder import cv32e40x_pkg::*;
                             instr_o.bus_resp.rdata = {4'h0, 8'hff, 2'b01, instr[9:7], 3'b111, 2'b01, instr[9:7],  OPCODE_OPIMM};
                           end
                           3'b001: begin
-                            // c.sext.b -> sext.b rsd', rsd'
-                            instr_o.bus_resp.rdata = {7'b0110000, 5'b00100, 2'b01, instr[9:7], 3'b001, 2'b01, instr[9:7],  OPCODE_OPIMM};
+                            if (B_EXT != B_NONE) begin
+                              // c.sext.b -> sext.b rsd', rsd'
+                              instr_o.bus_resp.rdata = {7'b0110000, 5'b00100, 2'b01, instr[9:7], 3'b001, 2'b01, instr[9:7],  OPCODE_OPIMM};
+                            end else begin
+                              instr_o.bus_resp.rdata = {7'b0, 2'b01, instr[4:2], 2'b01, instr[9:7], 3'b111, 2'b01, instr[9:7], OPCODE_OP};
+                              illegal_instr_o = 1'b1;
+                            end
                           end
                           3'b010: begin
-                            // c.zext.h -> zext.h rsd', rsd'
-                            instr_o.bus_resp.rdata = {7'b0000100, 5'b00000, 2'b01, instr[9:7], 3'b100, 2'b01, instr[9:7],  OPCODE_OP};
+                            if (B_EXT != B_NONE) begin
+                              // c.zext.h -> zext.h rsd', rsd'
+                              instr_o.bus_resp.rdata = {7'b0000100, 5'b00000, 2'b01, instr[9:7], 3'b100, 2'b01, instr[9:7],  OPCODE_OP};
+                            end else begin
+                              instr_o.bus_resp.rdata = {7'b0, 2'b01, instr[4:2], 2'b01, instr[9:7], 3'b111, 2'b01, instr[9:7], OPCODE_OP};
+                              illegal_instr_o = 1'b1;
+                            end
                           end
                           3'b011: begin
-                            //c.sext.h -> sext.h rsd', rsd'
-                            instr_o.bus_resp.rdata = {7'b0110000, 5'b00101, 2'b01, instr[9:7], 3'b001, 2'b01, instr[9:7],  OPCODE_OPIMM};
+                            if (B_EXT != B_NONE) begin
+                              // c.sext.h -> sext.h rsd', rsd'
+                              instr_o.bus_resp.rdata = {7'b0110000, 5'b00101, 2'b01, instr[9:7], 3'b001, 2'b01, instr[9:7],  OPCODE_OPIMM};
+                            end else begin
+                              instr_o.bus_resp.rdata = {7'b0, 2'b01, instr[4:2], 2'b01, instr[9:7], 3'b111, 2'b01, instr[9:7], OPCODE_OP};
+                              illegal_instr_o = 1'b1;
+                            end
                           end
                           3'b101: begin
                             // c.not -> xori rsd', rsd', -1

--- a/rtl/cv32e40x_core.sv
+++ b/rtl/cv32e40x_core.sv
@@ -376,6 +376,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
   cv32e40x_if_stage
   #(
     .A_EXT               ( A_EXT                    ),
+    .B_EXT               ( B_EXT                    ),
     .X_EXT               ( X_EXT                    ),
     .X_ID_WIDTH          ( X_ID_WIDTH               ),
     .PMA_NUM_REGIONS     ( PMA_NUM_REGIONS          ),
@@ -436,7 +437,6 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .B_EXT                        ( B_EXT                     ),
     .M_EXT                        ( M_EXT                     ),
     .X_EXT                        ( X_EXT                     ),
-    .ZC_EXT                       ( ZC_EXT                    ),
     .REGFILE_NUM_READ_PORTS       ( REGFILE_NUM_READ_PORTS    )
   )
   id_stage_i

--- a/rtl/cv32e40x_decoder.sv
+++ b/rtl/cv32e40x_decoder.sv
@@ -30,7 +30,6 @@ module cv32e40x_decoder import cv32e40x_pkg::*;
   parameter bit          A_EXT                  = 0,
   parameter b_ext_e      B_EXT                  = B_NONE,
   parameter m_ext_e      M_EXT                  = M,
-  parameter bit          ZC_EXT                 = 0,
   parameter              DEBUG_TRIGGER_EN       = 1
 )
 (
@@ -138,17 +137,15 @@ module cv32e40x_decoder import cv32e40x_pkg::*;
       assign decoder_a_ctrl = DECODER_CTRL_ILLEGAL_INSN;
     end
 
-    if ((B_EXT != B_NONE) || ZC_EXT) begin: b_decoder
+    if (B_EXT != B_NONE) begin: b_decoder
       // RV32B extension decoder
       cv32e40x_b_decoder
       #(
-        .B_EXT  (B_EXT ),
-        .ZC_EXT (ZC_EXT)
+        .B_EXT  (B_EXT )
       )
       b_decoder_i
       (
         .instr_rdata_i      ( instr_rdata                        ),
-        .instr_compressed_i ( if_id_pipe_i.instr_meta.compressed ),
         .decoder_ctrl_o     ( decoder_b_ctrl                     )
       );
     end else begin: no_b_decoder

--- a/rtl/cv32e40x_id_stage.sv
+++ b/rtl/cv32e40x_id_stage.sv
@@ -36,7 +36,6 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
   parameter b_ext_e      B_EXT                  = B_NONE,
   parameter m_ext_e      M_EXT                  = M,
   parameter bit          X_EXT                  = 0,
-  parameter bit          ZC_EXT                 = 0,
   parameter              DEBUG_TRIGGER_EN       = 1,
   parameter int unsigned REGFILE_NUM_READ_PORTS = 2
 )
@@ -395,7 +394,6 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
     .A_EXT                           ( A_EXT                     ),
     .B_EXT                           ( B_EXT                     ),
     .M_EXT                           ( M_EXT                     ),
-    .ZC_EXT                          ( ZC_EXT                    ),
     .DEBUG_TRIGGER_EN                ( DEBUG_TRIGGER_EN          )
   )
   decoder_i

--- a/rtl/cv32e40x_if_stage.sv
+++ b/rtl/cv32e40x_if_stage.sv
@@ -29,6 +29,7 @@
 module cv32e40x_if_stage import cv32e40x_pkg::*;
 #(
   parameter bit          A_EXT           = 0,
+  parameter b_ext_e      B_EXT           = B_NONE,
   parameter bit          X_EXT           = 0,
   parameter int          X_ID_WIDTH      = 4,
   parameter int          PMA_NUM_REGIONS = 0,
@@ -37,7 +38,7 @@ module cv32e40x_if_stage import cv32e40x_pkg::*;
   parameter bit          SMCLIC          = 1'b0,
   parameter int          SMCLIC_ID_WIDTH = 5,
   parameter bit          ZC_EXT          = 0,
-  parameter m_ext_e      M_EXT           = M
+  parameter m_ext_e      M_EXT           = M_NONE
 )
 (
   input  logic          clk,
@@ -307,6 +308,7 @@ module cv32e40x_if_stage import cv32e40x_pkg::*;
   cv32e40x_compressed_decoder
   #(
       .ZC_EXT ( ZC_EXT ),
+      .B_EXT  ( B_EXT  ),
       .M_EXT  ( M_EXT  )
   )
   compressed_decoder_i

--- a/rtl/include/cv32e40x_pkg.sv
+++ b/rtl/include/cv32e40x_pkg.sv
@@ -1269,7 +1269,7 @@ typedef struct packed {
   typedef enum logic {TRANSPARENT, REGISTERED} obi_if_state_e;
 
   // Enum used for configuration of B extension
-  typedef enum logic [1:0] {B_NONE, ZBA_ZBB_ZBS, ZBA_ZBB_ZBC_ZBS} b_ext_e;
+  typedef enum logic [1:0] {B_NONE, ZBA_ZBB, ZBA_ZBB_ZBS, ZBA_ZBB_ZBC_ZBS} b_ext_e;
 
   // Enum used for configuration of M extension
   typedef enum logic [1:0] {M_NONE, M, ZMMUL} m_ext_e;


### PR DESCRIPTION
Fix related to https://github.com/riscv/riscv-code-size-reduction/issues/159
Introduced B_EXT = ZBA_ZBB option as well (did not optimize for area yet; will file ticket for that)
SEC clean with Zc = 0.

Signed-off-by: Arjan Bink <Arjan.Bink@silabs.com>