### PR TITLE
Sequencer integration

### DIFF
--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -338,7 +338,7 @@ module cv32e40x_wrapper
                .PMA_CFG(PMA_CFG))
       write_buffer_sva(.*);
 
-/*
+/* todo: reintroduce once ZC_EXT is set to 1 by default.
   bind cv32e40x_sequencer:
     core_i.if_stage_i.gen_seq.sequencer_i
       cv32e40x_sequencer_sva

--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -209,6 +209,7 @@ module cv32e40x_wrapper
                               .csr_illegal_i       (core_i.cs_registers_i.csr_illegal_o),
                               .xif_commit_kill     (core_i.xif_commit_if.commit.commit_kill),
                               .xif_commit_valid    (core_i.xif_commit_if.commit_valid),
+                              .last_op_id_i        (core_i.if_id_pipe.last_op),
                               .*);
   bind cv32e40x_cs_registers:        core_i.cs_registers_i              cv32e40x_cs_registers_sva  #(.SMCLIC(SMCLIC)) cs_registers_sva (.*);
 
@@ -337,12 +338,12 @@ module cv32e40x_wrapper
                .PMA_CFG(PMA_CFG))
       write_buffer_sva(.*);
 
-/* todo: include once localparam ZC_EXT is set back to 1
+
   bind cv32e40x_sequencer:
     core_i.if_stage_i.gen_seq.sequencer_i
       cv32e40x_sequencer_sva
         sequencer_sva (.*);
-*/
+
 `ifndef FORMAL
   bind cv32e40x_rvfi:
     rvfi_i
@@ -385,7 +386,7 @@ module cv32e40x_wrapper
          .if_valid_i               ( core_i.if_stage_i.if_valid_o                                         ),
          .pc_if_i                  ( core_i.if_stage_i.pc_if_o                                            ),
          .instr_pmp_err_if_i       ( 1'b0                          /* PMP not implemented in cv32e40x */  ),
-         .last_op_if_i             ( core_i.if_stage_i.last_op                                            ),
+         .last_op_if_i             ( core_i.if_stage_i.last_op_o                                          ),
          .prefetch_valid_if_i      ( core_i.if_stage_i.prefetch_unit_i.prefetch_valid_o                   ),
          .prefetch_ready_if_i      ( core_i.if_stage_i.prefetch_unit_i.prefetch_ready_i                   ),
          .prefetch_addr_if_i       ( core_i.if_stage_i.prefetch_unit_i.prefetch_addr_o                    ),

--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -338,12 +338,12 @@ module cv32e40x_wrapper
                .PMA_CFG(PMA_CFG))
       write_buffer_sva(.*);
 
-
+/*
   bind cv32e40x_sequencer:
     core_i.if_stage_i.gen_seq.sequencer_i
       cv32e40x_sequencer_sva
         sequencer_sva (.*);
-
+*/
 `ifndef FORMAL
   bind cv32e40x_rvfi:
     rvfi_i

--- a/rtl/cv32e40x_controller.sv
+++ b/rtl/cv32e40x_controller.sv
@@ -46,7 +46,9 @@ module cv32e40x_controller import cv32e40x_pkg::*;
   input  logic        if_valid_i,
 
   // From IF stage
-  input logic [31:0]  pc_if_i,
+  input  logic [31:0] pc_if_i,
+  input  logic        first_op_if_i,
+  input  logic        last_op_if_i,
 
   // from IF/ID pipeline
   input  if_id_pipe_t if_id_pipe_i,
@@ -57,8 +59,11 @@ module cv32e40x_controller import cv32e40x_pkg::*;
   input  logic        sys_mret_id_i,
   input  logic        csr_en_raw_id_i,
   input  csr_opcode_e csr_op_id_i,
+  input  logic        first_op_id_i,
 
   input  id_ex_pipe_t id_ex_pipe_i,
+  input  logic        first_op_ex_i,
+
   input  ex_wb_pipe_t ex_wb_pipe_i,
 
   // Last operation bits
@@ -141,6 +146,8 @@ module cv32e40x_controller import cv32e40x_pkg::*;
 
     .if_valid_i                  ( if_valid_i               ),
     .pc_if_i                     ( pc_if_i                  ),
