### PR TITLE
Moved instruction address word alignment to core boundary

### DIFF
--- a/rtl/cv32e40x_alignment_buffer.sv
+++ b/rtl/cv32e40x_alignment_buffer.sv
@@ -57,11 +57,9 @@ module cv32e40x_alignment_buffer import cv32e40x_pkg::*;
 
 );
 
-
   // FIFO_DEPTH set to 3 as the alignment_buffer will need 3 to function correctly
   localparam DEPTH                     = 3;
   localparam int unsigned FIFO_ADDR_DEPTH   = $clog2(DEPTH);
-
 
   // Counter for number of instructions in the FIFO
   // FIFO_ADDR_DEPTH defines number of words
@@ -73,7 +71,6 @@ module cv32e40x_alignment_buffer import cv32e40x_pkg::*;
   logic [FIFO_ADDR_DEPTH-1:0] outstanding_cnt_n, outstanding_cnt_q;
   logic outstanding_count_up;
   logic outstanding_count_down;
-
 
   // number of complete instructions in resp_data
   logic [1:0] n_incoming_ins;
@@ -138,7 +135,7 @@ module cv32e40x_alignment_buffer import cv32e40x_pkg::*;
 
   // Signal aligned branch to the prefetcher
   assign fetch_branch_o = ctrl_fsm_i.pc_set;
