### PR TITLE
Pipeline flush for JVT writes

### DIFF
--- a/rtl/cv32e40x_clic_int_controller.sv
+++ b/rtl/cv32e40x_clic_int_controller.sv
@@ -28,7 +28,7 @@
 
 module cv32e40x_clic_int_controller import cv32e40x_pkg::*;
 #(
-  parameter int SMCLIC_ID_WIDTH
+  parameter int SMCLIC_ID_WIDTH = 5
 )
 (
   input  logic                       clk,

--- a/rtl/cv32e40x_controller.sv
+++ b/rtl/cv32e40x_controller.sv
@@ -84,6 +84,8 @@ module cv32e40x_controller import cv32e40x_pkg::*;
 
   input logic  [1:0]  mtvec_mode_i,
 
+  input  logic        csr_wr_in_wb_flush_i,
+
   // Debug Signal
   input  logic        debug_req_i,
   input  dcsr_t       dcsr_i,
@@ -165,6 +167,10 @@ module cv32e40x_controller import cv32e40x_pkg::*;
     .last_op_wb_i                ( last_op_wb_i             ),
 
     .lsu_interruptible_i         ( lsu_interruptible_i      ),
+
+    // CSR write strobes
+    .csr_wr_in_wb_flush_i        ( csr_wr_in_wb_flush_i     ),
+
     // Interrupt Controller Signals
     .irq_req_ctrl_i              ( irq_req_ctrl_i           ),
     .irq_id_ctrl_i               ( irq_id_ctrl_i            ),

--- a/rtl/cv32e40x_controller_fsm.sv
+++ b/rtl/cv32e40x_controller_fsm.sv
@@ -666,7 +666,7 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
               fencei_flush_req_set = 1'b1;
             end
             if (fencei_req_and_ack_q) begin
-              // fencei req and ack were set at in the same cycle, complete handshake and jump to PC_FENCEI
+              // fencei req and ack were set at in the same cycle, complete handshake and jump to PC_WB_PLUS4
 
               // Unhalt wb, kill if,id,ex
               ctrl_fsm_o.kill_if   = 1'b1;
@@ -684,7 +684,7 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
               end
 
               ctrl_fsm_o.pc_set    = 1'b1;
-              ctrl_fsm_o.pc_mux    = PC_FENCEI;
+              ctrl_fsm_o.pc_mux    = PC_WB_PLUS4;
 
               fencei_flush_req_set = 1'b0;
             end
@@ -702,13 +702,13 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
             debug_mode_n  = 1'b0;
           end else if (csr_wr_in_wb_flush_i) begin
             // CSR write in WB requires pipeline flush, halt all stages except WB
-            // EX could contain a load/store, need to avoid it's address phase going onto the bus
+            // EX could contain a load/store, need to avoid its address phase going onto the bus
             ctrl_fsm_o.halt_if = 1'b1;
             ctrl_fsm_o.halt_id = 1'b1;
             ctrl_fsm_o.halt_ex = 1'b1;
 
-            // Set flop input to get
-            csr_flush_ack_n    = csr_wr_in_wb_flush_i;
+            // Set flop input to get ack in the next cycle when the write is done.
+            csr_flush_ack_n    = 1'b1;
           end else if (csr_flush_ack_q) begin
             // Flush pipeline because of CSR update in the previous cycle
             ctrl_fsm_o.kill_if   = 1'b1;
@@ -725,7 +725,7 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
             end
 
             ctrl_fsm_o.pc_set    = 1'b1;
-            ctrl_fsm_o.pc_mux    = PC_FENCEI;
+            ctrl_fsm_o.pc_mux    = PC_WB_PLUS4;
 
 
           end else if (branch_taken_ex) begin

--- a/rtl/cv32e40x_core.sv
+++ b/rtl/cv32e40x_core.sv
@@ -208,6 +208,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
 
   logic [31:0] csr_rdata;
   logic csr_counter_read;
+  logic csr_wr_in_wb_flush;
 
   privlvl_t     priv_lvl;
 
@@ -736,6 +737,9 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .clic_pa_valid_o            ( csr_clic_pa_valid      ),
     .clic_pa_o                  ( csr_clic_pa            ),
 
+    // CSR write strobes
+    .csr_wr_in_wb_flush_o       ( csr_wr_in_wb_flush     ),
+
     // Debug
     .trigger_match_o            ( trigger_match_if       ),
     .pc_if_i                    ( pc_if                  ),
@@ -811,6 +815,9 @@ module cv32e40x_core import cv32e40x_pkg::*;
 
     // From CSR registers
     .mtvec_mode_i                   ( mtvec_mode             ),
+
+    // CSR write strobes
+    .csr_wr_in_wb_flush_i           ( csr_wr_in_wb_flush     ),
 
     // Debug signals
     .debug_req_i                    ( debug_req_i            ),

--- a/rtl/cv32e40x_cs_registers.sv
+++ b/rtl/cv32e40x_cs_registers.sv
@@ -238,7 +238,7 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
 
   // Detect JVT writes (requires pipeline flush)
   logic                         csr_wr_in_wb;
-  logic                         jvt_write_in_wb;
+  logic                         jvt_wr_in_wb;
 
   // Performance Counter Signals
   logic [31:0] [63:0]           mhpmcounter_q;                                  // Performance counters
@@ -1355,10 +1355,10 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
                          (csr_op == CSR_OP_CLEAR));
 
   // Detect when a JVT write is in WB
