### PR TITLE
Made mseccfg hardwired to 0x0 if PMP_NUM_REGIONS = 0. Added note that…

### DIFF
--- a/docs/user_manual/source/control_status_registers.rst
+++ b/docs/user_manual/source/control_status_registers.rst
@@ -2041,6 +2041,9 @@ Detailed:
     | 0    | WARL        | **MML**. Machine Mode Lockdown. This is a sticky bit and once set can only be unset due to ``rst_ni`` assertion.                  |
     +------+-------------+-----------------------------------------------------------------------------------------------------------------------------------+
 
+  .. note::
+     ``mseccfg`` is hardwired to 0x0 if ``PMP_NUM_REGIONS`` == 0.
+
   Machine Security Configuration (``mseccfgh``)
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -2134,7 +2137,7 @@ Detailed:
     +-------+------------------+---------------------------+
 
   .. note::
-     pmpxcfg is WARL (0x0) if x >= ``PMP_NUM_REGIONS``.
+     ``pmpxcfg`` is WARL (0x0) if x >= ``PMP_NUM_REGIONS``.
 
   .. note::
      If **mseccfg.MML** = 0, then the **R**, **W** and **X**  together form a collective WARL field for which the combinations with **R** = 0 and **W** = 1 are reserved for future use
@@ -2158,7 +2161,8 @@ Detailed:
     | 31:0  | WARL / WARL (0x0)     | ADDRESS[33:2]             |
     +-------+-----------------------+---------------------------+
 
-  pmpaddrx is WARL if x < ``PMP_NUM_REGIONS`` and WARL (0x0) otherwise.
+  .. note::
+     ``pmpaddrx`` is WARL if x < ``PMP_NUM_REGIONS`` and WARL (0x0) otherwise.
 
 .. only:: ZICNTR
 

--- a/docs/user_manual/source/debug.rst
+++ b/docs/user_manual/source/debug.rst
@@ -5,6 +5,12 @@ Debug & Trigger
 
 |corev| offers support for execution-based debug according to [RISC-V-DEBUG]_. The main requirements for the core are described in Chapter 4: RISC-V Debug, Chapter 5: Trigger Module, and Appendix A.2: Execution Based.
 
+.. note::
+
+   As execution based debug is used, the Debug Module (with code entry points defined by ``dm_halt_addr_i`` and ``dm_exception_addr_i``) needs to be located
+   in a memory region that supports code execution. This therefore (at least) requires that the related memory region is marked as Main in the PMA (:ref:`pma`), which
+   is the default behavior if the PMA is deconfigured.
+
 The following list shows the simplified overview of events that occur in the core when debug is requested:
 
  #. Enters Debug Mode

--- a/docs/user_manual/source/pma.rst
+++ b/docs/user_manual/source/pma.rst
@@ -51,6 +51,10 @@ load access fault (exception code 5). An attempt to perform a modifiable/modifie
    Modifiable transactions are transactions which allow transformations as for example merging or splitting. For example, a misaligned store word instruction that
    is handled as two subword transactions on the data interface is considered to use modified transactions.
 
+.. note::
+   As execution based debug is used, the Debug Module (with code entry points defined by ``dm_halt_addr_i`` and ``dm_exception_addr_i``) needs to be located
+   in a memory region that supports code execution, i.e. in a region defined as main.
+
 Bufferable and Cacheable
 ~~~~~~~~~~~~~~~~~~~~~~~~
 Accesses to regions marked as bufferable (``bufferable=1``) will result in the OBI ``mem_type[0]`` bit being set, except if the access was an instruction fetch, a load, or part of an atomic memory operation. Bufferable stores will utilize the write buffer, see :ref:`Write buffer <write_buffer>`.


### PR DESCRIPTION
… execution based debug requires that the Debug Module is located in a PMA main region.

Signed-off-by: Arjan Bink <Arjan.Bink@silabs.com>