### PR TITLE
wb_valid for all suboperations

### DIFF
--- a/bhv/cv32e40x_rvfi.sv
+++ b/bhv/cv32e40x_rvfi.sv
@@ -79,6 +79,7 @@ module cv32e40x_rvfi
    input logic                                csr_en_wb_i,
    input logic                                sys_wfi_insn_wb_i,
    input logic                                sys_en_wb_i,
+   input logic                                last_op_wb_i,
    // Register writes
    input logic                                rf_we_wb_i,
    input logic [4:0]                          rf_addr_wb_i,
@@ -639,7 +640,8 @@ module cv32e40x_rvfi
 
   // WFI instructions retire when their wake-up condition is present.
   // The wake-up condition is only checked in the SLEEP state of the controller FSM.
-  assign wb_valid_adjusted = (sys_en_wb_i && sys_wfi_insn_wb_i) ? (ctrl_fsm_cs_i == SLEEP) && (ctrl_fsm_ns_i == FUNCTIONAL) : wb_valid_i;
+  // Other instructions retire when their last suboperation is done in WB.
+  assign wb_valid_adjusted = (sys_en_wb_i && sys_wfi_insn_wb_i) ? (ctrl_fsm_cs_i == SLEEP) && (ctrl_fsm_ns_i == FUNCTIONAL) : wb_valid_i && last_op_wb_i;
 
   // Pipeline stage model //
 

--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -422,6 +422,7 @@ module cv32e40x_wrapper
          .rf_addr_wb_i             ( core_i.wb_stage_i.rf_waddr_wb_o                                      ),
          .rf_wdata_wb_i            ( core_i.wb_stage_i.rf_wdata_wb_o                                      ),
          .lsu_rdata_wb_i           ( core_i.load_store_unit_i.lsu_rdata_1_o                               ),
+         .last_op_wb_i             ( core_i.wb_stage_i.last_op_o                                          ),
 
          .branch_addr_n_i          ( core_i.if_stage_i.branch_addr_n                                      ),
 

--- a/rtl/cv32e40x_controller.sv
+++ b/rtl/cv32e40x_controller.sv
@@ -61,8 +61,11 @@ module cv32e40x_controller import cv32e40x_pkg::*;
   input  id_ex_pipe_t id_ex_pipe_i,
   input  ex_wb_pipe_t ex_wb_pipe_i,
 
+  // Last operation bits
+  input  logic        last_op_ex_i,               // EX contains the last operation of an instruction
+  input  logic        last_op_wb_i,               // WB contains the last operation of an instruction
+
   // LSU
-  input  logic        lsu_split_ex_i,             // LSU is splitting misaligned
   input  mpu_status_e lsu_mpu_status_wb_i,        // MPU status (WB stage)
   input  logic        data_stall_wb_i,            // WB stalled by LSU
   input  logic [1:0]  lsu_err_wb_i,               // LSU bus error in WB stage
@@ -150,7 +153,7 @@ module cv32e40x_controller import cv32e40x_pkg::*;
     .branch_decision_ex_i        ( branch_decision_ex_i     ),
     .ex_ready_i                  ( ex_ready_i               ),
     .ex_valid_i                  ( ex_valid_i               ),
-    .lsu_split_ex_i              ( lsu_split_ex_i           ),
+    .last_op_ex_i                ( last_op_ex_i             ),
 
     // From WB stage
     .ex_wb_pipe_i                ( ex_wb_pipe_i             ),
@@ -159,6 +162,7 @@ module cv32e40x_controller import cv32e40x_pkg::*;
     .data_stall_wb_i             ( data_stall_wb_i          ),
     .wb_ready_i                  ( wb_ready_i               ),
     .wb_valid_i                  ( wb_valid_i               ),
+    .last_op_wb_i                ( last_op_wb_i             ),
 
     .lsu_interruptible_i         ( lsu_interruptible_i      ),
     // Interrupt Controller Signals

