### PR TITLE
Changed reset value of tdata1. Removed reset values for mcontrol6 and…

### DIFF
--- a/docs/user_manual/source/control_status_registers.rst
+++ b/docs/user_manual/source/control_status_registers.rst
@@ -304,8 +304,10 @@ level):
   If the legal value(s) are not specified, then all possible values are considered valid.
   For example, a WARL (0x0) field supports only the value 0x0. Any value may be written, but
   all reads would return 0x0 regardless of the value being written to it. A WARL field may
-  support more than one value. If an unsupported value is (attempted to be) written to a WARL field, the original (legal) value
-  of the bitfield is preserved.
+  support more than one value. If an unsupported value is (attempted to be) written to a WARL
+  field, the value marked with an asterix (the so-called resolution value) is written. If there
+  is no such predefined resolution value, then the original (legal) value of the bitfield is
+  preserved.
 
 * **WPRI**: Software should ignore values read from these fields, and preserve the values when writing.
 
@@ -462,7 +464,7 @@ Reset Value: defined (based on `X_EXT``, ``X_ECS_XS``)
   +-------------+-----------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
   | 8           | WARL (0x0)      | **SPP**. Hardwired to 0.                                                                                                                                                                                                                                      |
   +-------------+-----------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-  | 7           | RW              | **MPIE**: When an exception is encountered, MPIE will be set to MIE. When the mret instruction is executed, the value of MPIE will be stored to MIE.                                                                                                          |
+  | 7           | RW              | **MPIE**. When an exception is encountered, MPIE will be set to MIE. When the ``mret`` instruction is executed, the value of MPIE will be stored to MIE.                                                                                                      |
   +-------------+-----------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
   | 6           | WARL (0x0)      | **UBE**. Hardwired to 0.                                                                                                                                                                                                                                      |
   +-------------+-----------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
@@ -1446,10 +1448,7 @@ Trigger Data 1 (``tdata1``)
 
 CSR Address: 0x7A1
 
-Reset Value: 0x6800_1044
-
-Accessible in Debug Mode or M-Mode, depending on **tdata1.dmode**. The contents of the **data** field depends on the current
-value of the **type** field. See [RISC-V-DEBUG]_ for details regarding all trigger related CSRs.
+Reset Value: 0x6800_1000
 
 .. table::
   :widths: 10 20 70
@@ -1461,21 +1460,23 @@ value of the **type** field. See [RISC-V-DEBUG]_ for details regarding all trigg
   | 31:28 | WARL (0x5,  | **TYPE**. 5 = Exception trigger, 6 = Address match trigger     |
   |       | 0x6)        | type.                                                          |
   +-------+-------------+----------------------------------------------------------------+
-  | 27    | WARL (0x1)  | **DMODE**. Only debug mode can write tdata registers           |
+  | 27    | WARL (0x1)  | **DMODE**. Only debug mode can write ``tdata`` registers.      |
   +-------+-------------+----------------------------------------------------------------+
   | 26:0  | WARL        | **DATA**. Trigger data depending on type                       |
   +-------+-------------+----------------------------------------------------------------+
+
+.. note::
+   The WARL behavior of ``tdata1.DATA`` depends on the value of ``tdata1.TYPE`` as described for
+   ``mcontrol6`` and ``etrigger``.
 
 .. _csr-mcontrol6:
 
 Match Control Type 6 (``mcontrol6``)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-CSR Address: 0x7A1
+CSR Address: 0x7A1 (``mcontrol6`` is accessible as ``tdata1`` when ``tdata1.TYPE`` is 6)
 
-Reset Value: 0x6800_1000
-
-Accessible in Debug Mode or M-Mode, depending on **tdata1.dmode**.
+Reset Value: Not applicable
 
 .. table::
   :widths: 10 20 70
@@ -1486,7 +1487,7 @@ Accessible in Debug Mode or M-Mode, depending on **tdata1.dmode**.
   +=======+=============+================================================================+
   | 31:28 | WARL (0x6)  | **TYPE**. 6 = Address match trigger.                           |
   +-------+-------------+----------------------------------------------------------------+
-  | 27    | WARL (0x1)  | **DMODE**. Only debug mode can write tdata registers           |
+  | 27    | WARL (0x1)  | **DMODE**. Only debug mode can write ``tdata`` registers.      |
   +-------+-------------+----------------------------------------------------------------+
   | 26:25 | WARL (0x0)  | Hardwired to 0.                                                |
   +-------+-------------+----------------------------------------------------------------+
@@ -1507,10 +1508,10 @@ Accessible in Debug Mode or M-Mode, depending on **tdata1.dmode**.
   +-------+-------------+----------------------------------------------------------------+
   | 11    | WARL (0x0)  | **CHAIN**. Hardwired to 0.                                     |
   +-------+-------------+----------------------------------------------------------------+
-  | 10:7  | WARL (0x0,  | **MATCH**. 0: Address matches `tdata2`, 2: Address is greater  |
+  | 10:7  | WARL (0x0*, | **MATCH**. 0: Address matches `tdata2`, 2: Address is greater  |
   |       | 0x2, 0x3)   | than or equal to `tdata2`, 3: Address is less than `tdata2`.   |
   +-------+-------------+----------------------------------------------------------------+
-  | 6     | WARL        | **M**. Match in M-Mode.                                        |
+  | 6     | WARL        | **M**. Match in machine mode.                                  |
   +-------+-------------+----------------------------------------------------------------+
   | 5     | WARL (0x0)  | Hardwired to 0.                                                |
   +-------+-------------+----------------------------------------------------------------+
@@ -1530,11 +1531,9 @@ Accessible in Debug Mode or M-Mode, depending on **tdata1.dmode**.
 Exception Trigger (``etrigger``)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-CSR Address: 0x7A1
+CSR Address: 0x7A1 (``etrigger`` is accessible as ``tdata1`` when ``tdata1.TYPE`` is 5)
 
-Reset Value: 0x5800_0001
-
-Accessible in Debug Mode or M-Mode, depending on **tdata1.dmode**.
+Reset Value: Not applicable
 
 .. table::
   :widths: 10 20 70
@@ -1545,7 +1544,7 @@ Accessible in Debug Mode or M-Mode, depending on **tdata1.dmode**.
   +=======+==============+================================================================+
   | 31:28 | WARL (0x5)   | **TYPE**. 5 = Exception trigger.                               |
   +-------+--------------+----------------------------------------------------------------+
-  | 27    | WARL (0x1)   | **DMODE**. Only debug mode can write tdata registers           |
+  | 27    | WARL (0x1)   | **DMODE**. Only debug mode can write ``tdata`` registers.      |
   +-------+--------------+----------------------------------------------------------------+
   | 26    | WARL (0x0)   | **HIT**. Hardwired to 0.                                       |
   +-------+--------------+----------------------------------------------------------------+
@@ -1557,7 +1556,7 @@ Accessible in Debug Mode or M-Mode, depending on **tdata1.dmode**.
   +-------+--------------+----------------------------------------------------------------+
   | 10    | WARL         | **NMI**. Set to enable trigger on NMI.                         |
   +-------+--------------+----------------------------------------------------------------+
-  | 9     | WARL         | **M**. Match in M-Mode.                                        |
+  | 9     | WARL         | **M**. Match in machine mode.                                  |
   +-------+--------------+----------------------------------------------------------------+
   | 8     | WARL (0x0)   | Hardwired to 0.                                                |
   +-------+--------------+----------------------------------------------------------------+


### PR DESCRIPTION
… etrigger. Defined resolution value for mcontrol6.match and updated WARL definition to take resolution value into account.

Signed-off-by: Arjan Bink <Arjan.Bink@silabs.com>