### PR TITLE
RVFI update. Sample data_addr and data_wdata in EX stage before write buffer

### DIFF
--- a/bhv/cv32e40x_rvfi.sv
+++ b/bhv/cv32e40x_rvfi.sv
@@ -71,8 +71,8 @@ module cv32e40x_rvfi
    input logic                                lsu_pmp_err_ex_i,
    input logic                                lsu_pma_err_atomic_ex_i,
    input logic [31:0]                         branch_target_ex_i,
-   input logic [31:0]                         data_addr_ex_i,
-   input logic [31:0]                         data_wdata_ex_i,
+   input logic [31:0]                         buffer_trans_addr_ex_i,
+   input logic [31:0]                         buffer_trans_wdata_ex_i,
    input logic                                lsu_split_q_ex_i,
 
    // WB probes
@@ -651,7 +651,7 @@ module cv32e40x_rvfi
   logic [31:0]       mhpmcounter_h_during_wb;
 
 
-  logic [63:0] data_wdata_ror; // Intermediate rotate signal, as direct part-select not supported in all tools
+  logic [63:0] buffer_trans_wdata_ror; // Intermediate rotate signal, as direct part-select not supported in all tools
 
   logic         wb_valid_adjusted;
   logic         wb_valid_subop;
@@ -1141,11 +1141,11 @@ module cv32e40x_rvfi
   end
 
   // Memory adddress
-  assign rvfi_mem_addr_d = data_addr_ex_i;
+  assign rvfi_mem_addr_d = buffer_trans_addr_ex_i;
 
   // Align Memory write data
-  assign rvfi_mem_wdata_d  = data_wdata_ror[31:0];
-  assign data_wdata_ror    = {data_wdata_ex_i, data_wdata_ex_i} >> (8*rvfi_mem_addr_d[1:0]); // Rotate right
+  assign rvfi_mem_wdata_d       = buffer_trans_wdata_ror[31:0];
+  assign buffer_trans_wdata_ror = {buffer_trans_wdata_ex_i, buffer_trans_wdata_ex_i} >> (8*rvfi_mem_addr_d[1:0]); // Rotate right
 
   // Destination Register
   // The rd_addr signal in rtl can contain contain unused non-zero values when not reading

--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -427,8 +427,8 @@ module cv32e40x_wrapper
          .lsu_pma_err_atomic_ex_i  ( core_i.load_store_unit_i.mpu_i.pma_i.atomic_access_i && // Todo: Consider making this a signal in the pma (no expressions allowed in module hookup)
                                     !core_i.load_store_unit_i.mpu_i.pma_i.pma_cfg_atomic                 ),
          .branch_target_ex_i       ( core_i.if_stage_i.branch_target_ex_i                                 ),
-         .data_addr_ex_i           ( core_i.load_store_unit_i.buffer_trans.addr                           ),
-         .data_wdata_ex_i          ( core_i.load_store_unit_i.buffer_trans.wdata                          ),
+         .buffer_trans_addr_ex_i   ( core_i.load_store_unit_i.buffer_trans.addr                           ),
+         .buffer_trans_wdata_ex_i  ( core_i.load_store_unit_i.buffer_trans.wdata                          ),
          .lsu_split_q_ex_i         ( core_i.load_store_unit_i.split_q                                     ),
 
          // WB Probes

--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -427,8 +427,8 @@ module cv32e40x_wrapper
          .lsu_pma_err_atomic_ex_i  ( core_i.load_store_unit_i.mpu_i.pma_i.atomic_access_i && // Todo: Consider making this a signal in the pma (no expressions allowed in module hookup)
                                     !core_i.load_store_unit_i.mpu_i.pma_i.pma_cfg_atomic                 ),
          .branch_target_ex_i       ( core_i.if_stage_i.branch_target_ex_i                                 ),
-         .data_addr_ex_i           ( core_i.data_addr_o                                                   ),
-         .data_wdata_ex_i          ( core_i.data_wdata_o                                                  ),
+         .data_addr_ex_i           ( core_i.load_store_unit_i.buffer_trans.addr                           ),
+         .data_wdata_ex_i          ( core_i.load_store_unit_i.buffer_trans.wdata                          ),
          .lsu_split_q_ex_i         ( core_i.load_store_unit_i.split_q                                     ),
 
          // WB Probes


### PR DESCRIPTION
Fix for https://github.com/openhwgroup/cv32e40s/issues/281

Signed-off-by: Oivind Ekelund <oivind.ekelund@silabs.com>