### PR TITLE
Removed exception checking in IF stage

### DIFF
--- a/bhv/cv32e40x_rvfi.sv
+++ b/bhv/cv32e40x_rvfi.sv
@@ -915,10 +915,13 @@ module cv32e40x_rvfi
         // Only update rs1/rs2 on the first part of a multi operation instruction.
         // Jumps may actually use rs1 before (id_valid && ex_ready), an assertion exists to check that
         // the jump target is stable and it should be safe to use rs1/2_rdata at the time of the pipeline handshake.
-        // rs1/2 should reflect state of the first operation of any instruction.
-        rs1_addr   [STAGE_EX] <= first_op_id_i ? rs1_addr_id : rs1_addr[STAGE_EX]; // todo: why the first_op_id_i dependency? In https://github.com/openhwgroup/cv32e40x/pull/605 it was stated as not needed.
-        rs2_addr   [STAGE_EX] <= first_op_id_i ? rs2_addr_id : rs2_addr[STAGE_EX]; // todo: why the first_op_id_i dependency? In https://github.com/openhwgroup/cv32e40x/pull/605 it was stated as not needed.
-        rs1_rdata  [STAGE_EX] <= first_op_id_i ? rs1_rdata_id : rs1_rdata[STAGE_EX]; // todo: add good explanation why the select is needed here and not for example on rs1_rdata_subop
+        // rs1/2 address and rdata should reflect state of the first operation of any instruction, thus
+        // the gating with first_op_id_i in the lines below to not update the fields multiple times for sequenced instructions (including table jumps).
+        // The rs*_subop fields below are used to capture the state of _all_ operations within a sequence, and are used to populate the rvfi_gpr outputs
+        // to reflect all values read by the entire instruction.
+        rs1_addr   [STAGE_EX] <= first_op_id_i ? rs1_addr_id : rs1_addr[STAGE_EX];
+        rs2_addr   [STAGE_EX] <= first_op_id_i ? rs2_addr_id : rs2_addr[STAGE_EX];
+        rs1_rdata  [STAGE_EX] <= first_op_id_i ? rs1_rdata_id : rs1_rdata[STAGE_EX];
         rs2_rdata  [STAGE_EX] <= first_op_id_i ? rs2_rdata_id : rs2_rdata[STAGE_EX];
 
         mem_rmask  [STAGE_EX] <= (lsu_en_id_i && !lsu_we_id_i) ? rvfi_mem_mask_int : '0;

--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -214,6 +214,7 @@ module cv32e40x_wrapper
                               .first_op_ex_i                (core_i.first_op_ex),
                               .prefetch_valid_if_i          (core_i.if_stage_i.prefetch_valid),
                               .prefetch_is_tbljmp_ptr_if_i  (core_i.if_stage_i.prefetch_is_tbljmp_ptr),
+                              .abort_op_id_i                (core_i.id_stage_i.abort_op),
                               .*);
   bind cv32e40x_cs_registers:        core_i.cs_registers_i              cv32e40x_cs_registers_sva  #(.SMCLIC(SMCLIC)) cs_registers_sva (.*);
 
@@ -391,6 +392,7 @@ module cv32e40x_wrapper
          .pc_if_i                  ( core_i.if_stage_i.pc_if_o                                            ),
          .instr_pmp_err_if_i       ( 1'b0                          /* PMP not implemented in cv32e40x */  ),
          .last_op_if_i             ( core_i.if_stage_i.last_op_o                                          ),
+         .abort_op_if_i            ( core_i.if_stage_i.abort_op_o                                         ),
          .prefetch_valid_if_i      ( core_i.if_stage_i.prefetch_unit_i.prefetch_valid_o                   ),
          .prefetch_ready_if_i      ( core_i.if_stage_i.prefetch_unit_i.prefetch_ready_i                   ),
          .prefetch_addr_if_i       ( core_i.if_stage_i.prefetch_unit_i.prefetch_addr_o                    ),
@@ -445,6 +447,7 @@ module cv32e40x_wrapper
          .rf_addr_wb_i             ( core_i.wb_stage_i.rf_waddr_wb_o                                      ),
          .rf_wdata_wb_i            ( core_i.wb_stage_i.rf_wdata_wb_o                                      ),
          .lsu_rdata_wb_i           ( core_i.load_store_unit_i.lsu_rdata_1_o                               ),
+         .abort_op_wb_i            ( core_i.wb_stage_i.abort_op_o                                         ),
 
          .branch_addr_n_i          ( core_i.if_stage_i.branch_addr_n                                      ),
 

--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -214,7 +214,6 @@ module cv32e40x_wrapper
                               .first_op_ex_i                (core_i.first_op_ex),
                               .prefetch_valid_if_i          (core_i.if_stage_i.prefetch_valid),
                               .prefetch_is_tbljmp_ptr_if_i  (core_i.if_stage_i.prefetch_is_tbljmp_ptr),
-                              .abort_op_id_i                (core_i.id_stage_i.abort_op),
                               .*);
   bind cv32e40x_cs_registers:        core_i.cs_registers_i              cv32e40x_cs_registers_sva  #(.SMCLIC(SMCLIC)) cs_registers_sva (.*);
 