+    .first_op_if_i               ( first_op_if_i            ),
+    .last_op_if_i                ( last_op_if_i             ),
 
     // From ID stage
     .if_id_pipe_i                ( if_id_pipe_i             ),
@@ -150,6 +157,7 @@ module cv32e40x_controller import cv32e40x_pkg::*;
     .sys_mret_id_i               ( sys_mret_id_i            ),
     .alu_en_id_i                 ( alu_en_id_i              ),
     .sys_en_id_i                 ( sys_en_id_i              ),
+    .first_op_id_i               ( first_op_id_i            ),
 
     // From EX stage
     .id_ex_pipe_i                ( id_ex_pipe_i             ),
@@ -157,6 +165,7 @@ module cv32e40x_controller import cv32e40x_pkg::*;
     .ex_ready_i                  ( ex_ready_i               ),
     .ex_valid_i                  ( ex_valid_i               ),
     .last_op_ex_i                ( last_op_ex_i             ),
+    .first_op_ex_i               ( first_op_ex_i            ),
 
     // From WB stage
     .ex_wb_pipe_i                ( ex_wb_pipe_i             ),

--- a/rtl/cv32e40x_controller_fsm.sv
+++ b/rtl/cv32e40x_controller_fsm.sv
@@ -217,10 +217,10 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
   logic       csr_flush_ack_n;
   logic       csr_flush_ack_q;
 
-  // Flag for checking if pipeline can be killed due to multi op instructions
+  // Flag for checking if multi op instructions are in an interruptible state
   logic       sequence_interruptible;
 
-  // Flg for checking if ID stage can be halted
+  // Flag for checking if ID stage can be halted
   // Used to not halt sequences in the middle, potentially causing deadlocks
   logic       id_stage_haltable;
 
@@ -485,7 +485,6 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
   // If ID stage does not contain a valid instruction, the same check is performed
   // for the IF stage (although this is likely not needed).
   always_comb begin
-    id_stage_haltable = 1'b0;
     if (if_id_pipe_i.instr_valid) begin
       id_stage_haltable = first_op_id_i;
     end else begin
@@ -536,7 +535,7 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
     // but not allowed to be taken. This is to create an interruptible bubble in WB.
     // Interrupts: Machine mode: Prevent issuing new instructions until we get an interruptible bubble.
     //             Debug mode:   Interrupts are not allowed during debug. Cannot halt ID stage in such a case
-    //                           since the dret that brings the core out of debug mode may never get passed a halted ID stage.
+    //                           since the dret that brings the core out of debug mode may never get past a halted ID stage.
     //             Sequences:    If we need to halt for debug or interrupt not allowed due to a sequence, we must check if we can
     //                           actually halt the ID stage or not. Halting the same sequence that causes *_allowed to go to 0
     //                           may cause a deadlock.

--- a/rtl/cv32e40x_controller_fsm.sv
+++ b/rtl/cv32e40x_controller_fsm.sv
@@ -488,7 +488,8 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
     if (if_id_pipe_i.instr_valid) begin
       id_stage_haltable = first_op_id_i;
     end else begin
-      // IF stage first_op defaults to 1'b1 if the stage does not hold a valid instruction.
+      // IF stage first_op defaults to 1'b1 if the stage does not hold a valid instruction or
+      // table jump pointer. Table jump pointers will have first_op set to 0.
       id_stage_haltable = first_op_if_i;
     end
   end

--- a/rtl/cv32e40x_core.sv
+++ b/rtl/cv32e40x_core.sv
@@ -134,7 +134,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
 
   // Zc is always present
   // todo: turn on when Zc is ready for core-v-verif
-  localparam bit ZC_EXT = 1;
+  localparam bit ZC_EXT = 0;
 
   // Determine alignedness of mtvt
   // mtvt[31:N] holds mtvt table entry

--- a/rtl/cv32e40x_core.sv
+++ b/rtl/cv32e40x_core.sv
@@ -134,7 +134,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
 
   // Zc is always present
   // todo: turn on when Zc is ready for core-v-verif
