### PR TITLE
Converted unique case to regular case with defaults in load_store_uni…

### DIFF
--- a/rtl/cv32e40x_alignment_buffer.sv
+++ b/rtl/cv32e40x_alignment_buffer.sv
@@ -364,6 +364,7 @@ module cv32e40x_alignment_buffer import cv32e40x_pkg::*;
       2'b11 : begin
         outstanding_cnt_n = outstanding_cnt_q;
       end
+      default;
     endcase
   end
 

--- a/rtl/cv32e40x_compressed_decoder.sv
+++ b/rtl/cv32e40x_compressed_decoder.sv
@@ -335,8 +335,10 @@ module cv32e40x_compressed_decoder import cv32e40x_pkg::*;
                       instr_o.bus_resp.rdata = {7'b0, 2'b01, instr[4:2], 2'b01, instr[9:7], 3'b111, 2'b01, instr[9:7], OPCODE_OP};
                       illegal_instr_o = 1'b1;
                     end
+                    default:;
                   endcase
                 end
+                default:;
               endcase
             end
 
@@ -345,6 +347,7 @@ module cv32e40x_compressed_decoder import cv32e40x_pkg::*;
               // 1: c.bnez -> bne rs1', x0, imm
               instr_o.bus_resp.rdata = {{4 {instr[12]}}, instr[6:5], instr[2], 5'b0, 2'b01, instr[9:7], 2'b00, instr[13], instr[11:10], instr[4:3], instr[12], OPCODE_BRANCH};
             end
+            default:;
           endcase
         end
 
@@ -472,6 +475,7 @@ module cv32e40x_compressed_decoder import cv32e40x_pkg::*;
               instr_o.bus_resp.rdata = {4'b0, instr[3:2], instr[12], instr[6:4], 2'b00, 5'h02, 3'b010, instr[11:7], OPCODE_LOAD};
               illegal_instr_o = 1'b1;
             end
+            default:;
           endcase
         end
 

--- a/rtl/cv32e40x_div.sv
+++ b/rtl/cv32e40x_div.sv
@@ -114,6 +114,8 @@ module cv32e40x_div import cv32e40x_pkg::*;
 
   always_comb
   begin
+    alu_clz_data = op_b_i;
+
     case (operator_i)
       DIV_DIVU,
       DIV_REMU: alu_clz_data = op_b_i;

--- a/rtl/cv32e40x_div.sv
+++ b/rtl/cv32e40x_div.sv
@@ -114,7 +114,7 @@ module cv32e40x_div import cv32e40x_pkg::*;
 
   always_comb
   begin
-    unique case (operator_i)
+    case (operator_i)
       DIV_DIVU,
       DIV_REMU: alu_clz_data = op_b_i;
 
@@ -126,6 +126,7 @@ module cv32e40x_div import cv32e40x_pkg::*;
           alu_clz_data = op_b_i;
         end
       end
+      default:;
     endcase
   end
 

--- a/rtl/cv32e40x_i_decoder.sv
+++ b/rtl/cv32e40x_i_decoder.sv
@@ -222,6 +222,7 @@ module cv32e40x_i_decoder import cv32e40x_pkg::*;
               decoder_ctrl_o = DECODER_CTRL_ILLEGAL_INSN;
             end
           end
+          default:;
         endcase
       end
 

--- a/rtl/cv32e40x_load_store_unit.sv
+++ b/rtl/cv32e40x_load_store_unit.sv
@@ -175,6 +175,7 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
           2'b01: be = 4'b0010;
           2'b10: be = 4'b0100;
           2'b11: be = 4'b1000;
+          default:;
         endcase; // case (trans.addr[1:0])
       end
       2'b01:
@@ -186,6 +187,7 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
             2'b01: be = 4'b0110;
             2'b10: be = 4'b1100;
             2'b11: be = 4'b1000;
+            default:;
           endcase; // case (trans.addr[1:0])
         end
         else
@@ -202,6 +204,7 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
             2'b01: be = 4'b1110;
             2'b10: be = 4'b1100;
             2'b11: be = 4'b1000;
+            default:;
           endcase; // case (trans.addr[1:0])
         end
         else
@@ -211,6 +214,7 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
             2'b01: be = 4'b0001;
             2'b10: be = 4'b0011;
             2'b11: be = 4'b0111;
+            default:;
           endcase; // case (trans.addr[1:0])
         end
       end
@@ -227,6 +231,7 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
       2'b01: wdata = {trans.wdata[23:0], trans.wdata[31:24]};
       2'b10: wdata = {trans.wdata[15:0], trans.wdata[31:16]};
       2'b11: wdata = {trans.wdata[ 7:0], trans.wdata[31: 8]};
+      default:;
     endcase; // case (trans.addr[1:0])
   end
 
@@ -511,7 +516,7 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
   assign count_down = resp_valid;                       // Decrement upon accepted transfer response
 
   always_comb begin
-    unique case ({count_up, count_down})
+    case ({count_up, count_down})
       2'b00 : begin
         next_cnt = cnt_q;
       end
@@ -524,6 +529,7 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
       2'b11 : begin
         next_cnt = cnt_q;
       end
+      default:;
     endcase
   end
 

--- a/rtl/cv32e40x_prefetcher.sv
+++ b/rtl/cv32e40x_prefetcher.sv
@@ -119,6 +119,8 @@ module cv32e40x_prefetcher
           next_state = IDLE;
         end
       end // case: BRANCH_WAIT
+
+      default:;
     endcase
   end
 

--- a/rtl/cv32e40x_write_buffer.sv
+++ b/rtl/cv32e40x_write_buffer.sv
@@ -90,6 +90,8 @@ module cv32e40x_write_buffer import cv32e40x_pkg::*;
           end
         end
       end
+
+      default:;
     endcase // case (state)
   end
 


### PR DESCRIPTION
…t and divider to avoid warnings at reset during simulation.

Adde default to other case statements where defaults were missing.

SEC clean.

Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>