-  assign jvt_write_in_wb = csr_wr_in_wb && (csr_waddr == CSR_JVT);
+  assign jvt_wr_in_wb = csr_wr_in_wb && (csr_waddr == CSR_JVT);
 
   // Output to controller to request pipeline flush
-  assign csr_wr_in_wb_flush_o = jvt_write_in_wb;
+  assign csr_wr_in_wb_flush_o = jvt_wr_in_wb;
 
   ////////////////////////////////////////////////////////////////////////
   //

--- a/rtl/cv32e40x_cs_registers.sv
+++ b/rtl/cv32e40x_cs_registers.sv
@@ -94,6 +94,9 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
   output logic                          clic_pa_valid_o,        // CSR read data is an address to a function pointer
   output logic [31:0]                   clic_pa_o,              // Address to CLIC function pointer
 
+  // CSR write strobes
+  output logic                          csr_wr_in_wb_flush_o,
+
   // Debug
   input  logic [31:0]                   pc_if_i,
   input  logic                          ptr_in_if_i,
@@ -232,6 +235,10 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
   logic                         mtval_we;                                       // Not used in RTL (used by RVFI)
 
   privlvl_t                     priv_lvl_rdata;
+
+  // Detect JVT writes (requires pipeline flush)
+  logic                         csr_wr_in_wb;
+  logic                         jvt_write_in_wb;
 
   // Performance Counter Signals
   logic [31:0] [63:0]           mhpmcounter_q;                                  // Performance counters
@@ -1053,8 +1060,8 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
   (
     .clk                ( clk                   ),
     .rst_n              ( rst_n                 ),
-    .wr_data_i          ( dscratch1_n           ), 
-    .wr_en_i            ( dscratch1_we          ), 
+    .wr_data_i          ( dscratch1_n           ),
+    .wr_en_i            ( dscratch1_we          ),
     .rd_data_o          ( dscratch1_q           )
   );
 
@@ -1169,8 +1176,8 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
       (
         .clk            ( clk                   ),
         .rst_n          ( rst_n                 ),
-        .wr_data_i      ( mtvt_n                ), 
-        .wr_en_i        ( mtvt_we               ), 
+        .wr_data_i      ( mtvt_n                ),
+        .wr_en_i        ( mtvt_we               ),
         .rd_data_o      ( mtvt_q                )
       );
 
@@ -1339,6 +1346,19 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
   endgenerate
 
   assign csr_rdata_o = csr_rdata_int;
+
+  // Any CSR write in WB
+  assign csr_wr_in_wb = ex_wb_pipe_i.csr_en &&
+                        ex_wb_pipe_i.instr_valid &&
+                        ((csr_op == CSR_OP_WRITE) ||
+                         (csr_op == CSR_OP_SET)   ||
+                         (csr_op == CSR_OP_CLEAR));
+
+  // Detect when a JVT write is in WB
+  assign jvt_write_in_wb = csr_wr_in_wb && (csr_waddr == CSR_JVT);
+
+  // Output to controller to request pipeline flush
+  assign csr_wr_in_wb_flush_o = jvt_write_in_wb;
 
   ////////////////////////////////////////////////////////////////////////
   //

--- a/rtl/cv32e40x_if_stage.sv
+++ b/rtl/cv32e40x_if_stage.sv
@@ -137,7 +137,7 @@ module cv32e40x_if_stage import cv32e40x_pkg::*;
       PC_BRANCH:     branch_addr_n = branch_target_ex_i;
       PC_MRET:       branch_addr_n = mepc_i;                                                      // PC is restored when returning from IRQ/exception
       PC_DRET:       branch_addr_n = dpc_i;
-      PC_FENCEI:     branch_addr_n = ctrl_fsm_i.pipe_pc;                                          // Jump to next instruction forces prefetch buffer reload
+      PC_WB_PLUS4:   branch_addr_n = ctrl_fsm_i.pipe_pc;                                          // Jump to next instruction forces prefetch buffer reload
       PC_TRAP_EXC:   branch_addr_n = {mtvec_addr_i, 7'h0};                                        // All the exceptions go to base address
       PC_TRAP_IRQ:   branch_addr_n = {mtvec_addr_i, ctrl_fsm_i.mtvec_pc_mux, 2'b00};     // interrupts are vectored
       PC_TRAP_DBD:   branch_addr_n = {dm_halt_addr_i[31:2], 2'b0};

--- a/rtl/include/cv32e40x_pkg.sv
+++ b/rtl/include/cv32e40x_pkg.sv
@@ -838,7 +838,7 @@ typedef enum logic[3:0] {
   PC_DRET       = 4'b0010,
   PC_JUMP       = 4'b0100,
   PC_BRANCH     = 4'b0101,
-  PC_FENCEI     = 4'b0110,
+  PC_WB_PLUS4   = 4'b0110,
   PC_TRAP_EXC   = 4'b1000,
   PC_TRAP_IRQ   = 4'b1001,
   PC_TRAP_DBD   = 4'b1010,


### PR DESCRIPTION
When JVT is being written in WB, all stages are halted until the write is done. A pipeline flush and refetch of PC+4 is then performed to ensure any table jumps in the pipeline will use the correct JVT value.

SEC clean when ZC_EXT=0
Not SEC clean when ZC_EXT=1 due to different halt/flush conditions.

Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>