-  localparam bit ZC_EXT = 0;
+  localparam bit ZC_EXT = 1;
 
   // Determine alignedness of mtvt
   // mtvt[31:N] holds mtvt table entry
@@ -180,8 +180,14 @@ module cv32e40x_core import cv32e40x_pkg::*;
   logic [31:0] rf_wdata_ex;
 
   // Detect last_op
+  logic        last_op_if;
   logic        last_op_ex;
   logic        last_op_wb;
+
+  // First op bits
+  logic        first_op_if;
+  logic        first_op_id;
+  logic        first_op_ex;
 
   // Register file signals from ID/decoder to controller
   logic [REGFILE_NUM_READ_PORTS-1:0] rf_re_id;
@@ -437,6 +443,9 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .if_busy_o           ( if_busy                  ),
     .ptr_in_if_o         ( ptr_in_if                ),
 
+    .first_op_o          ( first_op_if              ),
+    .last_op_o           ( last_op_if               ),
+
     // Pipeline handshakes
     .if_valid_o          ( if_valid                 ),
     .id_ready_i          ( id_ready                 ),
@@ -495,6 +504,8 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .csr_op_o                     ( csr_op_id                 ),
     .alu_en_o                     ( alu_en_id                 ),
     .sys_en_o                     ( sys_en_id                 ),
+
+    .first_op_o                   ( first_op_id               ),
 
     .rf_re_o                      ( rf_re_id                  ),
     .rf_raddr_o                   ( rf_raddr_id               ),
@@ -565,7 +576,8 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .ex_ready_o                 ( ex_ready                     ),
     .ex_valid_o                 ( ex_valid                     ),
     .wb_ready_i                 ( wb_ready                     ),
-    .last_op_o                  ( last_op_ex                   )
+    .last_op_o                  ( last_op_ex                   ),
+    .first_op_o                 ( first_op_ex                  )
   );
 
   ////////////////////////////////////////////////////////////////////////////////////////
@@ -788,6 +800,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
 
     // From ID/EX pipeline
     .id_ex_pipe_i                   ( id_ex_pipe             ),
+    .first_op_ex_i                  ( first_op_ex            ),
 
     .csr_counter_read_i             ( csr_counter_read       ),
     .csr_mnxti_read_i               ( csr_mnxti_read         ),
@@ -801,6 +814,8 @@ module cv32e40x_core import cv32e40x_pkg::*;
 
     .if_valid_i                     ( if_valid               ),
     .pc_if_i                        ( pc_if                  ),
+    .first_op_if_i                  ( first_op_if            ),
+    .last_op_if_i                   ( last_op_if             ),
     // from IF/ID pipeline
     .if_id_pipe_i                   ( if_id_pipe             ),
 
@@ -811,6 +826,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .sys_mret_id_i                  ( sys_mret_insn_id       ),
     .csr_en_raw_id_i                ( csr_en_raw_id          ),
     .csr_op_id_i                    ( csr_op_id              ),
+    .first_op_id_i                  ( first_op_id            ),
 
     // LSU
     .lsu_mpu_status_wb_i            ( lsu_mpu_status_wb      ),

--- a/rtl/cv32e40x_id_stage.sv
+++ b/rtl/cv32e40x_id_stage.sv
@@ -76,6 +76,8 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
   output logic        alu_en_o,
   output logic        sys_en_o,
 
+  output logic        first_op_o,
+
   // RF interface -> controller
   output logic [REGFILE_NUM_READ_PORTS-1:0] rf_re_o,
   output rf_addr_t    rf_raddr_o[REGFILE_NUM_READ_PORTS],
@@ -675,7 +677,7 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
   // multi_cycle_id_stall is currently tied to 1'b0. Will be used for Zce push/pop instructions.
   assign id_valid_o = (instr_valid && !xif_waiting) || (multi_cycle_id_stall && !ctrl_fsm_i.kill_id && !ctrl_fsm_i.halt_id);
 
-
+  assign first_op_o = if_id_pipe_i.first_op;
   //---------------------------------------------------------------------------
   // eXtension interface
   //---------------------------------------------------------------------------

