### PR TITLE
Update XIF interface

### DIFF
--- a/rtl/cv32e40x_load_store_unit.sv
+++ b/rtl/cv32e40x_load_store_unit.sv
@@ -354,7 +354,8 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
   assign lsu_rdata_1_o = rdata_ext;
 
   // misaligned_access is high for both transfers of a misaligned transfer
-  assign misaligned_access = split_q || lsu_split_0_o || misaligned_halfword || (xif_req && xif_mem_if.mem_req.attr[1]);
+  // TODO: Give MPU a separate modified_access_i input
+  assign misaligned_access = split_q || lsu_split_0_o || misaligned_halfword || (xif_req && (xif_mem_if.mem_req.attr[0] || xif_mem_if.mem_req.attr[1]));
 
   // Check for misaligned accesses that need a second memory access
   // If one is detected, this is signaled with lsu_split_0_o.

--- a/rtl/cv32e40x_wb_stage.sv
+++ b/rtl/cv32e40x_wb_stage.sv
@@ -168,7 +168,7 @@ module cv32e40x_wb_stage import cv32e40x_pkg::*;
 
   // Coprocessor signals a synchronous exception
   // TODO: Maybe do something when an exception occurs (other than just inhibiting writeback)
-  assign xif_exception = ex_wb_pipe_i.instr_valid && ex_wb_pipe_i.xif_en && xif_result_if.result_valid && xif_result_if.result.exc;
+  assign xif_exception = ex_wb_pipe_i.instr_valid && ex_wb_pipe_i.xif_en && xif_result_if.result_valid && (xif_result_if.result.exc || xif_result_if.result.err);
 
   assign xif_result_if.result_ready = ex_wb_pipe_i.instr_valid && ex_wb_pipe_i.xif_en;
 

--- a/rtl/cv32e40x_wb_stage.sv
+++ b/rtl/cv32e40x_wb_stage.sv
@@ -168,7 +168,9 @@ module cv32e40x_wb_stage import cv32e40x_pkg::*;
 
   // Coprocessor signals a synchronous exception
   // TODO: Maybe do something when an exception occurs (other than just inhibiting writeback)
-  assign xif_exception = ex_wb_pipe_i.instr_valid && ex_wb_pipe_i.xif_en && xif_result_if.result_valid && (xif_result_if.result.exc || xif_result_if.result.err);
+  assign xif_exception = ex_wb_pipe_i.instr_valid && ex_wb_pipe_i.xif_en && xif_result_if.result_valid && xif_result_if.result.exc;
+
+  // todo: Handle xif_result_if.result.err as NMI (do not factor into xif_exception as that signal is for synchronous exceptions)
 
   assign xif_result_if.result_ready = ex_wb_pipe_i.instr_valid && ex_wb_pipe_i.xif_en;
 

--- a/rtl/if_xif.sv
+++ b/rtl/if_xif.sv
@@ -64,13 +64,13 @@ interface if_xif import cv32e40x_pkg::*;
   } x_issue_req_t;
 
   typedef struct packed {
-    logic accept;     // Is the offloaded instruction (id) accepted by the coprocessor?
-    logic writeback;  // Will the coprocessor perform a writeback in the core to rd?
-    logic dualwrite;  // Will the coprocessor perform a dual writeback in the core to rd and rd+1?
-    logic dualread;   // Will the coprocessor require dual reads from rs1\rs2\rs3 and rs1+1\rs2+1\rs3+1?
-    logic loadstore;  // Is the offloaded instruction a load/store instruction?
-    logic ecswrite ;  // Will the coprocessor write the Extension Context Status in mstatus?
-    logic exc;        // Can the offloaded instruction possibly cause a synchronous exception in the coprocessor itself?
+    logic       accept;     // Is the offloaded instruction (id) accepted by the coprocessor?
+    logic       writeback;  // Will the coprocessor perform a writeback in the core to rd?
+    logic       dualwrite;  // Will the coprocessor perform a dual writeback in the core to rd and rd+1?
+    logic [2:0] dualread;   // Will the coprocessor require dual reads from rs1\rs2\rs3 and rs1+1\rs2+1\rs3+1?
+    logic       loadstore;  // Is the offloaded instruction a load/store instruction?
+    logic       ecswrite ;  // Will the coprocessor write the Extension Context Status in mstatus?
+    logic       exc;        // Can the offloaded instruction possibly cause a synchronous exception in the coprocessor itself?
   } x_issue_resp_t;
 
   typedef struct packed {
@@ -83,7 +83,9 @@ interface if_xif import cv32e40x_pkg::*;
     logic [             31:0] addr;  // Virtual address of the memory transaction
     logic [              1:0] mode;  // Privilege level
     logic                     we;    // Write enable of the memory transaction
-    logic [X_MEM_WIDTH/8-1:0] be;    // Size of the memory transaction
+    logic [              2:0] size;  // Size of the memory transaction
+    logic [X_MEM_WIDTH/8-1:0] be;    // Byte enables for memory transaction
+    logic [              1:0] attr;  // Memory transaction attributes
     logic [X_MEM_WIDTH  -1:0] wdata; // Write data of a store memory transaction
     logic                     last;  // Is this the last memory transaction for the offloaded instruction?
     logic                     spec;  // Is the memory transaction speculative?
@@ -111,6 +113,8 @@ interface if_xif import cv32e40x_pkg::*;
     logic [                 2:0] ecswe;   // Write enables for {mstatus.xs, mstatus.fs, mstatus.vs}
     logic                        exc;     // Did the instruction cause a synchronous exception?
     logic [                 5:0] exccode; // Exception code
+    logic                        err;     // Did the instruction cause a bus error?
+    logic                        dbg;     // Did the instruction cause a debug trigger match with ``mcontrol.timing`` = 0?
   } x_result_t;
 
   // Compressed interface


### PR DESCRIPTION
Hi,

This PR updates the XIF interface definition, the LSU, and the WB stage to the changes in openhwgroup/core-v-xif@e65cc88 and openhwgroup/core-v-xif@6c257cd.

XIF memory requests are no longer aligned by the CPU. Instead, data and byte enable signals (`wdata`, `rdata`, and `be`) are assumed to be already aligned to the width of the memory bus (any required alignment and splitting must be performed by the coprocessor).

The XIF memory request's transaction attribute `attr[1]` (indicates whether the request is naturally aligned) is included in `misaligned_access` and thus made available to the PMA.

**Question:** I am unsure how to handle the other transaction attribute (`attr[0]`, indicating whether the transaction was modified by the coprocessor) in CV32E40X. In the current PR this attribute is ignored. Does it need to be taken in account, and, if yes, what would be the consequence if it is set for a transaction?