@@ -456,6 +455,7 @@ module cv32e40x_wrapper
          .ctrl_fsm_cs_i            ( core_i.controller_i.controller_fsm_i.ctrl_fsm_cs                     ),
          .ctrl_fsm_ns_i            ( core_i.controller_i.controller_fsm_i.ctrl_fsm_ns                     ),
          .pending_single_step_i    ( core_i.controller_i.controller_fsm_i.pending_single_step             ),
+         .pending_single_step_ptr_i( core_i.controller_i.controller_fsm_i.pending_single_step_ptr         ),
          .single_step_allowed_i    ( core_i.controller_i.controller_fsm_i.single_step_allowed             ),
          .nmi_pending_i            ( core_i.controller_i.controller_fsm_i.nmi_pending_q                   ),
          .nmi_is_store_i           ( core_i.controller_i.controller_fsm_i.nmi_is_store_q                  ),

--- a/rtl/cv32e40x_controller.sv
+++ b/rtl/cv32e40x_controller.sv
@@ -61,6 +61,7 @@ module cv32e40x_controller import cv32e40x_pkg::*;
   input  csr_opcode_e csr_op_id_i,
   input  logic        first_op_id_i,
   input  logic        last_op_id_i,
+  input  logic        abort_op_id_i,
 
   input  id_ex_pipe_t id_ex_pipe_i,
 
@@ -161,6 +162,7 @@ module cv32e40x_controller import cv32e40x_pkg::*;
     .sys_en_id_i                 ( sys_en_id_i              ),
     .first_op_id_i               ( first_op_id_i            ),
     .last_op_id_i                ( last_op_id_i             ),
+    .abort_op_id_i               ( abort_op_id_i            ),
 
     // From EX stage
     .id_ex_pipe_i                ( id_ex_pipe_i             ),

--- a/rtl/cv32e40x_controller.sv
+++ b/rtl/cv32e40x_controller.sv
@@ -48,6 +48,7 @@ module cv32e40x_controller import cv32e40x_pkg::*;
   // From IF stage
   input  logic [31:0] pc_if_i,
   input  logic        last_op_if_i,
+  input  logic        abort_op_if_i,
 
   // from IF/ID pipeline
   input  if_id_pipe_t if_id_pipe_i,
@@ -68,6 +69,8 @@ module cv32e40x_controller import cv32e40x_pkg::*;
   // Last operation bits
   input  logic        last_op_ex_i,               // EX contains the last operation of an instruction
   input  logic        last_op_wb_i,               // WB contains the last operation of an instruction
+
+  input  logic        abort_op_wb_i,
 
   // LSU
   input  mpu_status_e lsu_mpu_status_wb_i,        // MPU status (WB stage)
@@ -146,6 +149,7 @@ module cv32e40x_controller import cv32e40x_pkg::*;
     .if_valid_i                  ( if_valid_i               ),
     .pc_if_i                     ( pc_if_i                  ),
     .last_op_if_i                ( last_op_if_i             ),
+    .abort_op_if_i               ( abort_op_if_i            ),
 
     // From ID stage
     .if_id_pipe_i                ( if_id_pipe_i             ),
@@ -173,6 +177,7 @@ module cv32e40x_controller import cv32e40x_pkg::*;
     .wb_ready_i                  ( wb_ready_i               ),
     .wb_valid_i                  ( wb_valid_i               ),
     .last_op_wb_i                ( last_op_wb_i             ),
+    .abort_op_wb_i               ( abort_op_wb_i            ),
 
     .lsu_interruptible_i         ( lsu_interruptible_i      ),
 

--- a/rtl/cv32e40x_controller_bypass.sv
+++ b/rtl/cv32e40x_controller_bypass.sv
@@ -215,6 +215,8 @@ module cv32e40x_controller_bypass import cv32e40x_pkg::*;
     end
   end
 
+  assign ctrl_byp_o.id_stage_abort = ctrl_byp_o.deassert_we;
+
   // Forwarding control unit
   always_comb
   begin

--- a/rtl/cv32e40x_controller_fsm.sv
+++ b/rtl/cv32e40x_controller_fsm.sv
@@ -49,6 +49,7 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
   // From IF stage
   input  logic [31:0] pc_if_i,
   input  logic        last_op_if_i,               // IF stage is handling the last operation of a sequence.
+  input  logic        abort_op_if_i,              // IF stage contains an operation that will aborted (bus error or MPU exception)
 
   // From ID stage
   input  if_id_pipe_t if_id_pipe_i,
@@ -68,6 +69,7 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
   input  ex_wb_pipe_t ex_wb_pipe_i,
   input  logic [1:0]  lsu_err_wb_i,               // LSU caused bus_error in WB stage, gated with data_rvalid_i inside load_store_unit
   input  logic        last_op_wb_i,               // WB stage contains the last operation of an instruction
+  input  logic        abort_op_wb_i,              // WB stage contains an (to be) aborted instruction or sequence
 
   // From LSU (WB)
   input  mpu_status_e lsu_mpu_status_wb_i,        // MPU status (WB timing)
@@ -378,7 +380,7 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
   assign non_shv_irq_ack = ctrl_fsm_o.irq_ack && !irq_clic_shv_i;
 
   // single step becomes pending when the last operation of an instruction is done in WB, or we ack a non-shv interrupt.
