### PR TITLE
Restricted misa CSR and X_MISA parameter to always have D and Q bits 0

### DIFF
--- a/docs/user_manual/source/control_status_registers.rst
+++ b/docs/user_manual/source/control_status_registers.rst
@@ -521,7 +521,7 @@ Detailed:
   +-------------+------------+------------------------------------------------------------------------+
   | 17          | WARL (0x0) | **R** (Reserved).                                                      |
   +-------------+------------+------------------------------------------------------------------------+
-  | 16          | WARL       | **Q** (Quad-precision floating-point extension).                       |
+  | 16          | WARL (0x0) | **Q** (Quad-precision floating-point extension).                       |
   +-------------+------------+------------------------------------------------------------------------+
   | 15          | WARL       | **P** (Packed-SIMD extension).                                         |
   +-------------+------------+------------------------------------------------------------------------+
@@ -548,7 +548,7 @@ Detailed:
   +-------------+------------+------------------------------------------------------------------------+
   | 4           | WARL       | **E** (RV32E base ISA).                                                |
   +-------------+------------+------------------------------------------------------------------------+
-  | 3           | WARL       | **D** (Double-precision floating-point extension).                     |
+  | 3           | WARL (0x0) | **D** (Double-precision floating-point extension).                     |
   +-------------+------------+------------------------------------------------------------------------+
   | 2           | WARL (0x1) | **C** (Compressed extension).                                          |
   +-------------+------------+------------------------------------------------------------------------+
@@ -569,7 +569,7 @@ All bitfields in the ``misa`` CSR read as 0 except for the following:
 
 .. note::
 
-   The ``WARL  `` in above table is depending on `X_EXT``. If ``X_EXT`` == 1, then some of the ``misa`` bits
+   The ``WARL`` in above table is depending on `X_EXT``. If ``X_EXT`` == 1, then some of the ``misa`` bits
    can read values depending on the value of ``X_MISA``.
 
 Machine Interrupt Enable Register (``mie``) - ``SMCLIC`` == 0

--- a/docs/user_manual/source/integration.rst
+++ b/docs/user_manual/source/integration.rst
@@ -156,7 +156,7 @@ Parameters
   +--------------------------------+----------------+---------------+--------------------------------------------------------------------+
   | ``X_MISA``                     | logic [31:0]   | 32'h0         | MISA extensions implemented on the eXtension interface,            |
   |                                |                |               | see :ref:`csr-misa`. X_MISA can only be used to set a subset of    |
-  |                                |                |               | the following: {P, V, F, D, Q, X, M}.                              |
+  |                                |                |               | the following: {P, V, F, X, M}.                                    |
   +--------------------------------+----------------+---------------+--------------------------------------------------------------------+
   | ``X_ECS_XS``                   | logic [1:0]    | 2'b0          | Default value for ``mstatus.XS`` if X_EXT = 1,                     |
   |                                |                |               | see :ref:`csr-mstatus`.                                            |


### PR DESCRIPTION
CV32E40X only
Signed-off-by: Arjan Bink <Arjan.Bink@silabs.com>