### PR TITLE
Moved decoding of tablejumps to the sequencer

### DIFF
--- a/rtl/cv32e40x_compressed_decoder.sv
+++ b/rtl/cv32e40x_compressed_decoder.sv
@@ -35,8 +35,7 @@ module cv32e40x_compressed_decoder import cv32e40x_pkg::*;
   input  logic        instr_is_ptr_i,
   output inst_resp_t  instr_o,
   output logic        is_compressed_o,
-  output logic        illegal_instr_o,
-  output logic        tbljmp_o
+  output logic        illegal_instr_o
 );
 
   logic [31:0] instr;
@@ -55,7 +54,6 @@ module cv32e40x_compressed_decoder import cv32e40x_pkg::*;
   begin
     illegal_instr_o  = 1'b0;
     instr_o          = instr_i;
-    tbljmp_o         = 1'b0;
 
     if (instr_is_ptr_i) begin
       is_compressed_o = 1'b0;
@@ -441,36 +439,13 @@ module cv32e40x_compressed_decoder import cv32e40x_pkg::*;
               end
             end
 
-            3'b101: begin
-              if (ZC_EXT) begin
-                // The cm.jt and cm.jalt have no equivalent 32-bit instructions.
-                // Mapping to JAL anyway, but an extra control bit is set to indicate that these
-                // are table jumps as opposed to regular JAL instruction.
-                if (instr[12:10] == 3'b000) begin
-                  tbljmp_o = 1'b1;
-                  if (instr[9:8] == 2'b00) begin
-                    // cm.jt -> JAL x0, index
-                    instr_o.bus_resp.rdata = {13'b0000000000000, instr[7:2], 5'b00000, OPCODE_JAL};
-                  end else begin
-                    // cm.jalt -> JAL, x1, index
-                    instr_o.bus_resp.rdata = {11'b00000000000, instr[9:2], 5'b00001, OPCODE_JAL};
-                  end
-                end else begin
-                    illegal_instr_o = 1'b1;
-                    instr_o.bus_resp.rdata = {4'b0, instr[3:2], instr[12], instr[6:4], 2'b00, 5'h02, 3'b010, instr[11:7], OPCODE_LOAD};
-                end
-              end else begin
-                instr_o.bus_resp.rdata = {4'b0, instr[3:2], instr[12], instr[6:4], 2'b00, 5'h02, 3'b010, instr[11:7], OPCODE_LOAD};
-                illegal_instr_o = 1'b1;
-              end
-            end
-
             3'b110: begin
               // c.swsp -> sw rs2, imm(x2)
               instr_o.bus_resp.rdata = {4'b0, instr[8:7], instr[12], instr[6:2], 5'h02, 3'b010, instr[11:9], 2'b00, OPCODE_STORE};
             end
 
             3'b011,
+            3'b101,
             3'b111: begin  // c.fswsp -> fsw rs2, imm(x2)
               instr_o.bus_resp.rdata = {4'b0, instr[3:2], instr[12], instr[6:4], 2'b00, 5'h02, 3'b010, instr[11:7], OPCODE_LOAD};
               illegal_instr_o = 1'b1;

--- a/rtl/cv32e40x_if_stage.sv
+++ b/rtl/cv32e40x_if_stage.sv
@@ -445,6 +445,7 @@ module cv32e40x_if_stage import cv32e40x_pkg::*;
       assign seq_instr = '0;
       assign seq_ready = 1'b1;
       assign seq_first = 1'b0;
+      assign tbljmp    = 1'b0;
     end
   endgenerate
 

--- a/rtl/cv32e40x_sequencer.sv
+++ b/rtl/cv32e40x_sequencer.sv
@@ -294,7 +294,7 @@ import cv32e40x_pkg::*;
             instr_o.bus_resp.rdata = {11'b00000000000, instr[9:2], 5'b00001, OPCODE_JAL};
           end
           // The second half of tablejumps (pointer) will not use the FSM (the jump will kill the sequencer anyway).
-          // Signalling ready here will acknowledge the prefetcher (to remain SEC clean).
+          // Signalling ready here will acknowledge the prefetcher.
           ready_fsm = ready_i && !halt_i;
         end else if (seq_move_s2a) begin
           // move s to a

--- a/rtl/cv32e40x_sequencer.sv
+++ b/rtl/cv32e40x_sequencer.sv
@@ -37,19 +37,21 @@ import cv32e40x_pkg::*;
     input  logic       clk,
     input  logic       rst_n,
 
-    input  inst_resp_t instr_i,          // Instruction from prefetch unit
-    input  logic       instr_is_ptr_i,   // Pointer flag, instr_i does not contain an instruction
+    input  inst_resp_t instr_i,               // Instruction from prefetch unit
+    input  logic       instr_is_clic_ptr_i,   // CLIC pointer flag, instr_i does not contain an instruction
+    input  logic       instr_is_tblj_ptr_i,   // Tablejump pointer flag, instr_i does not contain an instruction
 
-    input  logic       valid_i,          // valid input from if stage
-    input  logic       ready_i,          // Downstream is ready (ID stage)
-    input  logic       halt_i,           // Halt, not ready for new input, no output valid. Keep state
-    input  logic       kill_i,           // Kill. Ready for inputs, no output valid. Reset state
+    input  logic       valid_i,               // valid input from if stage
+    input  logic       ready_i,               // Downstream is ready (ID stage)
+    input  logic       halt_i,                // Halt, not ready for new input, no output valid. Keep state
+    input  logic       kill_i,                // Kill. Ready for inputs, no output valid. Reset state
 
-    output inst_resp_t instr_o,          // Output sequenced (32-bit) instruction
-    output logic       valid_o,          // Output is valid - input is valid AND we decode a valid seq instruction
-    output logic       ready_o,          // Sequencer is ready for new inputs
-    output logic       seq_first_o,      // First operation is being output
-    output logic       seq_last_o        // Last operation is being output
+    output inst_resp_t instr_o,               // Output sequenced (32-bit) instruction
+    output logic       valid_o,               // Output is valid - input is valid AND we decode a valid seq instruction
+    output logic       ready_o,               // Sequencer is ready for new inputs
+    output logic       seq_first_o,           // First operation is being output
+    output logic       seq_last_o,            // Last operation is being output,
+    output logic       seq_tbljmp_o           // Instruction is a table jump (jt/jalt)
   );
 
   seq_t                instr_cnt_q;        // Count number of emitted uncompressed instructions
@@ -63,13 +65,24 @@ import cv32e40x_pkg::*;
   logic                seq_load;
   logic                seq_store;
   logic                seq_move_a2s;
+  logic                seq_move_s2a;
 
   // FSM state
   seq_state_e          seq_state_n;
   seq_state_e          seq_state_q;
 
+  logic                seq_first_fsm;
+  logic                seq_last_fsm;
+
+  logic                instr_is_pointer;
+
+  logic                ready_fsm;
+
+
   assign instr = instr_i.bus_resp.rdata;
   assign rlist = instr[7:4];
+
+  assign instr_is_pointer = instr_is_clic_ptr_i || instr_is_tblj_ptr_i;
 
   // Count number of instructions emitted and set next state for FSM.
   always_ff @(posedge clk, negedge rst_n) begin
@@ -78,7 +91,12 @@ import cv32e40x_pkg::*;
       seq_state_q <= S_IDLE;
     end else begin
       if (valid_o && ready_i) begin
-        if (!seq_last_o) begin
+        // Exclude tablejumps and tablejump pointers from increasing the counter.
+        // To remain SEC clean, the prefetcher is ack'ed on a tablejump. If the tablejump
+        // has a bus error or mpu error, the instruction after the tablejump may reach EX before the pipeline is killed.
+        // If this next instruction is a load or store, the starting value for the stack adjustment will be wrong and the LSU
+        // outputs may get affected. If one changes to not ack the prefetcher on table jumps, this exclusion can likely be removed.
+        if (!seq_last_o && !seq_tbljmp_o && !instr_is_tblj_ptr_i) begin
           instr_cnt_q <= instr_cnt_q + 1'd1;
         end else begin
           instr_cnt_q <= '0;
@@ -106,66 +124,78 @@ import cv32e40x_pkg::*;
     seq_load     = 1'b0;
     seq_store    = 1'b0;
     seq_move_a2s = 1'b0;
-    // All sequenced instructions are within C2
-    if (instr[1:0] == 2'b10) begin
-      if (instr[15:13] == 3'b101) begin
-        unique case (instr[12:10])
-          3'b011: begin
-            // rs1 must be different from rs2
-            if (instr[9:7] != instr[4:2]) begin
-              if (instr[6:5] == 2'b11) begin
-                // cm.mva01s
-                seq_instr = MVA01S;
-              end else if (instr[6:5] == 2'b01) begin
-                // cm.mvsa01
-                seq_instr = MVSA01;
-                seq_move_a2s = 1'b1;
+    seq_move_s2a = 1'b0;
+    seq_tbljmp_o = 1'b0;
+    // Disregard all pointers, they do not contain instructions.
+    if (!instr_is_pointer) begin
+      // All sequenced instructions are within C2
+      if (instr[1:0] == 2'b10) begin
+        if (instr[15:13] == 3'b101) begin
+          unique case (instr[12:10])
+            3'b000: begin
+              seq_tbljmp_o = 1'b1;
+              seq_instr = TBLJMP;
+            end
+
+            3'b011: begin
+              // rs1 must be different from rs2
+              if (instr[9:7] != instr[4:2]) begin
+                if (instr[6:5] == 2'b11) begin
+                  // cm.mva01s
+                  seq_instr = MVA01S;
+                  seq_move_s2a = 1'b1;
+                end else if (instr[6:5] == 2'b01) begin
+                  // cm.mvsa01
+                  seq_instr = MVSA01;
+                  seq_move_a2s = 1'b1;
+                end
               end
             end
-          end
-          3'b110: begin
-            if (instr[9:8] == 2'b00) begin
-              // cm.push
-              if (rlist > 3) begin
-                seq_instr = PUSH;
-                seq_store = 1'b1;
-              end
-            end else if (instr[9:8] == 2'b10) begin
-              // cm.pop
-              if (rlist > 3) begin
-                seq_instr = POP;
-                seq_load = 1'b1;
-              end
-            end
-          end
-          3'b111: begin
-            if (instr[9:8] == 2'b00) begin
-              // cm.popretz
-              if (rlist > 3) begin
-                seq_instr = POPRETZ;
-                seq_load = 1'b1;
-              end
-            end else if (instr[9:8] == 2'b10) begin
-              // cm.popret
-              if (rlist > 3) begin
-                seq_instr = POPRET;
-                seq_load = 1'b1;
+            3'b110: begin
+              if (instr[9:8] == 2'b00) begin
+                // cm.push
+                if (rlist > 3) begin
+                  seq_instr = PUSH;
+                  seq_store = 1'b1;
+                end
+              end else if (instr[9:8] == 2'b10) begin
+                // cm.pop
+                if (rlist > 3) begin
+                  seq_instr = POP;
+                  seq_load = 1'b1;
+                end
               end
             end
-          end
-          default: begin
-            seq_instr = INVALID_INST;
-          end
-        endcase
-      end // instr[15:13]
-    end // C2
+            3'b111: begin
+              if (instr[9:8] == 2'b00) begin
+                // cm.popretz
+                if (rlist > 3) begin
+                  seq_instr = POPRETZ;
+                  seq_load = 1'b1;
+                end
+              end else if (instr[9:8] == 2'b10) begin
+                // cm.popret
+                if (rlist > 3) begin
+                  seq_instr = POPRET;
+                  seq_load = 1'b1;
+                end
+              end
+            end
+            default: begin
+              seq_instr = INVALID_INST;
+            end
+          endcase
+        end // instr[15:13]
+      end // C2
+    end // instr_is_pointer
   end // always_comb
 
   // Local valid
   // In principle this is the same as "seq_en && valid_i"
   //   as the output of the above decode logic is equivalent to seq_en
+  // We have valid outputs for any correctly decoded instruction, or when we are handling a tablejump pointer.
   // todo: halting IF stage would imply !valid, can this be an issue?
-  assign valid_o = (seq_instr != INVALID_INST) && !instr_is_ptr_i && valid_i && !halt_i && !kill_i;
+  assign valid_o = ((seq_instr != INVALID_INST) || instr_is_tblj_ptr_i) && valid_i && !halt_i && !kill_i;
 
 
   // Calculate number of S* registers needed in sequence (push/pop* only)
@@ -202,10 +232,10 @@ import cv32e40x_pkg::*;
   always_comb begin : sequencer_state_machine
     instr_o = instr_i;
     seq_state_n = seq_state_q;
-    seq_last_o = 1'b0;
+    seq_last_fsm = 1'b0;
     // default to 1, set to zero in non-first states.
-    seq_first_o = 1'b1;
-    ready_o = 1'b0;
+    seq_first_fsm = 1'b1;
+    ready_fsm = 1'b0;
 
     unique case (seq_state_q)
       S_IDLE: begin
@@ -255,7 +285,18 @@ import cv32e40x_pkg::*;
           // addi s*, a0, 0
           instr_o.bus_resp.rdata = {12'h000, 5'd10, 3'b000, sn_to_regnum(5'(instr[9:7])), OPCODE_OPIMM};
           seq_state_n = S_DMOVE;
-        end else begin
+        end else if (seq_tbljmp_o) begin
+          if (instr[9:8] == 2'b00) begin
+            // cm.jt -> JAL x0, index
+            instr_o.bus_resp.rdata = {13'b0000000000000, instr[7:2], 5'b00000, OPCODE_JAL};
+          end else begin
+            // cm.jalt -> JAL, x1, index
+            instr_o.bus_resp.rdata = {11'b00000000000, instr[9:2], 5'b00001, OPCODE_JAL};
+          end
+          // The second half of tablejumps (pointer) will not use the FSM (the jump will kill the sequencer anyway).
+          // Signalling ready here will acknowledge the prefetcher (to remain SEC clean).
+          ready_fsm = ready_i && !halt_i;
+        end else if (seq_move_s2a) begin
           // move s to a
           // addi a0, s*, 0
           instr_o.bus_resp.rdata = {12'h000, sn_to_regnum(5'(instr[9:7])), 3'b000, 5'd10, OPCODE_OPIMM};
@@ -265,7 +306,7 @@ import cv32e40x_pkg::*;
       end
       // todo: Any instruction output while not in S_IDLE should not combinatorially depend on instr_rdata_i
       S_PUSH: begin
-        seq_first_o = 1'b0;
+        seq_first_fsm = 1'b0;
         // sw rs2, current_stack_adj(sp)
         instr_o.bus_resp.rdata = {decode.current_stack_adj[11:5],sn_to_regnum(decode.sreg),REG_SP,3'b010,decode.current_stack_adj[4:0],OPCODE_STORE};
         // Advance FSM when we have saved all s* registers
@@ -274,7 +315,7 @@ import cv32e40x_pkg::*;
         end
       end
       S_POP: begin
-        seq_first_o = 1'b0;
+        seq_first_fsm = 1'b0;
         // lw rd, current_stack_adj(sp)
         instr_o.bus_resp.rdata = {decode.current_stack_adj,REG_SP,3'b010,sn_to_regnum(decode.sreg),OPCODE_LOAD};
         // Advance FSM when we have loaded all s* registers
@@ -283,7 +324,7 @@ import cv32e40x_pkg::*;
         end
       end
       S_DMOVE: begin
-        seq_first_o = 1'b0;
+        seq_first_fsm = 1'b0;
         // Second half of double moves
         if (seq_move_a2s) begin
           // addi s*, a1, 0
@@ -294,11 +335,11 @@ import cv32e40x_pkg::*;
         end
 
         seq_state_n = S_IDLE;
-        ready_o = ready_i && !halt_i;
-        seq_last_o = 1'b1;
+        ready_fsm = ready_i && !halt_i;
+        seq_last_fsm = 1'b1;
       end
       S_RA: begin
-        seq_first_o = 1'b0;
+        seq_first_fsm = 1'b0;
         // push pop ra register
         if (seq_load) begin
           // lw ra, current_stack_adj(sp)
@@ -311,7 +352,7 @@ import cv32e40x_pkg::*;
         seq_state_n = S_SP;
       end
       S_SP: begin
-        seq_first_o = 1'b0;
+        seq_first_fsm = 1'b0;
         // Adjust stack pointer
         if (seq_load) begin
           // addi sp, sp, total_stack_adj
@@ -328,12 +369,12 @@ import cv32e40x_pkg::*;
           seq_state_n = S_RET;
         end else begin
           seq_state_n = S_IDLE;
-          ready_o = ready_i && !halt_i;
-          seq_last_o = 1'b1;
+          ready_fsm = ready_i && !halt_i;
+          seq_last_fsm = 1'b1;
         end
       end
       S_A0: begin
-        seq_first_o = 1'b0;
+        seq_first_fsm = 1'b0;
         // Clear a0 for popretz
         // addi ra, x0, 0
         instr_o.bus_resp.rdata = {12'h000,5'd0,3'b0,5'd10,OPCODE_OPIMM};
@@ -341,30 +382,37 @@ import cv32e40x_pkg::*;
         seq_state_n = S_RET;
       end
       S_RET: begin
-        seq_first_o = 1'b0;
+        seq_first_fsm = 1'b0;
         // return for popret/popretz
         // jalr x0, 0(ra)
         instr_o.bus_resp.rdata = {12'b0,REG_RA,3'b0,5'b0,OPCODE_JALR};
 
         seq_state_n = S_IDLE;
-        ready_o = ready_i && !halt_i;
-        seq_last_o = 1'b1;
+        ready_fsm = ready_i && !halt_i;
+        seq_last_fsm = 1'b1;
       end
 
       default: begin
         // Should not happen
-        ready_o = 1'b1;
+        ready_fsm = 1'b1;
         seq_state_n = S_IDLE;
       end
     endcase
 
-    // If there is no valid output or we are killed: default to ready_o and set state to IDLE.
+    // If there is no valid output or we are killed: default to ready_fsm and set state to IDLE.
     // No reset if !valid while halted, as we may need to continue the sequence after being unhalted.
     if ((!valid_o && !halt_i) || kill_i) begin
-      ready_o = 1'b1;
+      ready_fsm = 1'b1;
       seq_state_n = S_IDLE;
     end
   end
+
+  // Bypass the sequencer FSM when there is an incoming tablejump pointer.
+  // Tablejump pointers are the last/non-first of a sequence.
+  // While waiting for a tablejump pointer, we still need to obey halt/kill inputs for the ready_o.
+  assign seq_last_o  = instr_is_tblj_ptr_i ? 1'b1               : seq_last_fsm;
+  assign seq_first_o = instr_is_tblj_ptr_i ? 1'b0               : seq_first_fsm;
+  assign ready_o     = instr_is_tblj_ptr_i ? (ready_i && !halt_i) || kill_i : ready_fsm;
 
 
 endmodule

--- a/rtl/include/cv32e40x_pkg.sv
+++ b/rtl/include/cv32e40x_pkg.sv
@@ -1351,7 +1351,8 @@ typedef struct packed {
     POPRET,
     POPRETZ,
     MVA01S,
-    MVSA01
+    MVSA01,
+    TBLJMP
   } seq_instr_e;
 
   typedef enum logic [3:0] {

--- a/sva/cv32e40x_if_stage_sva.sv
+++ b/sva/cv32e40x_if_stage_sva.sv
@@ -62,9 +62,11 @@ module cv32e40x_if_stage_sva
 
 
   // compressed_decoder and sequencer shall be mutually exclusive
+  // Excluding table jumps pointers as these will set seq_valid=1, but may
+  // contain a pointer that the compressed decoder is able to decode.
   a_compressed_seq_0:
   assert property (@(posedge clk) disable iff (!rst_n)
-                    seq_valid |-> illegal_c_insn)
+                    (seq_valid && !prefetch_is_tbljmp_ptr) |-> illegal_c_insn)
       else `uvm_error("if_stage", "Compressed decoder and sequencer not mutually exclusive.")
 
   a_compressed_seq_1:

--- a/sva/cv32e40x_if_stage_sva.sv
+++ b/sva/cv32e40x_if_stage_sva.sv
@@ -62,8 +62,8 @@ module cv32e40x_if_stage_sva
 
 
   // compressed_decoder and sequencer shall be mutually exclusive
-  // Excluding table jumps pointers as these will set seq_valid=1, but may
-  // contain a pointer that the compressed decoder is able to decode.
+  // Excluding table jumps pointers as these will set seq_valid=1 while the
+  // compressed decoder ignore pointers (illegal_c_insn will be 0)
   a_compressed_seq_0:
   assert property (@(posedge clk) disable iff (!rst_n)
                     (seq_valid && !prefetch_is_tbljmp_ptr) |-> illegal_c_insn)

--- a/sva/cv32e40x_sequencer_sva.sv
+++ b/sva/cv32e40x_sequencer_sva.sv
@@ -43,7 +43,7 @@ module cv32e40x_sequencer_sva
   input  seq_state_e     seq_state_q,
   input  logic           seq_last_o,
   input  seq_instr_e     seq_instr,
-  input  logic           instr_is_tblj_ptr_i,
+  input  logic           instr_is_tbljmp_ptr_i,
   input  logic           instr_is_clic_ptr_i,
   input  logic           seq_tbljmp_o
 );
@@ -159,7 +159,7 @@ module cv32e40x_sequencer_sva
   // Check that the sequencer does not decode any instructions from pointers
   a_ptr_illegal:
     assert property (@(posedge clk) disable iff (!rst_n)
-                    (instr_is_tblj_ptr_i || instr_is_clic_ptr_i)
+                    (instr_is_tbljmp_ptr_i || instr_is_clic_ptr_i)
                     |->
                     (seq_instr == INVALID_INST))
         else `uvm_error("sequencer", "Instruction should not be decoded from a pointer")
@@ -167,7 +167,7 @@ module cv32e40x_sequencer_sva
   // Check that the sequence counter does not count for tablejumps or tablejump pointers
   a_tbljmp_cnt:
     assert property (@(posedge clk) disable iff (!rst_n)
-                    (valid_o && ready_i && (seq_tbljmp_o || instr_is_tblj_ptr_i))
+                    (valid_o && ready_i && (seq_tbljmp_o || instr_is_tbljmp_ptr_i))
                     |=>
                     (instr_cnt_q == '0))
         else `uvm_error("sequencer", "Should not count when handling table jumps")

--- a/sva/cv32e40x_sequencer_sva.sv
+++ b/sva/cv32e40x_sequencer_sva.sv
@@ -42,7 +42,10 @@ module cv32e40x_sequencer_sva
   input  seq_t           instr_cnt_q,
   input  seq_state_e     seq_state_q,
   input  logic           seq_last_o,
-  input  seq_instr_e     seq_instr
+  input  seq_instr_e     seq_instr,
+  input  logic           instr_is_tblj_ptr_i,
+  input  logic           instr_is_clic_ptr_i,
+  input  logic           seq_tbljmp_o
 );
 
   // After kill, all state must be reset.
@@ -152,5 +155,21 @@ module cv32e40x_sequencer_sva
                     |->
                     (instr_cnt_q < 'd2))
         else `uvm_error("sequencer", "mva01s sequence too long")
+
+  // Check that the sequencer does not decode any instructions from pointers
+  a_ptr_illegal:
+    assert property (@(posedge clk) disable iff (!rst_n)
+                    (instr_is_tblj_ptr_i || instr_is_clic_ptr_i)
+                    |->
+                    (seq_instr == INVALID_INST))
+        else `uvm_error("sequencer", "Instruction should not be decoded from a pointer")
+
+  // Check that the sequence counter does not count for tablejumps or tablejump pointers
+  a_tbljmp_cnt:
+    assert property (@(posedge clk) disable iff (!rst_n)
+                    (valid_o && ready_i && (seq_tbljmp_o || instr_is_tblj_ptr_i))
+                    |=>
+                    (instr_cnt_q == '0))
+        else `uvm_error("sequencer", "Should not count when handling table jumps")
 endmodule
 


### PR DESCRIPTION
Tablejump pointers are handled within the sequencer, but bypass the internal FSM of the sequencer.

SEC clean for both values of ZC_EXT.