--- a/rtl/cv32e40x_core.sv
+++ b/rtl/cv32e40x_core.sv
@@ -173,6 +173,10 @@ module cv32e40x_core import cv32e40x_pkg::*;
   // Forwarding RF from EX
   logic [31:0] rf_wdata_ex;
 
+  // Detect last_op
+  logic        last_op_ex;
+  logic        last_op_wb;
+
   // Register file signals from ID/decoder to controller
   logic [REGFILE_NUM_READ_PORTS-1:0] rf_re_id;
   rf_addr_t    rf_raddr_id[REGFILE_NUM_READ_PORTS];
@@ -537,8 +541,9 @@ module cv32e40x_core import cv32e40x_pkg::*;
     // Pipeline handshakes
     .ex_ready_o                 ( ex_ready                     ),
     .ex_valid_o                 ( ex_valid                     ),
-    .wb_ready_i                 ( wb_ready                     )
-  );
+    .wb_ready_i                 ( wb_ready                     ),
+    .last_op_o                  ( last_op_ex                   )
+);
 
   ////////////////////////////////////////////////////////////////////////////////////////
   //    _     ___    _    ____    ____ _____ ___  ____  _____   _   _ _   _ ___ _____   //
@@ -641,7 +646,9 @@ module cv32e40x_core import cv32e40x_pkg::*;
 
     // CSR/CLIC pointer inputs
     .clic_pa_valid_i            ( csr_clic_pa_valid            ),
-    .clic_pa_i                  ( csr_clic_pa                  )
+    .clic_pa_i                  ( csr_clic_pa                  ),
+
+    .last_op_o                  ( last_op_wb                   )
   );
 
   //////////////////////////////////////
@@ -762,6 +769,10 @@ module cv32e40x_core import cv32e40x_pkg::*;
     // From EX/WB pipeline
     .ex_wb_pipe_i                   ( ex_wb_pipe             ),
 
+    // last_op bits
+    .last_op_ex_i                   ( last_op_ex             ),
+    .last_op_wb_i                   ( last_op_wb             ),
+
     .if_valid_i                     ( if_valid               ),
     .pc_if_i                        ( pc_if                  ),
     // from IF/ID pipeline
@@ -776,7 +787,6 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .csr_op_id_i                    ( csr_op_id              ),
 
     // LSU
-    .lsu_split_ex_i                 ( lsu_split_ex           ),
     .lsu_mpu_status_wb_i            ( lsu_mpu_status_wb      ),
     .data_stall_wb_i                ( data_stall_wb          ),
     .lsu_err_wb_i                   ( lsu_err_wb             ),