-  assign fetch_branch_addr_o = {branch_addr_i[31:2], 2'b00};
+  assign fetch_branch_addr_o = {branch_addr_i[31:1], 1'b0};
 
   //////////////////
   // FIFO signals //

--- a/rtl/cv32e40x_pma.sv
+++ b/rtl/cv32e40x_pma.sv
@@ -47,8 +47,7 @@ module cv32e40x_pma import cv32e40x_pkg::*;
   logic pma_cfg_atomic;
 
   // PMA addresses are word addresses
-  assign word_addr =  {2'b00, trans_addr_i[31:2]};
-
+  assign word_addr = {2'b00, trans_addr_i[31:2]};
 
   generate
     if(PMA_NUM_REGIONS == 0) begin: no_pma

--- a/rtl/cv32e40x_prefetcher.sv
+++ b/rtl/cv32e40x_prefetcher.sv
@@ -69,8 +69,8 @@ module cv32e40x_prefetcher
   logic [31:0]                   trans_addr_q, trans_addr_incr;
   logic                          trans_ptr_access_q;
 
-  // Increment address (always word fetch)
-  assign trans_addr_incr = {trans_addr_q[31:2], 2'b00} + 32'd4;
+  // Increment address (address will be made word aligned at core level)
+  assign trans_addr_incr = {trans_addr_q[31:1], 1'b0} + 32'd4;
 
   // Transaction request generation
   // alignment_buffer will request a transaction when it needs it.

--- a/sva/cv32e40x_alignment_buffer_sva.sv
+++ b/sva/cv32e40x_alignment_buffer_sva.sv
@@ -150,7 +150,7 @@ module cv32e40x_alignment_buffer_sva
 
   // Check that we change branch_addr to prefetcher correctly
   property p_prefetcher_branch;
-    @(posedge clk) disable iff (!rst_n) (ctrl_fsm_i.pc_set) |-> (fetch_branch_addr_o == {branch_addr_i[31:2], 2'b00});
+    @(posedge clk) disable iff (!rst_n) (ctrl_fsm_i.pc_set) |-> (fetch_branch_addr_o == {branch_addr_i[31:1], 1'b0});
   endproperty
 
     a_prefetcher_branch:

--- a/sva/cv32e40x_core_sva.sv
+++ b/sva/cv32e40x_core_sva.sv
@@ -63,6 +63,7 @@ module cv32e40x_core_sva
   input logic        alu_en_id_i,
 
   // probed OBI signals
+  input logic [31:0] instr_addr_o,
   input logic [1:0]  instr_memtype_o,
   input logic [1:0]  data_memtype_o,
   input logic        data_req_o,
@@ -81,7 +82,6 @@ module cv32e40x_core_sva
   input mcause_t     cs_registers_csr_cause_i, // From controller
   input mcause_t     cs_registers_mcause_q,    // From cs_registers, flopped mcause
   input mstatus_t    cs_registers_mstatus_q);
-
 
 if(SMCLIC) begin
   property p_clic_mie_tieoff;
@@ -372,6 +372,12 @@ end
                       ##1 wb_valid [->1]
                       |-> (ctrl_fsm.debug_mode && dcsr.step))
       else `uvm_error("core", "Multiple instructions retired during single stepping")
+
+  // Check that instruction fetches are always word aligned
+  a_instr_addr_word_aligned :
+    assert property (@(posedge clk) disable iff (!rst_ni)
+                     (instr_addr_o[1:0] == 2'b00))
+      else `uvm_error("core", "Instruction fetch not word aligned")
 
   // Check that instruction fetches are always non-bufferable
   a_instr_non_bufferable :

--- a/sva/cv32e40x_if_stage_sva.sv
+++ b/sva/cv32e40x_if_stage_sva.sv
@@ -33,13 +33,13 @@ module cv32e40x_if_stage_sva
   if_c_obi.monitor      m_c_obi_instr_if
 );
 
-  // Check that bus interface transactions are word aligned
-  property p_instr_addr_word_aligned;
-    @(posedge clk) (1'b1) |-> (m_c_obi_instr_if.req_payload.addr[1:0] == 2'b00);
+  // Check that bus interface transactions are halfword aligned (will be forced word aligned at core boundary)
+  property p_instr_addr_aligned;
+    @(posedge clk) (1'b1) |-> (m_c_obi_instr_if.req_payload.addr[0] == 1'b0);
   endproperty
 
-  a_instr_addr_word_aligned : assert property(p_instr_addr_word_aligned)
-    else `uvm_error("if_stage", "Assertion a_instr_addr_word_aligned failed")
+  a_instr_addr_aligned : assert property(p_instr_addr_aligned)
+    else `uvm_error("if_stage", "Assertion a_instr_addr_aligned failed")
 
   // Halt implies not ready and not valid
   a_halt :

--- a/sva/cv32e40x_mpu_sva.sv
+++ b/sva/cv32e40x_mpu_sva.sv
@@ -75,11 +75,13 @@ module cv32e40x_mpu_sva import cv32e40x_pkg::*; import uvm_pkg::*;
    input logic        load_access
    );
 
-
   // PMA assertions helper signals
 
   logic is_addr_match;
-  assign is_addr_match = obi_addr == pma_addr;
+
+  // Not checking bits [1:0]; bit 0 is always 0; bit 1 is not checked because it is only
+  // suppressed after the PMA. These address bits are also ignored by the PMA itself.
+  assign is_addr_match = obi_addr[31:2] == pma_addr[31:2];
 
   logic was_obi_waiting;
   logic was_obi_reqnognt;

--- a/sva/cv32e40x_prefetcher_sva.sv
+++ b/sva/cv32e40x_prefetcher_sva.sv
@@ -117,28 +117,27 @@ module cv32e40x_prefetcher_sva import cv32e40x_pkg::*;
       `uvm_error("Prefetcher SVA",
                 $sformatf("branch address not propagated to trans_addr_o correctly"))
 
-  // Check that fetch_branch_addr_i is word aligned
+  // Check that fetch_branch_addr_i is halfword aligned
   property p_fetch_branch_addr_aligned;
-    @(posedge clk) disable iff (!rst_n) (fetch_branch_addr_i[1:0] == 2'b00);
+    @(posedge clk) disable iff (!rst_n) (fetch_branch_addr_i[0] == 1'b0);
   endproperty
 
   a_fetch_branch_addr_aligned:
     assert property(p_fetch_branch_addr_aligned)
     else
       `uvm_error("Prefetcher SVA",
-                $sformatf("fetch_branch_addr_i is not word aligned."))
+                $sformatf("fetch_branch_addr_i is not halfword aligned."))
 
-  // Check that trans_addr_o is word aligned
+  // Check that trans_addr_o is halfword aligned
   property p_trans_addr_aligned;
-    @(posedge clk) disable iff (!rst_n) (trans_addr_o[1:0] == 2'b00);
+    @(posedge clk) disable iff (!rst_n) (trans_addr_o[0] == 1'b0);
   endproperty
 
   a_trans_addr_aligned:
     assert property(p_trans_addr_aligned)
     else
       `uvm_error("Prefetcher SVA",
-                $sformatf("trans_addr_o is not word aligned."))
-
+                $sformatf("trans_addr_o is not halfword aligned."))
 
   // Check that we acknowledge a fetch_valid when trans_ready high
   property p_fetch_ready;


### PR DESCRIPTION
SEC clean

This is a follow up to https://github.com/openhwgroup/cv32e40x/pull/560 (it will help to make the RVFI OBI tracking less dependent of probing the alignment buffer signals). Needed to fix (unnecessarily strict) assertions as part of this.

Signed-off-by: Arjan Bink <Arjan.Bink@silabs.com>