### PR TITLE
Initial version of RVFI OBI tracking

### DIFF
--- a/bhv/cv32e40x_rvfi_data_obi.sv
+++ b/bhv/cv32e40x_rvfi_data_obi.sv
@@ -1,0 +1,31 @@
+// Copyright (c) 2022 OpenHW Group
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://solderpad.org/licenses/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+
+// CV32E40X RVFI data OBI interface (aligns data OBI signals to WB timing)
+//
+// Contributors: Arjan Bink <arjan.bink@silabs.com>
+
+module cv32e40x_rvfi_data_obi import cv32e40x_pkg::*; import cv32e40x_rvfi_pkg::*;
+(
+  input  logic                          clk,
+  input  logic                          rst_n
+);
+
+  // DEPTH of the instruction buffer (at least depth of alignment buffer)
+  localparam DEPTH = 4;                                                         // Needs to be power of 2 (due to used pointer arithmetic)
+  localparam int unsigned PTR_WIDTH = $clog2(DEPTH);
+
+endmodule

--- a/bhv/cv32e40x_rvfi_instr_obi.sv
+++ b/bhv/cv32e40x_rvfi_instr_obi.sv
@@ -1,0 +1,236 @@
+// Copyright (c) 2022 OpenHW Group
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://solderpad.org/licenses/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+
+// CV32E40X RVFI instruction OBI interface (aligns instruction OBI signals to IF timing)
+//
+// Contributors: Arjan Bink <arjan.bink@silabs.com>
+
+module cv32e40x_rvfi_instr_obi import cv32e40x_pkg::*; import cv32e40x_rvfi_pkg::*;
+(
+  input  logic                          clk,
+  input  logic                          rst_n,
+
+  input  logic                          prefetch_valid_i,
+  input  logic                          prefetch_ready_i,
+  input  logic [31:0]                   prefetch_addr_i,
+  input  logic                          prefetch_compressed_i,
+  input  logic                          kill_if_i,
+
+  if_c_obi.monitor                      m_c_obi_instr_if,
+
+  output rvfi_obi_instr_t               obi_instr                               // OBI address and response phase packet aligned to IF timing
+);
+
+  // DEPTH of the instruction buffer (at least depth of alignment buffer)
+  localparam DEPTH = 4;                                                         // Needs to be power of 2 (due to used pointer arithmetic)
+  localparam int unsigned PTR_WIDTH = $clog2(DEPTH);
+
+  // FIFO
+  rvfi_obi_instr_t [0:DEPTH-1]  fifo_q;                                         // FIFO with OBI address phase and response phase signals
+  rvfi_obi_instr_t              fifo_req_n, fifo_resp_n;                        // FIFO with OBI address phase and response phase signals
+
+  // Read/write pointers
+  logic [PTR_WIDTH-1:0]         rptr_q, rptr_n;                                 // Pointer to FIFO entry to be read
+  logic [PTR_WIDTH-1:0]         rptr_q_inc;                                     // Next read pointer (needed if instruction word is split over two entries) 
+  logic [PTR_WIDTH-1:0]         wptr_req_q, wptr_req_n;                         // Pointer to FIFO (address phase) entry to be written
+  logic [PTR_WIDTH-1:0]         wptr_resp_q, wptr_resp_n;                       // Pointer to FIFO (response phase) entry to be written
+  logic [PTR_WIDTH:0]           cnt_q, cnt_n;                                   // Number of FIFO entries including incoming entries
+
+  logic                         fifo_req_push;                                  // Push FIFO when receiving OBI address phase signals
+  logic                         fifo_resp_push;                                 // Push FIFO when receiving OBI response phase signals
+  logic                         fifo_pop;                                       // Pop FIFO when entry has been fully used
+
+  // Outstanding and started OBI transactions
+  logic [PTR_WIDTH-1:0]         outstanding_cnt_n, outstanding_cnt_q;
+  logic                         outstanding_count_up;
+  logic                         outstanding_count_down;
+
+  logic                         started_q, started_n;                           // OBI transaction started (but not yet outstanding)
+
+  logic [PTR_WIDTH-1:0]         flush_cnt;                                      // Number of FIFO entries to be flushed upon IF kill
+
+  //////////////////////////////////////////////////////////////////////////////
+  // Count number of outstanding OBI transactions
+  //////////////////////////////////////////////////////////////////////////////
+
+  assign outstanding_count_up   = m_c_obi_instr_if.s_req.req && m_c_obi_instr_if.s_gnt.gnt;
+  assign outstanding_count_down = m_c_obi_instr_if.s_rvalid.rvalid;
+
+  always_comb begin
+    outstanding_cnt_n = outstanding_cnt_q;
+
+    case ({outstanding_count_up, outstanding_count_down})
+      2'b00 : begin
+        outstanding_cnt_n = outstanding_cnt_q;
+      end
+      2'b01 : begin
+        outstanding_cnt_n = outstanding_cnt_q - 1'b1;
+      end
+      2'b10 : begin
+        outstanding_cnt_n = outstanding_cnt_q + 1'b1;
+      end
+      2'b11 : begin
+        outstanding_cnt_n = outstanding_cnt_q;
+      end
+    endcase
+
+    started_n = (m_c_obi_instr_if.s_req.req && !m_c_obi_instr_if.s_gnt.gnt) ? 1'b1 : 1'b0;
+  end
+
+
+  //////////////////////////////////////////////////////////////////////////////
+  // Number of FIFO entries to be flushed
+  //////////////////////////////////////////////////////////////////////////////
+
+  // If an OBI transavyion has been started (req = 1), but not yet acceppted (gnt = 1),
+  // then it is not yet counted as outstanding, but it should be flushed nonetheless upon
+  // an IF kill.
+  
+  assign flush_cnt = started_q ? outstanding_cnt_q + 1'b1 : outstanding_cnt_q;
+
+  // The RVFI instruction OBI FIFO tracks reads, writes and flushes of the alignment
+  // buffer. As its size is at least the size of the alignment buffer, this FIFO
+  // should never overflow. As the OBI response phase is at least a cycle after
+  // the address phase acceptance, the address phase FIFO push will always be
+  // to a different FIFO entry than the response phase FIFO push.
+
+  // Push OBI address phase signals into FIFO when OBI address phase is accepted
+  assign fifo_req_push = m_c_obi_instr_if.s_req.req && m_c_obi_instr_if.s_gnt.gnt;
+
+  // Push OBI response phase signals into FIFO when OBI response phase is accepted
+  assign fifo_resp_push = m_c_obi_instr_if.s_rvalid.rvalid;
+
+  // Pop FIFO when reading word or when reading upper halfword
+  always_comb
+  begin
+    if (prefetch_compressed_i) begin
+      // Only pop FIFO when using upper halfword
+      fifo_pop = prefetch_valid_i && prefetch_ready_i && (prefetch_addr_i[1:0] == 2'b10);
+    end else begin
+      fifo_pop = prefetch_valid_i && prefetch_ready_i;
+    end
+  end
+
+  //////////////////////////////////////////////////////////////////////////////
+  // FIFO reads/writes
+  //////////////////////////////////////////////////////////////////////////////
+
+  assign rptr_n = rptr_q + 1'b1;
+
+  // Next address phase signals to FIFO
+  always_comb
+  begin
+    fifo_req_n = fifo_q[wptr_req_q];
+    fifo_req_n.req_payload = m_c_obi_instr_if.req_payload;
+    wptr_req_n = wptr_req_q + 1'b1; 
+  end
+
+  // Next response phase signals to FIFO
+  always_comb
+  begin
+    fifo_resp_n = fifo_q[wptr_resp_q];
+    fifo_resp_n.resp_payload = m_c_obi_instr_if.resp_payload;
+    wptr_resp_n = wptr_resp_q + 1'b1; 
+  end
+
+  //////////////////////////////////////////////////////////////////////////////
+  // Registers
+  //////////////////////////////////////////////////////////////////////////////
+
+  always_ff @(posedge clk, negedge rst_n)
+  begin
+    if (rst_n == 1'b0) begin
+      cnt_q                   <= 'b0;
+      rptr_q                  <= 'b0;
+      wptr_req_q              <= 'b0;
+      wptr_resp_q             <= 'b0;
+      fifo_q                  <= 'b0;
+      outstanding_cnt_q       <= 'b0;
+      started_q               <= 1'b0;
+    end else begin
+      // FIFO reads
+      if (kill_if_i) begin
+        cnt_q                 <= '0;                                    // No more entries in FIFO
+        rptr_q                <= PTR_WIDTH'(wptr_resp_q + flush_cnt);   // Flush/skip existing + incoming entries (assumes rptr_q is power of 2)
+      end else begin
+        if (fifo_pop) begin
+          rptr_q              <= rptr_n;
+        end
+      end
+
+      // FIFO writes
+      if (fifo_req_push) begin                                          // Will not push to same FIFO entry as response phase signals
+        fifo_q[wptr_req_q]  <= fifo_req_n;
+        wptr_req_q          <= wptr_req_n;
+      end
+      if (fifo_resp_push) begin                                         // Will not push to same FIFO entry as address phase signals
+        fifo_q[wptr_resp_q] <= fifo_resp_n;
+        wptr_resp_q         <= wptr_resp_n;
+      end
+
+      // OBI transaction outstanding or started
+      outstanding_cnt_q     <= outstanding_cnt_n;
+      started_q             <= started_n;
+
+    end
+  end
+
+  assign rptr_q_inc = rptr_q + 1'b1;                                    // Next read pointer
+
+  //////////////////////////////////////////////////////////////////////////////
+  // Transform FIFO content into compressed / uncompressed instructions plus meta data
+  //////////////////////////////////////////////////////////////////////////////
+
+  // The FIFO can have at most 3 entries full (because the alignment buffer has that depth); so,
+  // if rptr_q == wptr_resp_q, then the FIFO is empty and OBI response phase payload gets passed
+  // on directly from OBI. OBI address phase payload is available earlier and will therefore always
+  // be present in the FIFO.
+
+  always_comb
+  begin
+    if (prefetch_compressed_i) begin
+      if (prefetch_addr_i[1:0] == 2'b00) begin
+        // Compressed instruction in LSBs of 1 rdata item
+        obi_instr.req_payload               =  fifo_q[rptr_q].req_payload;
+        obi_instr.resp_payload.rdata[31:16] =  16'h0;
+        obi_instr.resp_payload.rdata[15:0]  =  (rptr_q     == wptr_resp_q) ? fifo_resp_n.resp_payload.rdata[15:0]  : fifo_q[rptr_q].resp_payload.rdata[15:0];
+        obi_instr.resp_payload.err          =  (rptr_q     == wptr_resp_q) ? fifo_resp_n.resp_payload.err          : fifo_q[rptr_q].resp_payload.err;
+      end else begin
+        // Compressed instruction in MSBs of 1 rdata item
+        obi_instr.req_payload               =  fifo_q[rptr_q].req_payload;
+        obi_instr.resp_payload.rdata[31:16] =  16'h0;
+        obi_instr.resp_payload.rdata[15:0]  =  (rptr_q     == wptr_resp_q) ? fifo_resp_n.resp_payload.rdata[31:16] : fifo_q[rptr_q].resp_payload.rdata[31:16];
+        obi_instr.resp_payload.err          =  (rptr_q     == wptr_resp_q) ? fifo_resp_n.resp_payload.err          : fifo_q[rptr_q].resp_payload.err;
+      end
+    end else begin
+      if (prefetch_addr_i[1:0] == 2'b00) begin
+        // Uncompressed instruction (or pointer) in 1 rdata item
+        obi_instr.req_payload               =  fifo_q[rptr_q].req_payload;
+        obi_instr.resp_payload.rdata[31:16] =  (rptr_q     == wptr_resp_q) ? fifo_resp_n.resp_payload.rdata[31:16] : fifo_q[rptr_q].resp_payload.rdata[31:16];
+        obi_instr.resp_payload.rdata[15:0]  =  (rptr_q     == wptr_resp_q) ? fifo_resp_n.resp_payload.rdata[15:0]  : fifo_q[rptr_q].resp_payload.rdata[15:0];
+        obi_instr.resp_payload.err          =  (rptr_q     == wptr_resp_q) ? fifo_resp_n.resp_payload.err          : fifo_q[rptr_q].resp_payload.err;
+      end else begin
+        // Uncompressed instruction (or pointer) in 2 rdata items
+        obi_instr.req_payload               =  fifo_q[rptr_q].req_payload;
+        obi_instr.resp_payload.rdata[31:16] =  (rptr_q_inc == wptr_resp_q) ? fifo_resp_n.resp_payload.rdata[15:0]  : fifo_q[rptr_q_inc].resp_payload.rdata[15:0];
+        obi_instr.resp_payload.rdata[15:0]  =                                                                        fifo_q[rptr_q].resp_payload.rdata[31:16];
+        obi_instr.resp_payload.err          = ((rptr_q_inc == wptr_resp_q) ? fifo_resp_n.resp_payload.err          : fifo_q[rptr_q_inc].resp_payload.err) ||
+                                                                                                                     fifo_q[rptr_q].resp_payload.err;
+      end
+    end
+  end
+
+endmodule

--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -370,61 +370,66 @@ module cv32e40x_wrapper
         (.clk_i                    ( clk_i                                                                ),
          .rst_ni                   ( rst_ni                                                               ),
 
+         // Non-pipeline Probes
+         .m_c_obi_instr_if         ( core_i.m_c_obi_instr_if                                              ),
+
+         // IF Probes
          .if_valid_i               ( core_i.if_stage_i.if_valid_o                                         ),
+         .pc_if_i                  ( core_i.if_stage_i.pc_if_o                                            ),
+         .instr_pmp_err_if_i       ( 1'b0                          /* PMP not implemented in cv32e40x */  ),
+         .last_op_if_i             ( core_i.if_stage_i.last_op                                            ),
+         .prefetch_valid_if_i      ( core_i.if_stage_i.prefetch_unit_i.prefetch_valid_o                   ),
+         .prefetch_ready_if_i      ( core_i.if_stage_i.prefetch_unit_i.prefetch_ready_i                   ),
+         .prefetch_addr_if_i       ( core_i.if_stage_i.prefetch_unit_i.prefetch_addr_o                    ),
+         .prefetch_compressed_if_i ( core_i.if_stage_i.instr_compressed_int                               ),
+         .prefetch_instr_if_i      ( core_i.if_stage_i.prefetch_unit_i.prefetch_instr_o                   ),
+
+         // ID Probes
          .id_valid_i               ( core_i.id_stage_i.id_valid_o                                         ),
          .id_ready_i               ( core_i.id_stage_i.id_ready_o                                         ),
-
-         .wb_valid_i               ( core_i.wb_stage_i.wb_valid_o                                         ),
-         .wb_ready_i               ( core_i.wb_stage_i.wb_ready_o                                         ),
-         .instr_rdata_wb_i         ( core_i.wb_stage_i.ex_wb_pipe_i.instr.bus_resp.rdata                  ),
-         .csr_en_wb_i              ( core_i.wb_stage_i.ex_wb_pipe_i.csr_en                                ),
-         .sys_wfi_insn_wb_i        ( core_i.wb_stage_i.ex_wb_pipe_i.sys_wfi_insn                          ),
-         .ebreak_in_wb_i           ( core_i.controller_i.controller_fsm_i.ebreak_in_wb                    ),
-         .sys_en_wb_i              ( core_i.wb_stage_i.ex_wb_pipe_i.sys_en                                ),
-
+         .pc_id_i                  ( core_i.id_stage_i.if_id_pipe_i.pc                                    ),
+         .rf_re_id_i               ( core_i.id_stage_i.rf_re_o                                            ),
+         .sys_mret_id_i            ( core_i.controller_i.controller_fsm_i.sys_mret_id_i                   ),
+         .jump_in_id_i             ( core_i.controller_i.controller_fsm_i.jump_in_id                      ),
+         .jump_target_id_i         ( core_i.id_stage_i.jmp_target_o                                       ),
+         .is_compressed_id_i       ( core_i.id_stage_i.if_id_pipe_i.instr_meta.compressed                 ),
+         .lsu_en_id_i              ( core_i.id_stage_i.lsu_en                                             ),
+         .lsu_we_id_i              ( core_i.id_stage_i.lsu_we                                             ),
+         .lsu_size_id_i            ( core_i.id_stage_i.lsu_size                                           ),
          .rs1_addr_id_i            ( core_i.register_file_wrapper_i.raddr_i[0]                            ),
          .rs2_addr_id_i            ( core_i.register_file_wrapper_i.raddr_i[1]                            ),
          .operand_a_fw_id_i        ( core_i.id_stage_i.operand_a_fw                                       ),
          .operand_b_fw_id_i        ( core_i.id_stage_i.operand_b_fw                                       ),
 
-         .pc_if_i                  ( core_i.if_stage_i.pc_if_o                                            ),
-         .pc_id_i                  ( core_i.id_stage_i.if_id_pipe_i.pc                                    ),
-         .last_op_if_i             ( core_i.if_stage_i.last_op                                            ),
-         .pc_wb_i                  ( core_i.wb_stage_i.ex_wb_pipe_i.pc                                    ),
-         .sys_mret_id_i            ( core_i.controller_i.controller_fsm_i.sys_mret_id_i                   ),
-         .jump_in_id_i             ( core_i.controller_i.controller_fsm_i.jump_in_id                      ),
-         .jump_target_id_i         ( core_i.id_stage_i.jmp_target_o                                       ),
-         .is_compressed_id_i       ( core_i.id_stage_i.if_id_pipe_i.instr_meta.compressed                 ),
-
-         .lsu_en_id_i              ( core_i.id_stage_i.lsu_en                                             ),
-         .lsu_size_id_i            ( core_i.id_stage_i.lsu_size                                           ),
-         .lsu_we_id_i              ( core_i.id_stage_i.lsu_we                                             ),
-
+         // EX Probes
+         .ex_ready_i               ( core_i.ex_stage_i.ex_ready_o                                         ),
+         .ex_valid_i               ( core_i.ex_stage_i.ex_valid_o                                         ),
          .branch_in_ex_i           ( core_i.controller_i.controller_fsm_i.branch_in_ex                    ),
          .branch_decision_ex_i     ( core_i.ex_stage_i.branch_decision_o                                  ),
          .dret_in_ex_i             ( core_i.ex_stage_i.id_ex_pipe_i.sys_dret_insn                         ),
          .lsu_en_ex_i              ( core_i.ex_stage_i.id_ex_pipe_i.lsu_en                                ),
-
-         .instr_pmp_err_if_i       ( 1'b0                          /* PMP not implemented in cv32e40x */  ),
          .lsu_pmp_err_ex_i         ( 1'b0                          /* PMP not implemented in cv32e40x */  ),
-         .lsu_pma_err_atomic_ex_i  ( core_i.load_store_unit_i.mpu_i.pma_i.atomic_access_i && // Todo: Consider making this a signal in the pma
+         .lsu_pma_err_atomic_ex_i  ( core_i.load_store_unit_i.mpu_i.pma_i.atomic_access_i && // Todo: Consider making this a signal in the pma (no expressions allowed in module hookup)
                                     !core_i.load_store_unit_i.mpu_i.pma_i.pma_cfg_atomic                 ),
-
-         .ex_ready_i               ( core_i.ex_stage_i.ex_ready_o                                         ),
-         .ex_valid_i               ( core_i.ex_stage_i.ex_valid_o                                         ),
-
          .branch_target_ex_i       ( core_i.if_stage_i.branch_target_ex_i                                 ),
-
          .data_addr_ex_i           ( core_i.data_addr_o                                                   ),
          .data_wdata_ex_i          ( core_i.data_wdata_o                                                  ),
          .lsu_split_q_ex_i         ( core_i.load_store_unit_i.split_q                                     ),
 
-         .rf_re_id_i               ( core_i.id_stage_i.rf_re_o                                            ),
+         // WB Probes
+         .wb_valid_i               ( core_i.wb_stage_i.wb_valid_o                                         ),
+         .wb_ready_i               ( core_i.wb_stage_i.wb_ready_o                                         ),
+         .pc_wb_i                  ( core_i.wb_stage_i.ex_wb_pipe_i.pc                                    ),
+         .instr_rdata_wb_i         ( core_i.wb_stage_i.ex_wb_pipe_i.instr.bus_resp.rdata                  ),
+         .ebreak_in_wb_i           ( core_i.controller_i.controller_fsm_i.ebreak_in_wb                    ),
+         .csr_en_wb_i              ( core_i.wb_stage_i.ex_wb_pipe_i.csr_en                                ),
+         .sys_wfi_insn_wb_i        ( core_i.wb_stage_i.ex_wb_pipe_i.sys_wfi_insn                          ),
+         .sys_en_wb_i              ( core_i.wb_stage_i.ex_wb_pipe_i.sys_en                                ),
+         .last_op_wb_i             ( core_i.wb_stage_i.last_op_o                                          ),
          .rf_we_wb_i               ( core_i.wb_stage_i.rf_we_wb_o                                         ),
          .rf_addr_wb_i             ( core_i.wb_stage_i.rf_waddr_wb_o                                      ),
          .rf_wdata_wb_i            ( core_i.wb_stage_i.rf_wdata_wb_o                                      ),
          .lsu_rdata_wb_i           ( core_i.load_store_unit_i.lsu_rdata_1_o                               ),
-         .last_op_wb_i             ( core_i.wb_stage_i.last_op_o                                          ),
 
          .branch_addr_n_i          ( core_i.if_stage_i.branch_addr_n                                      ),
 
@@ -441,6 +446,7 @@ module cv32e40x_wrapper
          .irq_i                    ( core_i.irq_i & IRQ_MASK                                              ),
          .irq_wu_ctrl_i            ( core_i.irq_wu_ctrl                                                   ),
          .irq_id_ctrl_i            ( core_i.irq_id_ctrl                                                   ),
+
          // CSRs
          .csr_jvt_n_i              ( core_i.cs_registers_i.jvt_n                                          ),
          .csr_jvt_q_i              ( core_i.cs_registers_i.jvt_rdata                                      ),

--- a/bhv/include/cv32e40x_rvfi_pkg.sv
+++ b/bhv/include/cv32e40x_rvfi_pkg.sv
@@ -115,5 +115,10 @@ package cv32e40x_rvfi_pkg;
     logic        trap;
   } rvfi_trap_t;
 
+  typedef struct packed {
+    obi_inst_req_t  req_payload;
+    obi_inst_resp_t resp_payload;
+  } rvfi_obi_instr_t;
+
 endpackage // cv32e40x_rvfi_pkg
 

--- a/cv32e40x_manifest.flist
+++ b/cv32e40x_manifest.flist
@@ -73,7 +73,6 @@ ${DESIGN_RTL_DIR}/cv32e40x_pma.sv
 ${DESIGN_RTL_DIR}/cv32e40x_pc_target.sv
 
 ${DESIGN_RTL_DIR}/../bhv/cv32e40x_sim_clock_gate.sv
-${DESIGN_RTL_DIR}/../bhv/cv32e40x_rvfi.sv
 ${DESIGN_RTL_DIR}/../bhv/cv32e40x_rvfi_instr_obi.sv
 ${DESIGN_RTL_DIR}/../bhv/cv32e40x_rvfi_data_obi.sv
 ${DESIGN_RTL_DIR}/../bhv/cv32e40x_rvfi.sv

--- a/cv32e40x_manifest.flist
+++ b/cv32e40x_manifest.flist
@@ -74,4 +74,7 @@ ${DESIGN_RTL_DIR}/cv32e40x_pc_target.sv
 
 ${DESIGN_RTL_DIR}/../bhv/cv32e40x_sim_clock_gate.sv
 ${DESIGN_RTL_DIR}/../bhv/cv32e40x_rvfi.sv
+${DESIGN_RTL_DIR}/../bhv/cv32e40x_rvfi_instr_obi.sv
+${DESIGN_RTL_DIR}/../bhv/cv32e40x_rvfi_data_obi.sv
+${DESIGN_RTL_DIR}/../bhv/cv32e40x_rvfi.sv
 ${DESIGN_RTL_DIR}/../bhv/rvfi_sim_trace.sv

--- a/rtl/cv32e40x_alignment_buffer.sv
+++ b/rtl/cv32e40x_alignment_buffer.sv
@@ -354,21 +354,20 @@ module cv32e40x_alignment_buffer import cv32e40x_pkg::*;
 
   always_comb begin
     outstanding_cnt_n = outstanding_cnt_q;
-      case ({outstanding_count_up, outstanding_count_down})
-        2'b00  : begin
-          outstanding_cnt_n = outstanding_cnt_q;
-        end
-        2'b01  : begin
-          outstanding_cnt_n = outstanding_cnt_q - 1'b1;
-        end
-        2'b10  : begin
-          outstanding_cnt_n = outstanding_cnt_q + 1'b1;
-        end
-        2'b11  : begin
-          outstanding_cnt_n = outstanding_cnt_q;
-        end
-      endcase
-    //end
+    case ({outstanding_count_up, outstanding_count_down})
+      2'b00 : begin
+        outstanding_cnt_n = outstanding_cnt_q;
+      end
+      2'b01 : begin
+        outstanding_cnt_n = outstanding_cnt_q - 1'b1;
+      end
+      2'b10 : begin
+        outstanding_cnt_n = outstanding_cnt_q + 1'b1;
+      end
+      2'b11 : begin
+        outstanding_cnt_n = outstanding_cnt_q;
+      end
+    endcase
   end
 
 

--- a/sva/cv32e40x_rvfi_sva.sv
+++ b/sva/cv32e40x_rvfi_sva.sv
@@ -27,10 +27,10 @@ module cv32e40x_rvfi_sva
   import uvm_pkg::*;
   import cv32e40x_pkg::*;
   import cv32e40x_rvfi_pkg::*;
-  #(
+#(
     parameter bit SMCLIC = 0
-  )
-  (
+)
+(
    input logic             clk_i,
    input logic             rst_ni,
 
@@ -50,8 +50,16 @@ module cv32e40x_rvfi_sva
    input logic             dbg_ack,
    input logic             ebreak_in_wb_i,
    input rvfi_intr_t [3:0] in_trap,
-   input logic [3:0] [2:0] debug_cause
-   );
+   input logic [3:0] [2:0] debug_cause,
+
+   input logic             if_valid_i,
+   input logic             id_ready_i,
+   input logic [31:0]      pc_if_i,
+   input inst_resp_t       prefetch_instr_if_i,
+   input logic             prefetch_compressed_if_i,
+   input rvfi_obi_instr_t  obi_instr_if
+);
+
   // Check that irq_ack results in RVFI capturing a trap
   // Ideally, we should assert that every irq_ack eventually leads to rvfi_intr,
   // but since there can be an infinite delay between irq_ack and rvfi_intr (e.g. because of bus stalls), we're settling for asserting
@@ -178,6 +186,31 @@ module cv32e40x_rvfi_sva
                      (rvfi_pc_rdata == {mtvec_addr_i, NMI_MTVEC_INDEX, 2'b00}) &&
                      ((rvfi_csr_mcause_rdata[10:0] == INT_CAUSE_LSU_LOAD_FAULT) || (rvfi_csr_mcause_rdata[10:0] == INT_CAUSE_LSU_STORE_FAULT)))
       else `uvm_error("rvfi", "dcsr.nmip not followed by rvfi_intr and NMI handler")
+
+  // Check that cv32e40x_rvfi_instr_obi tracks alignment buffer
+  a_rvfi_instr_obi_addr:
+    assert property (@(posedge clk_i) disable iff (!rst_ni)
+                     if_valid_i && id_ready_i |->
+                     (pc_if_i[31:2] == obi_instr_if.req_payload.addr[31:2]))
+      else `uvm_error("rvfi", "rvfi_instr_obi addr does not track alignment buffer")
+
+  a_rvfi_instr_obi_rdata_compressed:
+    assert property (@(posedge clk_i) disable iff (!rst_ni)
+                     if_valid_i && id_ready_i && prefetch_compressed_if_i |->
+                     (prefetch_instr_if_i.bus_resp.rdata[15:0] == obi_instr_if.resp_payload.rdata[15:0]))
+      else `uvm_error("rvfi", "rvfi_instr_obi compressed rdata does not track alignment buffer")
+
+  a_rvfi_instr_obi_rdata_uncompressed:
+    assert property (@(posedge clk_i) disable iff (!rst_ni)
+                     if_valid_i && id_ready_i && !prefetch_compressed_if_i |->
+                     (prefetch_instr_if_i.bus_resp.rdata[31:0] == obi_instr_if.resp_payload.rdata[31:0]))
+      else `uvm_error("rvfi", "rvfi_instr_obi uncompressed rdata does not track alignment buffer")
+
+  a_rvfi_instr_obi_err:
+    assert property (@(posedge clk_i) disable iff (!rst_ni)
+                     if_valid_i && id_ready_i |->
+                     (prefetch_instr_if_i.bus_resp.err == obi_instr_if.resp_payload.err))
+      else `uvm_error("rvfi", "rvfi_instr_obi err does not track alignment buffer")
 
 endmodule : cv32e40x_rvfi_sva
 


### PR DESCRIPTION
SEC clean (minor RTL updates are just syntax; behavioral updates mostly)

New assertions pass if PMA is not included (-rc=pma_1) and fail otherwise.

Work is not complete yet:

- need to fix tracking for the scenario with enabled PMA
- need to actually feed OBI signals through RVFI
- need to add data OBI tracking

Reason for an initial PR is to easily be able to make an additional PR with some aligner related RTL updates (while keeping these RTL updates in a separate PR).

Signed-off-by: Arjan Bink <Arjan.Bink@silabs.com>