### PR TITLE
Added a 'first_op' to track the first operation of multi operation in…

### DIFF
--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -163,6 +163,7 @@ module cv32e40x_wrapper
   bind cv32e40x_id_stage:
     core_i.id_stage_i cv32e40x_id_stage_sva id_stage_sva
     (
+      .jmp_taken_id_ctrl_i (core_i.controller_i.controller_fsm_i.jump_taken_id),
       .*
     );
 
@@ -406,6 +407,7 @@ module cv32e40x_wrapper
          .rs2_addr_id_i            ( core_i.register_file_wrapper_i.raddr_i[1]                            ),
          .operand_a_fw_id_i        ( core_i.id_stage_i.operand_a_fw                                       ),
          .operand_b_fw_id_i        ( core_i.id_stage_i.operand_b_fw                                       ),
+         .first_op_id_i            ( core_i.id_stage_i.if_id_pipe_i.first_op                              ),
 
          // EX Probes
          .ex_ready_i               ( core_i.ex_stage_i.ex_ready_o                                         ),

--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -170,6 +170,7 @@ module cv32e40x_wrapper
   bind cv32e40x_ex_stage:
     core_i.ex_stage_i cv32e40x_ex_stage_sva #(.X_EXT(X_EXT)) ex_stage_sva
     (
+      .branch_taken_ex_ctrl_i (core_i.controller_i.controller_fsm_i.branch_taken_ex),
       .*
     );
 

--- a/rtl/cv32e40x_controller_fsm.sv
+++ b/rtl/cv32e40x_controller_fsm.sv
@@ -256,7 +256,8 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
   // Blocking on branch_taken_q, as a jump has already been taken
   assign jump_taken_id = jump_in_id && !branch_taken_q;
 
- // todo: RVFI does not use jump_taken_id (which is not in itself an issue); we should have an assertion showing that the target address remains constant during jump_in_id; same remark for branches
+  // Note: RVFI does not use jump_taken_id (which is not in itself an issue); An assertion in id_stage_sva checks that the jump target remains stable;
+  // todo: Do we need a similar stability check for branches?
 
   // EX stage
   // Branch taken for valid branch instructions in EX with valid decision

--- a/rtl/cv32e40x_core.sv
+++ b/rtl/cv32e40x_core.sv
@@ -224,6 +224,8 @@ module cv32e40x_core import cv32e40x_pkg::*;
 
   // LSU
   logic        lsu_split_ex;
+  logic        lsu_first_op_ex;
+  logic        lsu_last_op_ex;
   mpu_status_e lsu_mpu_status_wb;
   logic [31:0] lsu_rdata_wb;
   logic [1:0]  lsu_err_wb;
@@ -237,9 +239,6 @@ module cv32e40x_core import cv32e40x_pkg::*;
   logic        lsu_ready_wb;
   logic        lsu_valid_wb;
   logic        lsu_ready_1;
-
-  logic        lsu_first_op_ex;
-  logic        lsu_last_op_ex;
 
   logic        data_stall_wb;
 

--- a/rtl/cv32e40x_core.sv
+++ b/rtl/cv32e40x_core.sv
@@ -238,6 +238,9 @@ module cv32e40x_core import cv32e40x_pkg::*;
   logic        lsu_valid_wb;
   logic        lsu_ready_1;
 
+  logic        lsu_first_op_ex;
+  logic        lsu_last_op_ex;
+
   logic        data_stall_wb;
 
   // Stage ready signals
@@ -556,6 +559,8 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .lsu_valid_o                ( lsu_valid_ex                 ),
     .lsu_ready_i                ( lsu_ready_0                  ),
     .lsu_split_i                ( lsu_split_ex                 ),
+    .lsu_last_op_i              ( lsu_last_op_ex               ),
+    .lsu_first_op_i             ( lsu_first_op_ex              ),
 
     // Pipeline handshakes
     .ex_ready_o                 ( ex_ready                     ),
@@ -601,11 +606,13 @@ module cv32e40x_core import cv32e40x_pkg::*;
 
     // Stage 0 outputs (EX)
     .lsu_split_0_o         ( lsu_split_ex       ),
-    .lsu_mpu_status_1_o    ( lsu_mpu_status_wb  ),
+    .lsu_first_op_0_o      ( lsu_first_op_ex    ),
+    .lsu_last_op_0_o       ( lsu_last_op_ex     ),
 
     // Stage 1 outputs (WB)
     .lsu_err_1_o           ( lsu_err_wb         ), // To controller (has WB timing, but does not pass through WB stage)
     .lsu_rdata_1_o         ( lsu_rdata_wb       ),
+    .lsu_mpu_status_1_o    ( lsu_mpu_status_wb  ),
 
     // Valid/ready
     .valid_0_i             ( lsu_valid_ex       ), // First LSU stage (EX)

--- a/rtl/cv32e40x_id_stage.sv
+++ b/rtl/cv32e40x_id_stage.sv
@@ -543,12 +543,14 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
       id_ex_pipe_o.instr_meta             <= '0;
       id_ex_pipe_o.trigger_match          <= 1'b0;
 
+      id_ex_pipe_o.first_op               <= 1'b0;
       id_ex_pipe_o.last_op                <= 1'b0;
     end else begin
       // normal pipeline unstall case
       if (id_valid_o && ex_ready_i) begin
         id_ex_pipe_o.instr_valid  <= 1'b1;
         id_ex_pipe_o.last_op      <= if_id_pipe_i.last_op;