--- a/rtl/cv32e40x_if_stage.sv
+++ b/rtl/cv32e40x_if_stage.sv
@@ -299,10 +299,13 @@ module cv32e40x_if_stage import cv32e40x_pkg::*;
   // any operations. A trigger match is a last_op by definition.
   // todo: Factor CLIC pointers?
   assign last_op_o = trigger_match_i ? 1'b1 :
-                     tbljmp ? 1'b0 :
-                     seq_valid ? seq_last : 1'b1;
+                     tbljmp          ? 1'b0 :  // tbljmps are the first half
+                     seq_valid       ? seq_last : 1'b1;
 
   // Flag first operation of a sequence.
+  // Sequencer will set seq_first=1 when not in use
+  // Would ideally be something like "seq_valid ? : seq_first : 1'b1", but that would cause combinatorial loops
+  // through the controllers sequence_interruptible, via kill_ex and seq_valid and then into the first_op_o.
   // todo: factor in CLIC pointers?
   assign first_op_o = prefetch_is_tbljmp_ptr ? 1'b0 : seq_first;
 

--- a/rtl/cv32e40x_if_stage.sv
+++ b/rtl/cv32e40x_if_stage.sv
@@ -70,6 +70,9 @@ module cv32e40x_if_stage import cv32e40x_pkg::*;
   output logic          if_busy_o,              // Is the IF stage busy fetching instructions?
   output logic          ptr_in_if_o,            // The IF stage currently holds a pointer
 
+  output logic          first_op_o,
+  output logic          last_op_o,
+
   // Stage ready/valid
   output logic          if_valid_o,
   input  logic          id_ready_i,
@@ -122,10 +125,6 @@ module cv32e40x_if_stage import cv32e40x_pkg::*;
 
   // eXtension interface signals
   logic [X_ID_WIDTH-1:0] xif_id;
-
-  // Flags for first and last operation of an instruction
-  logic              first_op;
-  logic              last_op;
 
   // ready signal for predecoder, tied to id_ready_i
   logic              predec_ready;
@@ -273,20 +272,16 @@ module cv32e40x_if_stage import cv32e40x_pkg::*;
   // if_stage ready when killed, otherwise when not halted and the sequencer and predecoder are both ready
   assign if_ready = ctrl_fsm_i.kill_if || (seq_ready && predec_ready && !ctrl_fsm_i.halt_if);
 
+
   // if stage valid when local instr_valid=1
   // Ideally this should be the following:
   //
   // assign if_valid_o = (seq_en    && seq_valid    ) ||
   //                     (predec_en && predec_valid ) && instr_valid;
   //
-  // seq_en would be an internal signal in the sequencer that is set when a legal push/pop/doublemove is decoded.
-  // seq_valid would then simply be the same as sequencer's valid_i, which is set to instr_valid.
-  //
-  // predec_valid would be tied to 1'b1 (similar to the ALU in the EX stage) as this is a combinatorial unit with
-  // with no handshake to improve timing.
-  // predec_en would also be tied to 1'b1 as the predecoder will produce output for any input
-  //   Legal or illegal compressed, + passthru of uncompressed instructions
-  // In short: Any prefetched instruction (or pointer) will make if_valid_o high
+  // The predecoder is purely combinatorial module, and will produce a valid output for any valid input (instr_valid)
+  // The Sequencer will output valid=1 for any instruction it can decode while not halted or killed
+  //   when its valid_i (prefetch_valid) is high.
 
   assign if_valid_o = instr_valid;
 
@@ -300,12 +295,17 @@ module cv32e40x_if_stage import cv32e40x_pkg::*;
 
   // Last operation of table jumps are set when the pointer is fed to ID stage
   // tbljmp is set when a cm.jt or cm.jalt is decoded in the compressed decoder.
-  // todo: Factor in last operation of sequenced Zc* (push/pop)
-  assign last_op = tbljmp ? 1'b0 : 1'b1;
+  // Trigger matches will get all write enables deasserted, and debug entered before executing
+  // any operations. A trigger match is a last_op by definition.
+  // todo: Factor CLIC pointers?
+  assign last_op_o = trigger_match_i ? 1'b1 :
+                     tbljmp ? 1'b0 :
+                     seq_valid ? seq_last : 1'b1;
 
   // Flag first operation of a sequence.
