### PR TITLE
Table jump stall

### DIFF
--- a/rtl/cv32e40x_controller_bypass.sv
+++ b/rtl/cv32e40x_controller_bypass.sv
@@ -81,6 +81,7 @@ module cv32e40x_controller_bypass import cv32e40x_pkg::*;
   logic                              csr_exp_unqual_id;         // Explicit CSR in ID (not qualified with csr_en)
   logic                              csr_unqual_id;             // Explicit or implicit CSR in ID (not qualified)
   logic                              jmpr_unqual_id;            // JALR in ID (not qualified with alu_en)
+  logic                              tbljmp_unqual_id;          // Table jump in ID (not qualified with alu_en)
 
   // todo: make all qualifiers here, and use those signals later in the file
 
@@ -105,8 +106,9 @@ module cv32e40x_controller_bypass import cv32e40x_pkg::*;
   assign sys_mret_unqual_id = sys_mret_id_i && if_id_pipe_i.instr_valid;
   assign csr_exp_unqual_id = csr_en_raw_id_i && if_id_pipe_i.instr_valid;
   assign jmpr_unqual_id = alu_jmpr_id_i && if_id_pipe_i.instr_valid;
+  assign tbljmp_unqual_id = if_id_pipe_i.instr_meta.tbljmp && if_id_pipe_i.instr_valid;
 
-  assign csr_unqual_id = csr_exp_unqual_id || sys_mret_unqual_id;
+  assign csr_unqual_id = csr_exp_unqual_id || sys_mret_unqual_id || tbljmp_unqual_id;
 
   /////////////////////////////////////////////////////////////
   //  ____  _        _ _    ____            _             _  //

--- a/rtl/cv32e40x_controller_fsm.sv
+++ b/rtl/cv32e40x_controller_fsm.sv
@@ -240,7 +240,10 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
   // This will also be true for table jumps, as they are encoded as JAL instructions.
   //   An extra table jump flag is used in the logic for taken jumps to disinguish between
   //   regular jumps and table jumps.
-  assign jump_in_id = (jmp_id && !ctrl_byp_i.jalr_stall) || (sys_mret_id && !ctrl_byp_i.csr_stall);
+  // Table jumps do an implicit read of the JVT CSR, so csr_stall must be accounted for.
+  assign jump_in_id = (jmp_id && !if_id_pipe_i.instr_meta.tbljmp && !ctrl_byp_i.jalr_stall) ||
+                      (jmp_id &&  if_id_pipe_i.instr_meta.tbljmp && !ctrl_byp_i.csr_stall ) ||
+                      (sys_mret_id && !ctrl_byp_i.csr_stall);
 
   // Blocking on branch_taken_q, as a jump has already been taken
   assign jump_taken_id = jump_in_id && !branch_taken_q;

--- a/sva/cv32e40x_core_sva.sv
+++ b/sva/cv32e40x_core_sva.sv
@@ -456,5 +456,17 @@ end
   a_jalr_fwd: assert property(p_jalr_fwd)
     else `uvm_error("core", "Forwarded jalr data from WB to ID not written to RF")
 
+  // Check that a table jump in ID is stalled when a CSR is written in EX or WB (could be JVT being written)
+  property p_tbljmp_stall;
+    @(posedge clk) disable iff (!rst_ni)
+    (id_ex_pipe.instr_valid && id_ex_pipe.csr_en) ||
+    (ex_wb_pipe.instr_valid && ex_wb_pipe.csr_en)
+    |->
+    !ctrl_fsm.pc_set_tbljmp;
+  endproperty;
+
+  a_tbljmp_stall: assert property(p_tbljmp_stall)
+    else `uvm_error("core", "Table jump not stalled while CSR is written");
+
 endmodule // cv32e40x_core_sva
 


### PR DESCRIPTION
Table jumps could we using the wrong value of JVT in case a younger instruction in the pipeline is writing to JVT while the table jump is reading it. Fixed issue and also added assertion for the scenario.

SEC clean when ZC_EXT=0

Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>