### PR TITLE
(Partial) fix for issue #325.

### DIFF
--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -267,6 +267,9 @@ module cv32e40x_wrapper
                 .ctrl_debug_mode_n                (core_i.controller_i.controller_fsm_i.debug_mode_n),
                 .ctrl_pending_debug               (core_i.controller_i.controller_fsm_i.pending_debug),
                 .ctrl_debug_allowed               (core_i.controller_i.controller_fsm_i.debug_allowed),
+                .ctrl_pending_nmi                 (core_i.controller_i.controller_fsm_i.pending_nmi),
+                .ctrl_pending_interrupt           (core_i.controller_i.controller_fsm_i.pending_interrupt),
+                .ctrl_interrupt_allowed           (core_i.controller_i.controller_fsm_i.interrupt_allowed),
                 .id_stage_multi_cycle_id_stall    (core_i.id_stage_i.multi_cycle_id_stall),
 
                 .id_stage_id_valid                (core_i.id_stage_i.id_valid_o),
@@ -278,6 +281,10 @@ module cv32e40x_wrapper
                 .alu_en_id_i                      (core_i.id_stage_i.alu_en),
                 .alu_jmpr_id_i                    (core_i.alu_jmpr_id),
                 .irq_ack                          (core_i.irq_ack),
+                .mie_n                            (core_i.cs_registers_i.mie_n),
+                .mie_we                           (core_i.cs_registers_i.mie_we),
+                .clic_irq_q                       (core_i.gen_clic_interrupt.clic_int_controller_i.clic_irq_q),
+                .clic_irq_level_q                 (core_i.gen_clic_interrupt.clic_int_controller_i.clic_irq_level_q),
                 .*);
 
   bind cv32e40x_sleep_unit:

--- a/rtl/cv32e40x_controller.sv
+++ b/rtl/cv32e40x_controller.sv
@@ -103,6 +103,8 @@ module cv32e40x_controller import cv32e40x_pkg::*;
   input  logic        csr_counter_read_i,         // A performance counter is read in CSR (EX)
   input  logic        csr_mnxti_read_i,           // MNXTI is read in CSR (EX)
 
+  input  logic        csr_irq_enable_write_i,     // An interrupt may be enabled by a write (WB)
+
   input logic [REGFILE_NUM_READ_PORTS-1:0] rf_re_id_i,
   input rf_addr_t     rf_raddr_id_i[REGFILE_NUM_READ_PORTS],
 
@@ -244,6 +246,7 @@ module cv32e40x_controller import cv32e40x_pkg::*;
 
     // From WB
     .wb_ready_i                 ( wb_ready_i               ),
+    .csr_irq_enable_write_i     ( csr_irq_enable_write_i   ),
 
     // Outputs
     .ctrl_byp_o                 ( ctrl_byp_o               )

--- a/rtl/cv32e40x_controller_fsm.sv
+++ b/rtl/cv32e40x_controller_fsm.sv
@@ -529,7 +529,8 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
     // Halting EX if minstret_stall occurs. Otherwise we would read the wrong minstret value
     // Also halting EX if an offloaded instruction in WB may cause an exception, such that a following offloaded
     // instruction can correctly receive commit_kill.
-    ctrl_fsm_o.halt_ex          = ctrl_byp_i.minstret_stall || ctrl_byp_i.xif_exception_stall;
+    // Halting EX when an instruction in WB may cause an interrupt to become pending.
+    ctrl_fsm_o.halt_ex          = ctrl_byp_i.minstret_stall || ctrl_byp_i.xif_exception_stall || ctrl_byp_i.irq_enable_stall;
     ctrl_fsm_o.halt_wb          = 1'b0;
 
     // By default no stages are killed

--- a/rtl/cv32e40x_core.sv
+++ b/rtl/cv32e40x_core.sv
@@ -224,6 +224,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
   logic [31:0] csr_rdata;
   logic csr_counter_read;
   logic csr_wr_in_wb_flush;
+  logic csr_irq_enable_write;
 
   privlvl_t     priv_lvl;
 
@@ -763,6 +764,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
     // To controller_bypass
     .csr_counter_read_o         ( csr_counter_read       ),
     .csr_mnxti_read_o           ( csr_mnxti_read         ),
+    .csr_irq_enable_write_o     ( csr_irq_enable_write   ),
 
     // Interface to CSRs (SRAM like)
     .csr_rdata_o                ( csr_rdata              ),