+        id_ex_pipe_o.first_op     <= if_id_pipe_i.first_op;
 
         // Operands
         if (alu_op_a_mux_sel != OP_A_NONE) begin

--- a/rtl/cv32e40x_if_stage.sv
+++ b/rtl/cv32e40x_if_stage.sv
@@ -123,7 +123,7 @@ module cv32e40x_if_stage import cv32e40x_pkg::*;
   // eXtension interface signals
   logic [X_ID_WIDTH-1:0] xif_id;
 
-  // Flag for first and last operation - used by Zc*
+  // Flags for first and last operation of an instruction
   logic              first_op;
   logic              last_op;
 
@@ -431,7 +431,7 @@ module cv32e40x_if_stage import cv32e40x_pkg::*;
       assign seq_last  = 1'b0;
       assign seq_instr = '0;
       assign seq_ready = 1'b1;
-      assign seq_first = 1'b1;
+      assign seq_first = 1'b0;
     end
   endgenerate
 

--- a/rtl/cv32e40x_load_store_unit.sv
+++ b/rtl/cv32e40x_load_store_unit.sv
@@ -52,6 +52,8 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
 
   // Stage 0 outputs (EX)
   output logic        lsu_split_0_o,            // Misaligned access is split in two transactions (to controller)
+  output logic        lsu_first_op_0_o,             // First operation is active in EX
+  output logic        lsu_last_op_0_o,              // Last operation is active in EX
 
   // Stage 1 outputs (WB)
   output logic [1:0]  lsu_err_1_o,
@@ -386,6 +388,9 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
       endcase // case (trans.size)
     end
   end
+
+  assign lsu_last_op_0_o = !lsu_split_0_o;
+  assign lsu_first_op_0_o = !split_q;
 
   // Busy if there are ongoing (or potentially outstanding) transfers
   // In the case of mpu errors, the LSU control logic can have outstanding transfers not seen by the response filter.

--- a/rtl/cv32e40x_load_store_unit.sv
+++ b/rtl/cv32e40x_load_store_unit.sv
@@ -52,8 +52,8 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
 
   // Stage 0 outputs (EX)
   output logic        lsu_split_0_o,            // Misaligned access is split in two transactions (to controller)
-  output logic        lsu_first_op_0_o,             // First operation is active in EX
-  output logic        lsu_last_op_0_o,              // Last operation is active in EX
+  output logic        lsu_first_op_0_o,         // First operation is active in EX
+  output logic        lsu_last_op_0_o,          // Last operation is active in EX
 
   // Stage 1 outputs (WB)
   output logic [1:0]  lsu_err_1_o,
@@ -389,6 +389,8 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
     end
   end
 
+  // Set flags for first and last op
+  // Only valid when id_ex_pipe.lsu_en == 1
   assign lsu_last_op_0_o = !lsu_split_0_o;
   assign lsu_first_op_0_o = !split_q;
 

--- a/rtl/include/cv32e40x_pkg.sv
+++ b/rtl/include/cv32e40x_pkg.sv
@@ -1046,6 +1046,7 @@ typedef struct packed {
   logic        trigger_match;
   logic [31:0] xif_id;           // ID of offloaded instruction
   logic [31:0] ptr;              // Flops to hold 32-bit pointer
+  logic        first_op;         // First part of multi operation instruction
   logic        last_op;          // Last part of multi operation instruction
 } if_id_pipe_t;
 
@@ -1113,7 +1114,8 @@ typedef struct packed {
   logic         xif_en;           // Instruction has been offloaded via eXtension interface
   xif_meta_t    xif_meta;         // xif meta struct
 
-  logic         last_op;
+  logic         first_op;         // First part of multi operation instruction
+  logic         last_op;          // Last part of multi operation instruction
 
 } id_ex_pipe_t;
 
@@ -1160,7 +1162,8 @@ typedef struct packed {
   logic         xif_en;           // Instruction has been offloaded via eXtension interface
   xif_meta_t    xif_meta;         // xif meta struct
 
-  logic         last_op;
+  logic         first_op;         // First part of multi operation instruction
+  logic         last_op;          // Last part of multi operation instruction
 } ex_wb_pipe_t;
 
 // Performance counter events

--- a/sva/cv32e40x_id_stage_sva.sv
+++ b/sva/cv32e40x_id_stage_sva.sv
@@ -137,6 +137,8 @@ module cv32e40x_id_stage_sva
 
   // Assert that jalr_fw has the same value as operand_a_fw when a jump is taken
   // Only checking for JALR, as regular JAL do not use any RF or bypass operands for the jump target.
+  // Checked because RVFI is using operand_a_fw only, even for JALR instructions. With this assert proven,
+  // there is no need to mux in jalr_fw inside RVFI.
   a_jalr_fw_match :
     assert property (@(posedge clk) disable iff (!rst_n)
                       jmp_taken_id_ctrl_i && alu_jmpr


### PR DESCRIPTION
…structions through the pipeline.

RVFI will now only latch rs1/2_rdata when the first operation of a multi operation instruction is in the ID stage.

Added assertions to check that jump targets are stable when remaining in ID for multiple cycles.
Added assertion to check that RVFI may use operand_a_fw also for JALR instructions, although JALR uses a different bypass mux in RTL.

SEC clean.

Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>