### PR TITLE
Fix controller FSM's XIF commit tracking signals (#610)

### DIFF
--- a/rtl/cv32e40x_controller_fsm.sv
+++ b/rtl/cv32e40x_controller_fsm.sv
@@ -1166,7 +1166,7 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
           commit_valid_q <= 1'b0;
           commit_kill_q  <= 1'b0;
         end else begin
-          if ((ex_valid_i && wb_ready_i) || ctrl_fsm_o.kill_ex) begin
+          if (ex_ready_i) begin
             commit_valid_q <= 1'b0;
             commit_kill_q  <= 1'b0;
           end else begin


### PR DESCRIPTION
Ensure that the controller FSM's XIF commit transaction tracking
signals are reset every time a new instruction enters the EX stage
(now ensured by simply resetting these signals anytime the EX stage is
ready).  Fixes #610.