@@ -813,6 +815,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
 
     .csr_counter_read_i             ( csr_counter_read       ),
     .csr_mnxti_read_i               ( csr_mnxti_read         ),
+    .csr_irq_enable_write_i         ( csr_irq_enable_write   ),
 
     // From EX/WB pipeline
     .ex_wb_pipe_i                   ( ex_wb_pipe             ),

--- a/rtl/cv32e40x_cs_registers.sv
+++ b/rtl/cv32e40x_cs_registers.sv
@@ -93,7 +93,7 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
   input  logic [7:0]                    mnxti_irq_level_i,
   output logic                          clic_pa_valid_o,        // CSR read data is an address to a function pointer
   output logic [31:0]                   clic_pa_o,              // Address to CLIC function pointer
-  output logic                          csr_irq_enable_write_o, // An irq enable write is being performed in WB (mie or mstatus.mie)
+  output logic                          csr_irq_enable_write_o, // An irq enable write is being performed in WB
 
   // CSR write strobes
   output logic                          csr_wr_in_wb_flush_o,

--- a/rtl/cv32e40x_cs_registers.sv
+++ b/rtl/cv32e40x_cs_registers.sv
@@ -93,6 +93,7 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
   input  logic [7:0]                    mnxti_irq_level_i,
   output logic                          clic_pa_valid_o,        // CSR read data is an address to a function pointer
   output logic [31:0]                   clic_pa_o,              // Address to CLIC function pointer
+  output logic                          csr_irq_enable_write_o, // An irq enable write is being performed in WB (mie or mstatus.mie)
 
   // CSR write strobes
   output logic                          csr_wr_in_wb_flush_o,
@@ -1382,6 +1383,15 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
 
   // Output to controller to request pipeline flush
   assign csr_wr_in_wb_flush_o = jvt_wr_in_wb;
+
+  // Signal when an interrupt may become enabled due to a CSR write
+  generate
+    if (SMCLIC) begin : smclic_irq_en
+      assign csr_irq_enable_write_o = mstatus_we || priv_lvl_we || mintthresh_we || mintstatus_we;
+    end else begin : basic_irq_en
+      assign csr_irq_enable_write_o = mie_we || mstatus_we || priv_lvl_we;
+    end
+  endgenerate
 
   ////////////////////////////////////////////////////////////////////////
   //

--- a/rtl/include/cv32e40x_pkg.sv
+++ b/rtl/include/cv32e40x_pkg.sv
@@ -1209,6 +1209,7 @@ typedef struct packed {
   logic         deassert_we;            // Deassert write enable and special insn bits
   logic         id_stage_abort;         // Same signal as deassert_we, with better name for use in the controller.
   logic         xif_exception_stall;    // Stall (EX) if xif insn in WB can cause an exception
+  logic         irq_enable_stall;       // Stall (EX) if an interrupt may be enabled by the instruction in WB.
 } ctrl_byp_t;
 
 // Controller FSM outputs

--- a/sva/cv32e40x_controller_fsm_sva.sv
+++ b/sva/cv32e40x_controller_fsm_sva.sv
@@ -656,5 +656,13 @@ end // SMCLIC
                     |=>
                     sequence_interruptible)
     else `uvm_error("controller", "sequence_interruptible should be 1 after an exception has been taken.")
+
+  // No new exception may occur in WB unless wb was ready the cycle before
+  a_wb_ready_exception:
+  assert property (@(posedge clk) disable iff (!rst_n)
+                    (!wb_ready_i)
+                    |=>
+                    $stable(exception_in_wb))
+    else `uvm_error("controller", "New exception in WB without WB being ready.")
 endmodule
 

--- a/sva/cv32e40x_core_sva.sv
+++ b/sva/cv32e40x_core_sva.sv
@@ -37,6 +37,8 @@ module cv32e40x_core_sva
   input ctrl_fsm_t   ctrl_fsm,
   input logic [10:0] exc_cause,
   input logic [31:0] mie,
+  input logic [31:0] mie_n,
+  input logic        mie_we,
   input logic [31:0] mip,
   input dcsr_t       dcsr,
   input              if_id_pipe_t if_id_pipe,