-  assign pending_single_step = (!debug_mode_q && dcsr_i.step && ((wb_valid_i && last_op_wb_i) || non_shv_irq_ack)) && !pending_debug;
+  assign pending_single_step = (!debug_mode_q && dcsr_i.step && ((wb_valid_i && (last_op_wb_i || abort_op_wb_i)) || non_shv_irq_ack)) && !pending_debug;
 
   // Separate flag for pending single step when doing CLIC SHV, evaluated while in POINTER_FETCH stage
   assign pending_single_step_ptr = !debug_mode_q && dcsr_i.step && (wb_valid_i || 1'b1) && !pending_debug;
@@ -465,7 +467,7 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
   assign ctrl_fsm_o.mhpmevent.if_invalid    = !if_valid_i && id_ready_i;
   assign ctrl_fsm_o.mhpmevent.id_invalid    = !id_valid_i && ex_ready_i;
   assign ctrl_fsm_o.mhpmevent.ex_invalid    = !ex_valid_i && wb_ready_i;
-  assign ctrl_fsm_o.mhpmevent.wb_invalid    = !(wb_valid_i && last_op_wb_i);
+  assign ctrl_fsm_o.mhpmevent.wb_invalid    = !(wb_valid_i && (last_op_wb_i || abort_op_wb_i));
   assign ctrl_fsm_o.mhpmevent.id_jalr_stall = ctrl_byp_i.jalr_stall && !id_valid_i && ex_ready_i;
   assign ctrl_fsm_o.mhpmevent.id_ld_stall   = ctrl_byp_i.load_stall && !id_valid_i && ex_ready_i;
   assign ctrl_fsm_o.mhpmevent.wb_data_stall = data_stall_wb_i;
@@ -932,7 +934,7 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
     // Detect first insn issue in single step after dret
     // Any Zc sequence must fully complete (last_op_if_i) before halting the IF stage.
     // Used to block further issuing
-    if (!ctrl_fsm_o.debug_mode && dcsr_i.step && !single_step_halt_if_q && (if_valid_i && id_ready_i && last_op_if_i)) begin
+    if (!ctrl_fsm_o.debug_mode && dcsr_i.step && !single_step_halt_if_q && (if_valid_i && id_ready_i && (last_op_if_i || abort_op_if_i))) begin
       single_step_halt_if_n = 1'b1;
     end
 
@@ -1061,36 +1063,37 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
   end
 
   // Instruction sequences may not be interrupted/killed if the first operation has already been retired.
-  // Flop set when first_op is done in WB, and cleared when last_op is done, or WB is killed
+  // Flop set when first_op without either last_op or abort_op is done in WB, and cleared when last_op is done.
   always_ff @(posedge clk, negedge rst_n) begin
     if (rst_n == 1'b0) begin
       sequence_in_progress_wb <= 1'b0;
     end else begin
       if (!sequence_in_progress_wb) begin
-        if (wb_valid_i && ex_wb_pipe_i.first_op && !last_op_wb_i) begin // wb_valid implies ex_wb_pipe.instr_valid
+        if (wb_valid_i && ex_wb_pipe_i.first_op && !(last_op_wb_i || abort_op_wb_i)) begin // wb_valid implies ex_wb_pipe.instr_valid
           sequence_in_progress_wb <= 1'b1;
         end
       end else begin
-        // sequence_in_progress_wb is set, clear when last_op retires
-        if (wb_valid_i && last_op_wb_i) begin
+        // sequence_in_progress_wb is set, clear when last_op retires or sequence is aborted.
+        if (wb_valid_i && (last_op_wb_i || abort_op_wb_i)) begin
           sequence_in_progress_wb <= 1'b0;
         end
-        // Needed in the future, but commented out to make a SEC clean PR.
-        //if (ctrl_fsm_o.kill_wb) begin
-        //  sequence_in_progress_wb <= 1'b0;
-        //end
+
+        // No need to reset this flag on kill_wb.
+        // When flag is high, there should be no reason to kill WB as they are blocked by the flag itself.
       end
     end
   end
 
   // Logic to track first_op and last_op through the ID stage to detect unhaltable sequences
   // Flop set when first_op is done in ID, and cleared when last_op is done, or ID is killed
+  // If the ID stage first_op has a known exception or trigger match the flop will not be set
+  // as the controller will either take an exception or enter debug mode without finishing the sequence.
   always_ff @(posedge clk, negedge rst_n) begin
     if (rst_n == 1'b0) begin
       sequence_in_progress_id <= 1'b0;
     end else begin
       if (!sequence_in_progress_id) begin
-        if (id_valid_i && ex_ready_i && first_op_id_i && !last_op_id_i) begin // id_valid implies if_id_pipe.instr.valid
+        if (id_valid_i && ex_ready_i && first_op_id_i && !last_op_id_i && !ctrl_byp_i.id_stage_abort) begin // id_valid implies if_id_pipe.instr.valid
           sequence_in_progress_id <= 1'b1;
         end
       end else begin

--- a/rtl/cv32e40x_controller_fsm.sv
+++ b/rtl/cv32e40x_controller_fsm.sv
@@ -293,6 +293,8 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
                             (ex_wb_pipe_i.sys_en && ex_wb_pipe_i.sys_ebrk_insn)                    ||
                             (lsu_mpu_status_wb_i != MPU_OK)) && ex_wb_pipe_i.instr_valid;
 
+  assign ctrl_fsm_o.exception_in_wb = exception_in_wb;
+
   // Set exception cause
   assign exception_cause_wb = (ex_wb_pipe_i.instr.mpu_status != MPU_OK)                  ? EXC_CAUSE_INSTR_FAULT     :
                               ex_wb_pipe_i.instr.bus_resp.err                            ? EXC_CAUSE_INSTR_BUS_FAULT :

--- a/rtl/cv32e40x_core.sv
+++ b/rtl/cv32e40x_core.sv
@@ -187,6 +187,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
 
   // Abort_op bits
   logic        abort_op_if;
+  logic        abort_op_id;
   logic        abort_op_wb;
 
   // First op bits
@@ -513,6 +514,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
 
     .first_op_o                   ( first_op_id               ),
     .last_op_o                    ( last_op_id                ),
+    .abort_op_o                   ( abort_op_id               ),
 
     .rf_re_o                      ( rf_re_id                  ),
     .rf_raddr_o                   ( rf_raddr_id               ),
@@ -820,6 +822,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .last_op_ex_i                   ( last_op_ex             ),
     .last_op_wb_i                   ( last_op_wb             ),
 
+    .abort_op_id_i                  ( abort_op_id            ),
     .abort_op_wb_i                  ( abort_op_wb            ),
 
     .if_valid_i                     ( if_valid               ),

--- a/rtl/cv32e40x_core.sv
+++ b/rtl/cv32e40x_core.sv
@@ -134,7 +134,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
 
   // Zc is always present
   // todo: turn on when Zc is ready for core-v-verif
-  localparam bit ZC_EXT = 1;
+  localparam bit ZC_EXT = 0;
 
   // Determine alignedness of mtvt
   // mtvt[31:N] holds mtvt table entry

--- a/rtl/cv32e40x_core.sv
+++ b/rtl/cv32e40x_core.sv
@@ -134,7 +134,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
 
   // Zc is always present
   // todo: turn on when Zc is ready for core-v-verif
-  localparam bit ZC_EXT = 0;
+  localparam bit ZC_EXT = 1;
 
   // Determine alignedness of mtvt
   // mtvt[31:N] holds mtvt table entry
@@ -184,6 +184,10 @@ module cv32e40x_core import cv32e40x_pkg::*;
   logic        last_op_id;
   logic        last_op_ex;
   logic        last_op_wb;
+
+  // Abort_op bits
+  logic        abort_op_if;
+  logic        abort_op_wb;
 
   // First op bits
   logic        first_op_if;
@@ -446,6 +450,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
 
     .first_op_o          ( first_op_if              ),
     .last_op_o           ( last_op_if               ),
+    .abort_op_o          ( abort_op_if              ),
 
     // Pipeline handshakes
     .if_valid_o          ( if_valid                 ),
@@ -687,7 +692,8 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .clic_pa_valid_i            ( csr_clic_pa_valid            ),
     .clic_pa_i                  ( csr_clic_pa                  ),
 
-    .last_op_o                  ( last_op_wb                   )
+    .last_op_o                  ( last_op_wb                   ),
+    .abort_op_o                 ( abort_op_wb                  )
   );
 
   //////////////////////////////////////
@@ -814,9 +820,13 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .last_op_ex_i                   ( last_op_ex             ),
     .last_op_wb_i                   ( last_op_wb             ),
 
+    .abort_op_wb_i                  ( abort_op_wb            ),
+
     .if_valid_i                     ( if_valid               ),
     .pc_if_i                        ( pc_if                  ),
     .last_op_if_i                   ( last_op_if             ),
+    .abort_op_if_i                  ( abort_op_if            ),
+
     // from IF/ID pipeline
     .if_id_pipe_i                   ( if_id_pipe             ),
 

--- a/rtl/cv32e40x_ex_stage.sv
+++ b/rtl/cv32e40x_ex_stage.sv
@@ -354,6 +354,7 @@ module cv32e40x_ex_stage import cv32e40x_pkg::*;
       ex_wb_pipe_o.xif_meta           <= '0;
       ex_wb_pipe_o.first_op           <= 1'b0;
       ex_wb_pipe_o.last_op            <= 1'b0;
+      ex_wb_pipe_o.abort_op           <= 1'b0;
     end
     else
     begin
@@ -362,6 +363,7 @@ module cv32e40x_ex_stage import cv32e40x_pkg::*;
 
         ex_wb_pipe_o.last_op     <= last_op_o;
         ex_wb_pipe_o.first_op    <= first_op_o;
+        ex_wb_pipe_o.abort_op    <= id_ex_pipe_i.abort_op; // MPU exceptions have WB timing and will not impace ex_wb_pipe.abort_op
         // Deassert rf_we in case of illegal csr instruction or
         // when the first half of a misaligned/split LSU goes to WB.
         // Also deassert if CSR was accepted both by eXtension if and pipeline

--- a/rtl/cv32e40x_ex_stage.sv
+++ b/rtl/cv32e40x_ex_stage.sv
@@ -363,7 +363,7 @@ module cv32e40x_ex_stage import cv32e40x_pkg::*;
 
         ex_wb_pipe_o.last_op     <= last_op_o;
         ex_wb_pipe_o.first_op    <= first_op_o;
-        ex_wb_pipe_o.abort_op    <= id_ex_pipe_i.abort_op; // MPU exceptions have WB timing and will not impace ex_wb_pipe.abort_op
+        ex_wb_pipe_o.abort_op    <= id_ex_pipe_i.abort_op; // MPU exceptions have WB timing and will not impact ex_wb_pipe.abort_op
         // Deassert rf_we in case of illegal csr instruction or
         // when the first half of a misaligned/split LSU goes to WB.
         // Also deassert if CSR was accepted both by eXtension if and pipeline

--- a/rtl/cv32e40x_id_stage.sv
+++ b/rtl/cv32e40x_id_stage.sv
@@ -78,6 +78,7 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
 
   output logic        first_op_o,
   output logic        last_op_o,
+  output logic        abort_op_o,
 
   // RF interface -> controller
   output logic [REGFILE_NUM_READ_PORTS-1:0] rf_re_o,
@@ -204,8 +205,6 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
 
   // Signal for detection of first operation (of two) of table jumps.
   logic                 tbljmp_first;
-
-  logic                 abort_op;
 
   assign instr_valid = if_id_pipe_i.instr_valid && !ctrl_fsm_i.kill_id && !ctrl_fsm_i.halt_id;
 
@@ -558,7 +557,7 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
         id_ex_pipe_o.instr_valid  <= 1'b1;
         id_ex_pipe_o.last_op      <= last_op_o;
         id_ex_pipe_o.first_op     <= first_op_o;
-        id_ex_pipe_o.abort_op     <= abort_op;
+        id_ex_pipe_o.abort_op     <= abort_op_o;
 
         // Operands
         if (alu_op_a_mux_sel != OP_A_NONE) begin
@@ -683,9 +682,9 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
   // multi_cycle_id_stall is currently tied to 1'b0. Will be used for Zce push/pop instructions.
   assign id_valid_o = (instr_valid && !xif_waiting) || (multi_cycle_id_stall && !ctrl_fsm_i.kill_id && !ctrl_fsm_i.halt_id);
 
-  assign first_op_o = if_id_pipe_i.first_op;
-  assign last_op_o  = if_id_pipe_i.last_op;
-  assign abort_op   = if_id_pipe_i.abort_op || ctrl_byp_i.id_stage_abort;
+  assign first_op_o  = if_id_pipe_i.first_op;
+  assign last_op_o   = if_id_pipe_i.last_op;
+  assign abort_op_o  = if_id_pipe_i.abort_op || ctrl_byp_i.id_stage_abort;
   //---------------------------------------------------------------------------
   // eXtension interface
   //---------------------------------------------------------------------------

--- a/rtl/cv32e40x_id_stage.sv
+++ b/rtl/cv32e40x_id_stage.sv
@@ -205,6 +205,8 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
   // Signal for detection of first operation (of two) of table jumps.
   logic                 tbljmp_first;
 
+  logic                 abort_op;
+
   assign instr_valid = if_id_pipe_i.instr_valid && !ctrl_fsm_i.kill_id && !ctrl_fsm_i.halt_id;
 
   assign sys_mret_insn_o = sys_mret_insn;
@@ -549,12 +551,14 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
 
       id_ex_pipe_o.first_op               <= 1'b0;
       id_ex_pipe_o.last_op                <= 1'b0;
+      id_ex_pipe_o.abort_op               <= 1'b0;
     end else begin
       // normal pipeline unstall case
       if (id_valid_o && ex_ready_i) begin
         id_ex_pipe_o.instr_valid  <= 1'b1;
         id_ex_pipe_o.last_op      <= last_op_o;
         id_ex_pipe_o.first_op     <= first_op_o;
+        id_ex_pipe_o.abort_op     <= abort_op;
 
         // Operands
         if (alu_op_a_mux_sel != OP_A_NONE) begin
@@ -681,6 +685,7 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
 
   assign first_op_o = if_id_pipe_i.first_op;
   assign last_op_o  = if_id_pipe_i.last_op;
+  assign abort_op   = if_id_pipe_i.abort_op || ctrl_byp_i.id_stage_abort;
   //---------------------------------------------------------------------------
   // eXtension interface
   //---------------------------------------------------------------------------

--- a/rtl/cv32e40x_id_stage.sv
+++ b/rtl/cv32e40x_id_stage.sv
@@ -553,8 +553,8 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
       // normal pipeline unstall case
       if (id_valid_o && ex_ready_i) begin
         id_ex_pipe_o.instr_valid  <= 1'b1;
-        id_ex_pipe_o.last_op      <= if_id_pipe_i.last_op;
-        id_ex_pipe_o.first_op     <= if_id_pipe_i.first_op;
+        id_ex_pipe_o.last_op      <= last_op_o;
+        id_ex_pipe_o.first_op     <= first_op_o;
 
         // Operands
         if (alu_op_a_mux_sel != OP_A_NONE) begin

--- a/rtl/cv32e40x_sequencer.sv
+++ b/rtl/cv32e40x_sequencer.sv
@@ -203,8 +203,7 @@ import cv32e40x_pkg::*;
     instr_o = instr_i;
     seq_state_n = seq_state_q;
     seq_last_o = 1'b0;
-    // default to 1, used by IF stage regardless of seq_valid
-    // See explanation around combinatorial loops in the if_stage.sv. // todo: reconsider, this is not clean enough
+    // default to 1, set to zero in non-first states.
     seq_first_o = 1'b1;
     ready_o = 1'b0;
 

--- a/rtl/cv32e40x_sequencer.sv
+++ b/rtl/cv32e40x_sequencer.sv
@@ -165,8 +165,7 @@ import cv32e40x_pkg::*;
   // In principle this is the same as "seq_en && valid_i"
   //   as the output of the above decode logic is equivalent to seq_en
   // todo: halting IF stage would imply !valid, can this be an issue?
-  // todo: revisit the error conditions below (they are bad for the critical path; why can't they be done in ID?)
-  assign valid_o = (seq_instr != INVALID_INST) && !instr_is_ptr_i && !(instr_i.bus_resp.err || !(instr_i.mpu_status == MPU_OK)) && valid_i && !halt_i && !kill_i;
+  assign valid_o = (seq_instr != INVALID_INST) && !instr_is_ptr_i && valid_i && !halt_i && !kill_i;
 
 
   // Calculate number of S* registers needed in sequence (push/pop* only)

--- a/rtl/cv32e40x_wb_stage.sv
+++ b/rtl/cv32e40x_wb_stage.sv
@@ -149,7 +149,7 @@ module cv32e40x_wb_stage import cv32e40x_pkg::*;
 
   // Signal that WB stage contains the last operation of an instruction
   // Split misaligned LSU instructions are forced to be 'last_op' if an exception occurs in either the first or last operation.
-  assign last_op_o = ex_wb_pipe_i.last_op || ( ex_wb_pipe_i.lsu_en && lsu_exception);
+  assign last_op_o = ex_wb_pipe_i.last_op || ctrl_fsm_i.exception_in_wb || ex_wb_pipe_i.trigger_match;
 
   // Export signal indicating WB stage stalled by load/store
   assign data_stall_o = ex_wb_pipe_i.lsu_en && !(lsu_valid_i && last_op_o) && instr_valid;

--- a/rtl/cv32e40x_wb_stage.sv
+++ b/rtl/cv32e40x_wb_stage.sv
@@ -149,15 +149,14 @@ module cv32e40x_wb_stage import cv32e40x_pkg::*;
   assign wb_valid_o = wb_valid;
 
   // Signal that WB stage contains the last operation of an instruction
-  // Exceptions and trigger matchces are forced to be 'last_op' as they either terminate a sequence or
-  // The sequence will be trapped on the first operation in case of a trigger match.
   assign last_op_o = ex_wb_pipe_i.last_op;
 
   // Append any MPU exception to abort_op
+  // An abort_op_o = 1 will terminate a sequence, either to take an exception or debug due to trigger match.
   assign abort_op_o = ex_wb_pipe_i.abort_op || ( ex_wb_pipe_i.lsu_en && lsu_exception);
 
   // Export signal indicating WB stage stalled by load/store
-  assign data_stall_o = ex_wb_pipe_i.lsu_en && !(lsu_valid_i && (last_op_o || abort_op_o)) && instr_valid;
+  assign data_stall_o = ex_wb_pipe_i.lsu_en && !lsu_valid_i && instr_valid;
 
   //---------------------------------------------------------------------------
   // eXtension interface

--- a/rtl/cv32e40x_wb_stage.sv
+++ b/rtl/cv32e40x_wb_stage.sv
@@ -148,7 +148,8 @@ module cv32e40x_wb_stage import cv32e40x_pkg::*;
   assign wb_valid_o = wb_valid;
 
   // Signal that WB stage contains the last operation of an instruction
-  // Split misaligned LSU instructions are forced to be 'last_op' if an exception occurs in either the first or last operation.
+  // Exceptions and trigger matchces are forced to be 'last_op' as they either terminate a sequence or
+  // The sequence will be trapped on the first operation in case of a trigger match.
   assign last_op_o = ex_wb_pipe_i.last_op || ctrl_fsm_i.exception_in_wb || ex_wb_pipe_i.trigger_match;
 
   // Export signal indicating WB stage stalled by load/store

--- a/rtl/include/cv32e40x_pkg.sv
+++ b/rtl/include/cv32e40x_pkg.sv
@@ -1052,6 +1052,7 @@ typedef struct packed {
   logic [31:0] ptr;              // Flops to hold 32-bit pointer
   logic        first_op;         // First part of multi operation instruction
   logic        last_op;          // Last part of multi operation instruction
+  logic        abort_op;         // Instruction will be aborted due to known exceptions or trigger matches
 } if_id_pipe_t;
 
 // ID/EX pipeline
@@ -1120,6 +1121,7 @@ typedef struct packed {
 
   logic         first_op;         // First part of multi operation instruction
   logic         last_op;          // Last part of multi operation instruction
+  logic         abort_op;         // Instruction will be aborted due to known exceptions or trigger matches
 
 } id_ex_pipe_t;
 
@@ -1168,6 +1170,7 @@ typedef struct packed {
 
   logic         first_op;         // First part of multi operation instruction
   logic         last_op;          // Last part of multi operation instruction
+  logic         abort_op;         // Instruction will be aborted due to known exceptions or trigger matches
 } ex_wb_pipe_t;
 
 // Performance counter events
@@ -1202,6 +1205,7 @@ typedef struct packed {
   logic         mnxti_stall;            // Stall due to mnxti CSR access in EX
   logic         minstret_stall;         // Stall due to minstret/h read in EX
   logic         deassert_we;            // Deassert write enable and special insn bits
+  logic         id_stage_abort;         // Same signal as deassert_we, with better name for use in the controller.
   logic         xif_exception_stall;    // Stall (EX) if xif insn in WB can cause an exception
 } ctrl_byp_t;
 

--- a/rtl/include/cv32e40x_pkg.sv
+++ b/rtl/include/cv32e40x_pkg.sv
@@ -1270,6 +1270,9 @@ typedef struct packed {
 
   // Kill signal for xif_commit_if
   logic        kill_xif; // Kill (attempted) offloaded instruction
+
+  // Signal that an exception is in WB
+  logic        exception_in_wb;
 } ctrl_fsm_t;
 
   ////////////////////////////////////////

--- a/sva/cv32e40x_controller_fsm_sva.sv
+++ b/sva/cv32e40x_controller_fsm_sva.sv
@@ -633,9 +633,26 @@ end // SMCLIC
     else `uvm_error("controller", "ID stage not haltable after a deasserted operation")
 
   // Check that wb stage is interruptible after passing through an operation with exception_in_wb
-  a_wb_interruptible_exception:
+  a_wb_interruptible_abort:
   assert property (@(posedge clk) disable iff (!rst_n)
                     (wb_valid_i && abort_op_wb_i)
+                    |=>
+                    sequence_interruptible)
+    else `uvm_error("controller", "sequence_interruptible should be 1 after an exception has been taken.")
+
+
+  // Check that id stage is haltable after passing through an operation with abort_op=1
+  a_id_halt_last:
+  assert property (@(posedge clk) disable iff (!rst_n)
+                    (id_valid_i && ex_ready_i && last_op_id_i)
+                    |=>
+                    id_stage_haltable)
+    else `uvm_error("controller", "ID stage not haltable after a deasserted operation")
+
+  // Check that wb stage is interruptible after passing through an operation with exception_in_wb
+  a_wb_interruptible_last:
+  assert property (@(posedge clk) disable iff (!rst_n)
+                    (wb_valid_i && last_op_wb_i)
                     |=>
                     sequence_interruptible)
     else `uvm_error("controller", "sequence_interruptible should be 1 after an exception has been taken.")

--- a/sva/cv32e40x_controller_fsm_sva.sv
+++ b/sva/cv32e40x_controller_fsm_sva.sv
@@ -199,8 +199,8 @@ module cv32e40x_controller_fsm_sva
     assert property (@(posedge clk) disable iff (!rst_n)
             (pending_single_step && (ctrl_fsm_ns == DEBUG_TAKEN)
             |-> ((!(id_ex_pipe_i.instr_valid && first_op_ex_i) && !(if_id_pipe_i.instr_valid && if_id_pipe_i.first_op))) ||
-                (ctrl_fsm_o.irq_ack && ctrl_fsm_o.kill_if && ctrl_fsm_o.kill_id && ctrl_fsm_o.kill_ex && ctrl_fsm_o.kill_wb)//     ||
-                /*abort_op_wb_i*/))
+                (ctrl_fsm_o.irq_ack && ctrl_fsm_o.kill_if && ctrl_fsm_o.kill_id && ctrl_fsm_o.kill_ex && ctrl_fsm_o.kill_wb)))
+
       else `uvm_error("controller", "ID and EX not empty when when single step is taken")
 
   // Check trigger match never happens during debug_mode

--- a/sva/cv32e40x_controller_fsm_sva.sv
+++ b/sva/cv32e40x_controller_fsm_sva.sv
@@ -76,6 +76,7 @@ module cv32e40x_controller_fsm_sva
   input dcsr_t          dcsr_i,
   input logic           irq_clic_shv_i,
   input logic           last_op_wb_i,
+  input logic           abort_op_wb_i,
   input logic           csr_wr_in_wb_flush_i,
   input logic [2:0]     debug_cause_q,
   input logic           id_valid_i,
@@ -87,7 +88,8 @@ module cv32e40x_controller_fsm_sva
   input logic           sequence_interruptible,
   input logic           id_stage_haltable,
   input logic           prefetch_valid_if_i,
-  input logic           prefetch_is_tbljmp_ptr_if_i
+  input logic           prefetch_is_tbljmp_ptr_if_i,
+  input logic           abort_op_id_i
 );
 
 
@@ -189,20 +191,16 @@ module cv32e40x_controller_fsm_sva
           (ex_wb_pipe_i.sys_en && ex_wb_pipe_i.sys_wfi_insn && ex_wb_pipe_i.instr_valid) |-> !(id_ex_pipe_i.lsu_en) )
     else `uvm_error("controller", "LSU instruction follows WFI")
 