-  // todo: factor in seq_first. For now only tablejump pointer may be the only non-first operation.
-  assign first_op = prefetch_is_tbljmp_ptr ? 1'b0 : 1'b1;
+  // todo: factor in CLIC pointers?
+  assign first_op_o = prefetch_is_tbljmp_ptr ? 1'b0 : seq_first;
+
 
   // Populate instruction meta data
   // Fields 'compressed' and 'tbljmp' keep their old value by default.
@@ -349,8 +349,8 @@ module cv32e40x_if_stage import cv32e40x_pkg::*;
 
         if_id_pipe_o.trigger_match    <= trigger_match_i;
         if_id_pipe_o.xif_id           <= xif_id;
-        if_id_pipe_o.last_op          <= last_op;
-        if_id_pipe_o.first_op         <= first_op;
+        if_id_pipe_o.last_op          <= last_op_o;
+        if_id_pipe_o.first_op         <= first_op_o;
 
         // No PC update for tablejump pointer, PC of instruction itself is needed later.
         // No update to the meta compressed, as this is used in calculating the link address.
@@ -417,26 +417,29 @@ module cv32e40x_if_stage import cv32e40x_pkg::*;
         .instr_i            ( prefetch_instr          ),
         .instr_is_ptr_i     ( ptr_in_if_o             ),
 
-        .valid_i            ( instr_valid             ),
+        .valid_i            ( prefetch_valid          ),
         .ready_i            ( id_ready_i              ),
+        .halt_i             ( ctrl_fsm_i.halt_if      ),
+        .kill_i             ( ctrl_fsm_i.kill_if      ),
 
 
         .instr_o            ( seq_instr               ),
         .valid_o            ( seq_valid               ),
         .ready_o            ( seq_ready               ),
-        .seq_last_o         ( seq_last                ) // todo: currently not used, will be factored into 'last_op' later
+        .seq_first_o        ( seq_first               ),
+        .seq_last_o         ( seq_last                )
       );
     end else begin : gen_no_seq
       assign seq_valid = 1'b0;
       assign seq_last  = 1'b0;
       assign seq_instr = '0;
       assign seq_ready = 1'b1;
-      assign seq_first = 1'b0;
+      assign seq_first = 1'b1; // Tie high to enable default first_op when ZC_EXT=0
     end
   endgenerate
 
 
-  // tbljmp below is used in calculating 'last_op'. If we have a faulted fetch, the instruction word may be anything
+  // tbljmp below is used in calculating 'last_op_o'. If we have a faulted fetch, the instruction word may be anything
   // (not cleared on faulted fetches). A faulted fetch should not be decoded to anything and thus tbljmp is cleared.
   // One could instead set the instruction word itself to all zeros or another illegal instruction on known fetch faults,
   // but this may impact timing more than suppressing control bits.

--- a/rtl/cv32e40x_sequencer.sv
+++ b/rtl/cv32e40x_sequencer.sv
@@ -209,7 +209,7 @@ import cv32e40x_pkg::*;
     seq_first_o = 1'b1;
     ready_o = 1'b0;
 
-    case (seq_state_q)
+    unique case (seq_state_q)
       S_IDLE: begin
         // First instruction is output here
         if (seq_load) begin
@@ -351,6 +351,12 @@ import cv32e40x_pkg::*;
         seq_state_n = S_IDLE;
         ready_o = ready_i && !halt_i;
         seq_last_o = 1'b1;
+      end
+
+      default: begin
+        // Should not happen
+        ready_o = 1'b1;
+        seq_state_n = S_IDLE;
       end
     endcase
 

--- a/rtl/cv32e40x_sequencer.sv
+++ b/rtl/cv32e40x_sequencer.sv
@@ -204,13 +204,14 @@ import cv32e40x_pkg::*;
     instr_o = instr_i;
     seq_state_n = seq_state_q;
     seq_last_o = 1'b0;
+    // default to 1, used by IF stage regardless of seq_valid
+    // See explanation around combinatorial loops in the if_stage.sv.
     seq_first_o = 1'b1;
     ready_o = 1'b0;
 
     case (seq_state_q)
       S_IDLE: begin
         // First instruction is output here