@@ -46,6 +48,7 @@ module cv32e40x_core_sva
   input logic        ex_ready,
   input logic        irq_ack, // irq ack output
   input logic        irq_clic_shv, // ack'ed irq is a CLIC SHV
+  input logic        irq_req_ctrl, // Interrupt controller request an interrupt
   input ex_wb_pipe_t ex_wb_pipe,
   input logic        wb_valid,
   input logic        branch_taken_in_ex,
@@ -74,14 +77,19 @@ module cv32e40x_core_sva
   input logic        ctrl_debug_mode_n,
   input logic        ctrl_pending_debug,
   input logic        ctrl_debug_allowed,
+  input logic        ctrl_interrupt_allowed,
+  input logic        ctrl_pending_interrupt,
   input              ctrl_state_e ctrl_fsm_ns,
   input ctrl_byp_t   ctrl_byp,
+  input logic        ctrl_pending_nmi,
    // probed cs_registers signals
   input logic [31:0] cs_registers_mie_q,
   input logic [31:0] cs_registers_mepc_n,
   input mcause_t     cs_registers_csr_cause_i, // From controller
   input mcause_t     cs_registers_mcause_q,    // From cs_registers, flopped mcause
-  input mstatus_t    cs_registers_mstatus_q);
+  input mstatus_t    cs_registers_mstatus_q,
+  input logic        clic_irq_q,
+  input logic [7:0]  clic_irq_level_q);
 
 if (SMCLIC) begin
   property p_clic_mie_tieoff;
@@ -476,5 +484,54 @@ end
   a_tbljmp_stall: assert property(p_tbljmp_stall)
     else `uvm_error("core", "Table jump not stalled while CSR is written");
 
+if (SMCLIC) begin
+    // Check that a pending interrupt is taken as soon as possible after being enabled
+  property p_clic_enable;
+    @(posedge clk) disable iff (!rst_ni)
+    ( !irq_req_ctrl
+       ##1
+       irq_req_ctrl && $stable(clic_irq_q) && $stable(clic_irq_level_q) && !(ctrl_fsm.debug_mode || (dcsr.step && !dcsr.stepie))
+       |-> (ctrl_pending_interrupt && ctrl_interrupt_allowed));
+  endproperty;
+
+  a_clic_enable: assert property(p_clic_enable)
+    else `uvm_error("core", "Interrupt not taken soon enough after enabling");
+
+  // Check a pending interrupt that is disabled is actually not taken
+  property p_clic_disable;
+    @(posedge clk) disable iff (!rst_ni)
+    (  irq_req_ctrl
+        ##1
+        !irq_req_ctrl && $stable(clic_irq_q) && $stable(clic_irq_level_q)
+        |-> !(ctrl_pending_interrupt && ctrl_interrupt_allowed));
+  endproperty;
+
+  a_clic_disable: assert property(p_clic_disable)
+    else `uvm_error("core", "Interrupt taken after disabling");
+end else begin
+  // Check that a pending interrupt is taken as soon as possible after being enabled
+  property p_mip_mie_write_enable;
+    @(posedge clk) disable iff (!rst_ni)
+    ( !irq_req_ctrl
+       ##1
+       irq_req_ctrl && $stable(mip) && !(ctrl_fsm.debug_mode || (dcsr.step && !dcsr.stepie))
+       |-> (ctrl_pending_interrupt && ctrl_interrupt_allowed));
+  endproperty;
+
+  a_mip_mie_write_enable: assert property(p_mip_mie_write_enable)
+    else `uvm_error("core", "Interrupt not taken soon enough after enabling");
+
+  // Check a pending interrupt that is disabled is actually not taken
+  property p_mip_mie_write_disable;
+    @(posedge clk) disable iff (!rst_ni)
+    (  irq_req_ctrl
+        ##1
+        !irq_req_ctrl && $stable(mip)
+        |-> !(ctrl_pending_interrupt && ctrl_interrupt_allowed));
+  endproperty;
+
+  a_mip_mie_write_disable: assert property(p_mip_mie_write_disable)
+    else `uvm_error("core", "Interrupt taken after disabling");
+end
 endmodule // cv32e40x_core_sva
 


### PR DESCRIPTION
Halting EX stage if a CSR write in WB may enable interrupts and at the same time there is an LSU instruction in EX. Fix implemented for both CLIC and basic interrupt mode.

Issue can still occur when X_EXT=1. Fixing this would also need several other fixes for the X-interface.

Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>