-  // Check that no instructions are valid in ID or EX when a single step is taken
+  // Check that no new instructions (first_op=1) are valid in ID or EX when a single step is taken
   // In case of interrupt during step, the instruction being stepped could be in any stage, and will get killed.
-  // Exception if first phase of a misaligned LSU gets an MPU error, then
-  // the controller will kill the pipeline and jump to debug with dpc set to exception handler,
-  // while id_ex_pipe may still contain the valid last phase of the misaligned LSU
-  // todo:ok: Add a second assert to check above exception?
-  // todo: Currently fails for Zc sequences where the first instruction has an exception. Could exclude all exceptions
-  //       in the same way only LSU MPU errors are excluded.
+  // Aborted instructions may cause early termination of sequences. Either we jump to the exception handler before debug entry,
+  // or straight to debug in case of a trigger match.
   a_single_step_pipecheck :
     assert property (@(posedge clk) disable iff (!rst_n)
-            (pending_single_step && (ctrl_fsm_ns == DEBUG_TAKEN) &&
-            (lsu_mpu_status_wb_i == MPU_OK))
-            |-> ((!id_ex_pipe_i.instr_valid && !if_id_pipe_i.instr_valid) ||
-                (ctrl_fsm_o.irq_ack && ctrl_fsm_o.kill_if && ctrl_fsm_o.kill_id && ctrl_fsm_o.kill_ex && ctrl_fsm_o.kill_wb)))
+            (pending_single_step && (ctrl_fsm_ns == DEBUG_TAKEN)
+            |-> ((!(id_ex_pipe_i.instr_valid && first_op_ex_i) && !(if_id_pipe_i.instr_valid && if_id_pipe_i.first_op))) ||
+                (ctrl_fsm_o.irq_ack && ctrl_fsm_o.kill_if && ctrl_fsm_o.kill_id && ctrl_fsm_o.kill_ex && ctrl_fsm_o.kill_wb)//     ||
+                /*abort_op_wb_i*/))
       else `uvm_error("controller", "ID and EX not empty when when single step is taken")
 
   // Check trigger match never happens during debug_mode
@@ -507,7 +505,7 @@ endgenerate
       valid_cnt <= '0;
     end else begin
       if (bus_error_latched) begin
-        if (wb_valid_i && last_op_wb_i && !ctrl_fsm_o.debug_mode && !(dcsr_i.step && !dcsr_i.stepie)) begin
+        if (wb_valid_i && (last_op_wb_i || abort_op_wb_i) && !ctrl_fsm_o.debug_mode && !(dcsr_i.step && !dcsr_i.stepie)) begin
           valid_cnt <= valid_cnt + 1'b1;
         end
       end else begin
@@ -606,6 +604,12 @@ end // SMCLIC
   assert property (@(posedge clk) disable iff (!rst_n)
                     (!sequence_interruptible |-> !(ctrl_fsm_o.dbg_ack && (debug_cause_q == DBG_CAUSE_HALTREQ)))) // todo: timing of (debug_cause_q == DBG_CAUSE_HALTREQ) seems wrong (and whole calsuse should not be needed)
     else `uvm_error("controller", "Sequence broken by external debug")