-        //seq_first_o = 1'b1;
         if (seq_load) begin
           if (decode.registers_saved == 'd1) begin
             // Exactly one S register popped

--- a/sva/cv32e40x_core_sva.sv
+++ b/sva/cv32e40x_core_sva.sv
@@ -296,7 +296,7 @@ always_ff @(posedge clk , negedge rst_ni)
   // For checking single step, ID stage is used as it contains a 'multi_cycle_id_stall' signal.
   // This makes it easy to count misaligned LSU ins as one instruction instead of two.
   logic inst_taken;
-  assign inst_taken = id_stage_id_valid && ex_ready && !id_stage_multi_cycle_id_stall;
+  assign inst_taken = id_stage_id_valid && ex_ready && if_id_pipe.last_op && !id_stage_multi_cycle_id_stall;
 
   // Support for single step assertion
   // In case of single step + taken interrupt, the first instruction

--- a/sva/cv32e40x_id_stage_sva.sv
+++ b/sva/cv32e40x_id_stage_sva.sv
@@ -159,5 +159,7 @@ module cv32e40x_id_stage_sva
 
   a_jmp_target_stable: assert property (p_jmp_target_stable)
     else `uvm_error("id_stage", "Jump target not stable")
+
+
 endmodule // cv32e40x_id_stage_sva
 

--- a/sva/cv32e40x_if_stage_sva.sv
+++ b/sva/cv32e40x_if_stage_sva.sv
@@ -62,7 +62,6 @@ module cv32e40x_if_stage_sva
 
 
   // compressed_decoder and sequencer shall be mutually exclusive
-  // todo: add opposite way - legal compressed -> !valid seq + ready
   a_compressed_seq_0:
   assert property (@(posedge clk) disable iff (!rst_n)
                     seq_valid |-> illegal_c_insn)
@@ -81,15 +80,6 @@ module cv32e40x_if_stage_sva
                       ctrl_fsm_i.kill_if |-> (seq_ready && !seq_valid))
         else `uvm_error("if_stage", "Kill should imply ready and not valid.")
 
-/* todo: currently fails as seq_ready will be set to 1'b1 when !valid_i.
-         this factors in both half_if and kill_if, and thus seq_ready will be 1'b1 for halt_if
-         This is similar to the way the multiplier drives it's ready_o in the EX stage.
-  // Halt implies not ready and not valid
-  a_seq_halt :
-    assert property (@(posedge clk) disable iff (!rst_n)
-                      (ctrl_fsm_i.halt_if && !ctrl_fsm_i.kill_if)
-                      |-> (!seq_ready && !seq_valid))
-      else `uvm_error("if_stage", "Halt should imply not ready and not valid")
-*/
+
 endmodule // cv32e40x_if_stage
 

--- a/sva/cv32e40x_sequencer_sva.sv
+++ b/sva/cv32e40x_sequencer_sva.sv
@@ -71,6 +71,12 @@ module cv32e40x_sequencer_sva
                       |-> (!ready_o && !valid_o))
       else `uvm_error("sequencer", "Halt should imply not ready and not valid")
 
+  // State should not update while halted and not killed
+  a_seq_halt_state_stable :
+    assert property (@(posedge clk) disable iff (!rst_n)
+                      (halt_i && !kill_i)
+                      |=> ($stable(instr_cnt_q) && $stable(seq_state_q)))
+      else `uvm_error("sequencer", "Counter or state not stable while halted")
 
   // todo: add assertion to check that atomic part cannot be killed -- how? Depends on when operations are done in WB
 


### PR DESCRIPTION
Integrating sequencer with pipeline.
- Not allowing interrupts to break sequences
- Not allowing NMI to break sequences
- Not allowing debug to break sequences
- Exception will be taken on any operation from WB
- Halting of ID stage not allowed if ID stage is in the middle of a sequence (to avoid deadlocks where the core is waiting for a sequence to finish before it can take an interrupt)
- Updated logic to halt IF due to single step to account for multiple operations from the sequencer
-
SEC clean when localparam ZC_EXT = 0 and correct OBI behavior is assumed (no instr_rvalid_i before instr_req_o)