### PR TITLE
Updates to RVFI to support Zc sequences

### DIFF
--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -436,6 +436,7 @@ module cv32e40x_wrapper
          .sys_wfi_insn_wb_i        ( core_i.wb_stage_i.ex_wb_pipe_i.sys_wfi_insn                          ),
          .sys_en_wb_i              ( core_i.wb_stage_i.ex_wb_pipe_i.sys_en                                ),
          .last_op_wb_i             ( core_i.wb_stage_i.last_op_o                                          ),
+         .first_op_wb_i            ( core_i.wb_stage_i.ex_wb_pipe_i.first_op                              ),
          .rf_we_wb_i               ( core_i.wb_stage_i.rf_we_wb_o                                         ),
          .rf_addr_wb_i             ( core_i.wb_stage_i.rf_waddr_wb_o                                      ),
          .rf_wdata_wb_i            ( core_i.wb_stage_i.rf_wdata_wb_o                                      ),

--- a/bhv/include/cv32e40x_rvfi_pkg.sv
+++ b/bhv/include/cv32e40x_rvfi_pkg.sv
@@ -26,6 +26,8 @@ package cv32e40x_rvfi_pkg;
   parameter STAGE_EX = 2;
   parameter STAGE_WB = 3;
 
+  parameter NMEM = 128;   // Maximum number of memory transactions per instruction is currently 13 when ZC_EXT=1
+
   typedef enum logic [1:0] { // Memory error types
     MEM_ERR_PMP      = 2'h2,
     MEM_ERR_ATOMIC   = 2'h1,


### PR DESCRIPTION
Updated rvfi_mem* to support up to 128 memory transactions per instruction.
Added rvfi_gpr outputs to support multiple register file read/writes per instruction.