### PR TITLE
Unifying interrupt controllers; aligning cs registers syntax with cor…

### DIFF
--- a/bhv/cv32e40x_rvfi.sv
+++ b/bhv/cv32e40x_rvfi.sv
@@ -198,9 +198,9 @@ module cv32e40x_rvfi
    // performance counters
    //  cycle,  instret,  hpcounter,  cycleh,  instreth,  hpcounterh
    // mcycle, minstret, mhpcounter, mcycleh, minstreth, mhpcounterh
-   input logic [31:0] [MHPMCOUNTER_WIDTH-1:0] csr_mhpmcounter_n_i,
-   input logic [31:0] [MHPMCOUNTER_WIDTH-1:0] csr_mhpmcounter_q_i,
-   input logic [31:0] [MHPMCOUNTER_WORDS-1:0] csr_mhpmcounter_we_i,
+   input logic [31:0] [63:0]                  csr_mhpmcounter_n_i,
+   input logic [31:0] [63:0]                  csr_mhpmcounter_q_i,
+   input logic [31:0] [1:0]                   csr_mhpmcounter_we_i,
 
    input logic [31:0]                         csr_mvendorid_i,
    input logic [31:0]                         csr_marchid_i,

--- a/bhv/include/cv32e40x_rvfi_pkg.sv
+++ b/bhv/include/cv32e40x_rvfi_pkg.sv
@@ -21,9 +21,6 @@
 package cv32e40x_rvfi_pkg;
   import cv32e40x_pkg::*;
 
-  // RVFI only supports MHPMCOUNTER_WIDTH == 64
-  parameter MHPMCOUNTER_WORDS  = MHPMCOUNTER_WIDTH/32;
-
   parameter STAGE_IF = 0;
   parameter STAGE_ID = 1;
   parameter STAGE_EX = 2;

--- a/rtl/include/cv32e40x_pkg.sv
+++ b/rtl/include/cv32e40x_pkg.sv
@@ -474,8 +474,6 @@ parameter MCAUSE_MPIE_BIT      = 27;
 // misa
 parameter logic [1:0] MXL = 2'd1; // M-XLEN: XLEN in M-Mode for RV32
 
-parameter MHPMCOUNTER_WIDTH  = 64;
-
 // Types for packed struct CSRs
 
 typedef struct packed {


### PR DESCRIPTION
…e level

SEC clean for SMCLIC =0 and SMCLIC =1 (if clic_irq_priv_i = 2'b11)

Do NOT merge into the CV32E40S (will have a separate/similar PR).

Signed-off-by: Arjan Bink <Arjan.Bink@silabs.com>