--- a/rtl/cv32e40x_load_store_unit.sv
+++ b/rtl/cv32e40x_load_store_unit.sv
@@ -426,10 +426,9 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
   assign ready_1_o   = ((cnt_q == 2'b00) ? 1'b1 : resp_valid) && ready_1_i;
   assign xif_ready_1 = ((cnt_q == 2'b00) ? 1'b1 : resp_valid);
 
-  // LSU second stage is valid when resp_valid (typically data_rvalid_i) is received. For a misaligned/split
-  // load/store only its second phase is marked as valid (last_q == 1'b1)
-  assign valid_1_o                          = last_q && resp_valid && valid_1_i && !xif_res_q;
-  assign xif_mem_result_if.mem_result_valid = last_q && resp_valid &&               xif_res_q;
+  // LSU second stage is valid when resp_valid (typically data_rvalid_i) is received. Both parts of a misaligned transfer will signal valid_1_o.
+  assign valid_1_o                          = resp_valid && valid_1_i && !xif_res_q;
+  assign xif_mem_result_if.mem_result_valid = last_q && resp_valid && xif_res_q; // todo: last_q or not?
 
   // LSU EX stage readyness requires two criteria to be met:
   //

--- a/rtl/cv32e40x_wb_stage.sv
+++ b/rtl/cv32e40x_wb_stage.sv
@@ -135,7 +135,7 @@ module cv32e40x_wb_stage import cv32e40x_pkg::*;
   // - Will be 0 for interrupted instruction and debug entry
   // - Will be 1 for synchronous exceptions (which is easier to deal with for RVFI); this implies that wb_valid
   //   cannot be used to increment the minstret CSR (as that should not increment for e.g. ecall, ebreak, etc.)
-  // - Will be 1 only for the both phases of a split misaligned load/store that completes without MPU errors.
+  // - Will be 1 for both phases of a split misaligned load/store that completes without MPU errors.
   //   If an MPU error occurs, wb_valid will be 1 due to lsu_exception (for any phase where the error occurs)
   // - Will be 0 for CLIC pointer fetches todo: Do we need wb_valid=1 for faulted pointer fetches for RVFI?
   assign wb_valid = ((!ex_wb_pipe_i.lsu_en && !xif_waiting) ||    // Non-LSU instructions have valid result in WB, also for exceptions, unless we are waiting for a coprocessor

--- a/rtl/cv32e40x_wb_stage.sv
+++ b/rtl/cv32e40x_wb_stage.sv
@@ -72,7 +72,9 @@ module cv32e40x_wb_stage import cv32e40x_pkg::*;
 
   // From cs_registers
   input logic [31:0]    clic_pa_i,
-  input logic           clic_pa_valid_i
+  input logic           clic_pa_valid_i,
+
+  output logic          last_op_o
 );
 
   logic                 instr_valid;
@@ -133,11 +135,9 @@ module cv32e40x_wb_stage import cv32e40x_pkg::*;
   // - Will be 0 for interrupted instruction and debug entry
   // - Will be 1 for synchronous exceptions (which is easier to deal with for RVFI); this implies that wb_valid
   //   cannot be used to increment the minstret CSR (as that should not increment for e.g. ecall, ebreak, etc.)
-  // - Will be 1 only for the second phase of a split misaligned load/store that completes without MPU errors.
+  // - Will be 1 only for the both phases of a split misaligned load/store that completes without MPU errors.
   //   If an MPU error occurs, wb_valid will be 1 due to lsu_exception (for any phase where the error occurs)
   // - Will be 0 for CLIC pointer fetches todo: Do we need wb_valid=1 for faulted pointer fetches for RVFI?
-  // todo: Now wb_valid is high once per instruction. For split LSU and push/pop we want it to go high for every
-  //       operation. RVFI, instret etc would need to factor in the 'last' bit
   assign wb_valid = ((!ex_wb_pipe_i.lsu_en && !xif_waiting) ||    // Non-LSU instructions have valid result in WB, also for exceptions, unless we are waiting for a coprocessor
                      ( ex_wb_pipe_i.lsu_en && lsu_valid_i)  ||    // LSU instructions have valid result based on data_rvalid_i
                                                                   // todo: ideally a similar line is added here that delays signaling wb_valid until a WFI really retires.
@@ -145,12 +145,15 @@ module cv32e40x_wb_stage import cv32e40x_pkg::*;
                      ( ex_wb_pipe_i.lsu_en && lsu_exception)      // LSU instruction had an exception
                     ) && !ex_wb_pipe_i.instr_meta.clic_ptr && instr_valid;
 
-  // todo: May let suboperations (last_op==0) through and handle last_op within RVFI.
-  //       This will also affect single step, and the controller must check last_op.
-  assign wb_valid_o = wb_valid && ex_wb_pipe_i.last_op;
+  // Letting all suboperations signal wb_valid
+  assign wb_valid_o = wb_valid;
+
+  // Signal that WB stage contains the last operation of an instruction
+  // Split misaligned LSU instructions are forced to be 'last_op' if an exception occurs in either the first or last operation.
+  assign last_op_o = ex_wb_pipe_i.last_op || ( ex_wb_pipe_i.lsu_en && lsu_exception);
 
   // Export signal indicating WB stage stalled by load/store
-  assign data_stall_o = (ex_wb_pipe_i.lsu_en && !lsu_valid_i) && !wb_valid && instr_valid;
+  assign data_stall_o = ex_wb_pipe_i.lsu_en && !(lsu_valid_i && last_op_o) && instr_valid;
 
   //---------------------------------------------------------------------------
   // eXtension interface

--- a/rtl/cv32e40x_wb_stage.sv
+++ b/rtl/cv32e40x_wb_stage.sv
@@ -139,10 +139,9 @@ module cv32e40x_wb_stage import cv32e40x_pkg::*;
   //   If an MPU error occurs, wb_valid will be 1 due to lsu_exception (for any phase where the error occurs)
   // - Will be 0 for CLIC pointer fetches todo: Do we need wb_valid=1 for faulted pointer fetches for RVFI?
   assign wb_valid = ((!ex_wb_pipe_i.lsu_en && !xif_waiting) ||    // Non-LSU instructions have valid result in WB, also for exceptions, unless we are waiting for a coprocessor
-                     ( ex_wb_pipe_i.lsu_en && lsu_valid_i)  ||    // LSU instructions have valid result based on data_rvalid_i
+                     ( ex_wb_pipe_i.lsu_en && lsu_valid_i)        // LSU instructions have valid result based on data_rvalid_i
                                                                   // todo: ideally a similar line is added here that delays signaling wb_valid until a WFI really retires.
                                                                   // This should be checked for bad timing paths. Currently RVFI contains a wb_valid_adjusted signal/hack to achieve the same
-                     ( ex_wb_pipe_i.lsu_en && lsu_exception)      // LSU instruction had an exception
                     ) && !ex_wb_pipe_i.instr_meta.clic_ptr && instr_valid;
 
   // Letting all suboperations signal wb_valid

--- a/sva/cv32e40x_controller_fsm_sva.sv
+++ b/sva/cv32e40x_controller_fsm_sva.sv
@@ -73,7 +73,8 @@ module cv32e40x_controller_fsm_sva
   input logic           nmi_is_store_q,
   input logic           nmi_pending_q,
   input dcsr_t          dcsr_i,
-  input logic           irq_clic_shv_i
+  input logic           irq_clic_shv_i,
+  input logic           last_op_wb_i
 );
 
 
@@ -491,7 +492,7 @@ endgenerate
       valid_cnt <= '0;
     end else begin
       if(bus_error_latched) begin
-        if(wb_valid_i && !ctrl_fsm_o.debug_mode && !(dcsr_i.step && !dcsr_i.stepie)) begin
+        if(wb_valid_i && last_op_wb_i && !ctrl_fsm_o.debug_mode && !(dcsr_i.step && !dcsr_i.stepie)) begin
           valid_cnt <= valid_cnt + 1'b1;
         end
       end else begin

--- a/sva/cv32e40x_core_sva.sv
+++ b/sva/cv32e40x_core_sva.sv
@@ -49,6 +49,7 @@ module cv32e40x_core_sva
   input ex_wb_pipe_t ex_wb_pipe,
   input logic        wb_valid,
   input logic        branch_taken_in_ex,
+  input logic        last_op_wb,
 
   input alu_op_a_mux_e alu_op_a_mux_sel_id_i,
   input alu_op_b_mux_e alu_op_b_mux_sel_id_i,
@@ -367,7 +368,7 @@ end
   // Check that only a single instruction can retire during single step
   a_single_step_retire :
     assert property (@(posedge clk) disable iff (!rst_ni)
-                      (wb_valid && dcsr.step && !ctrl_fsm.debug_mode)
+                      (wb_valid && last_op_wb && dcsr.step && !ctrl_fsm.debug_mode)
                       ##1 wb_valid [->1]
                       |-> (ctrl_fsm.debug_mode && dcsr.step))
       else `uvm_error("core", "Multiple instructions retired during single stepping")


### PR DESCRIPTION
Misaligned load/stores now signal wb_valid for both transfers. The last transfer gets marked with "last_op = 1".

SEC clean.


Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>