+
+  a_no_sequence_wb_kill:
+  assert property (@(posedge clk) disable iff (!rst_n)
+                    (!sequence_interruptible |-> !ctrl_fsm_o.kill_wb))
+    else `uvm_error("controller", "Sequence broken by external debug")
+
 /* todo: Bring back in if id_stage_haltable_alt can be correctly calculated.
   // Check that we do not allow ID stage to be halted for pending interrupts/debug if a sequence is not done
   // in the ID stage.
@@ -620,5 +624,20 @@ end // SMCLIC
                     (csr_wr_in_wb_flush_i && !ctrl_fsm_o.kill_wb) |-> (!ctrl_fsm_o.pc_set))
     else `uvm_error("controller", "Fetching new instruction before CSR values are updated")
 
+  // Check that id stage is haltable after passing through an operation with abort_op=1
+  a_id_halt_abort:
+  assert property (@(posedge clk) disable iff (!rst_n)
+                    (id_valid_i && ex_ready_i && abort_op_id_i)
+                    |=>
+                    id_stage_haltable)
+    else `uvm_error("controller", "ID stage not haltable after a deasserted operation")
+
+  // Check that wb stage is interruptible after passing through an operation with exception_in_wb
+  a_wb_interruptible_exception:
+  assert property (@(posedge clk) disable iff (!rst_n)
+                    (wb_valid_i && abort_op_wb_i)
+                    |=>
+                    sequence_interruptible)
+    else `uvm_error("controller", "sequence_interruptible should be 1 after an exception has been taken.")
 endmodule
 


### PR DESCRIPTION
Sequenced instructions and table jumps will proceed to ID stage regardless of MPU status and bus error.
Using deassert_we logic in ID stage to avoid side effects.

Added abort_op bits to all stages. These gets set whenever a known exception or trigger match is active in the stage where they occur.

Keeping ZC_EXT localparam as 0 until verification is ready to enable it.

NOT SEC clean as the difference in deassertion logic impacts the prefetcher.

