### PR TITLE
Fix for issue #507

### DIFF
--- a/rtl/cv32e40x_controller.sv
+++ b/rtl/cv32e40x_controller.sv
@@ -79,6 +79,7 @@ module cv32e40x_controller import cv32e40x_pkg::*;
   input  logic [1:0]  lsu_err_wb_i,               // LSU bus error in WB stage
   input  logic        lsu_busy_i,                 // LSU is busy with outstanding transfers
   input  logic        lsu_interruptible_i,        // LSU may be interrupted
+  input  logic        lsu_valid_wb_i,             // LSU is valid in WB (factors in rvalid from either OBI bus or write buffer)
 
   // jump/branch signals
   input  logic        branch_decision_ex_i,       // branch decision signal from EX ALU
@@ -182,6 +183,7 @@ module cv32e40x_controller import cv32e40x_pkg::*;
     .wb_valid_i                  ( wb_valid_i               ),
     .last_op_wb_i                ( last_op_wb_i             ),
     .abort_op_wb_i               ( abort_op_wb_i            ),
+    .lsu_valid_wb_i              ( lsu_valid_wb_i           ),
 
     .lsu_interruptible_i         ( lsu_interruptible_i      ),
 

--- a/rtl/cv32e40x_controller_bypass.sv
+++ b/rtl/cv32e40x_controller_bypass.sv
@@ -144,7 +144,12 @@ module cv32e40x_controller_bypass import cv32e40x_pkg::*;
   // This is needed because the data bypass from EX uses csr_rdata, and for mnxti this is actually mstatus and not the result
   // that will be written to the register file. Could be optimized to only stall when the result from the CSR instruction is used in ID,
   // but the common usecase is a CSR access followed by a branch using the mnxti result in the RF, so it would likely stall in most cases anyway.
-  assign ctrl_byp_o.mnxti_stall = csr_mnxti_read_i;
+  assign ctrl_byp_o.mnxti_stall_id = csr_mnxti_read_i;
+
+  // Stall EX stage when an mnxti is in EX and an LSU instruction is in WB.
+  // This is needed to make sure that any external interrupt clearing (due to a LSU instruction) gets picked
+  // up correctly by the mnxti access.
+  assign ctrl_byp_o.mnxti_stall_ex = csr_mnxti_read_i && (ex_wb_pipe_i.lsu_en && ex_wb_pipe_i.instr_valid);
 
   genvar i;
   generate

--- a/rtl/cv32e40x_controller_bypass.sv
+++ b/rtl/cv32e40x_controller_bypass.sv
@@ -144,12 +144,12 @@ module cv32e40x_controller_bypass import cv32e40x_pkg::*;
   // This is needed because the data bypass from EX uses csr_rdata, and for mnxti this is actually mstatus and not the result
   // that will be written to the register file. Could be optimized to only stall when the result from the CSR instruction is used in ID,
   // but the common usecase is a CSR access followed by a branch using the mnxti result in the RF, so it would likely stall in most cases anyway.
-  assign ctrl_byp_o.mnxti_stall_id = csr_mnxti_read_i;
+  assign ctrl_byp_o.mnxti_id_stall = csr_mnxti_read_i;
 
   // Stall EX stage when an mnxti is in EX and an LSU instruction is in WB.
   // This is needed to make sure that any external interrupt clearing (due to a LSU instruction) gets picked
   // up correctly by the mnxti access.
-  assign ctrl_byp_o.mnxti_stall_ex = csr_mnxti_read_i && (ex_wb_pipe_i.lsu_en && ex_wb_pipe_i.instr_valid);
+  assign ctrl_byp_o.mnxti_ex_stall = csr_mnxti_read_i && (ex_wb_pipe_i.lsu_en && ex_wb_pipe_i.instr_valid);
 
   genvar i;
   generate

--- a/rtl/cv32e40x_controller_fsm.sv
+++ b/rtl/cv32e40x_controller_fsm.sv
@@ -525,7 +525,7 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
     //             Sequences:    If we need to halt for debug or interrupt not allowed due to a sequence, we must check if we can
     //                           actually halt the ID stage or not. Halting the same sequence that causes *_allowed to go to 0
     //                           may cause a deadlock.
-    ctrl_fsm_o.halt_id          = ctrl_byp_i.jalr_stall || ctrl_byp_i.load_stall || ctrl_byp_i.csr_stall || ctrl_byp_i.wfi_stall || ctrl_byp_i.mnxti_stall_id ||
+    ctrl_fsm_o.halt_id          = ctrl_byp_i.jalr_stall || ctrl_byp_i.load_stall || ctrl_byp_i.csr_stall || ctrl_byp_i.wfi_stall || ctrl_byp_i.mnxti_id_stall ||
       (((pending_interrupt && !interrupt_allowed) || (pending_nmi && !nmi_allowed) || (pending_nmi_early)) && debug_interruptible && id_stage_haltable) ||
       (pending_debug && !debug_allowed && id_stage_haltable);
 
@@ -534,7 +534,7 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
     // Also halting EX if an offloaded instruction in WB may cause an exception, such that a following offloaded
     // instruction can correctly receive commit_kill.
     // Halting EX when an instruction in WB may cause an interrupt to become pending.
-    ctrl_fsm_o.halt_ex          = ctrl_byp_i.minstret_stall || ctrl_byp_i.xif_exception_stall || ctrl_byp_i.irq_enable_stall || ctrl_byp_i.mnxti_stall_ex;
+    ctrl_fsm_o.halt_ex          = ctrl_byp_i.minstret_stall || ctrl_byp_i.xif_exception_stall || ctrl_byp_i.irq_enable_stall || ctrl_byp_i.mnxti_ex_stall;
     ctrl_fsm_o.halt_wb          = 1'b0;
 
     // By default no stages are killed
@@ -1032,7 +1032,7 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
     if (rst_n == 1'b0) begin
       interrupt_blanking_q <= 1'b0;
     end else begin
-      interrupt_blanking_q <= ex_wb_pipe_i.instr_valid && ex_wb_pipe_i.lsu_en && lsu_valid_wb_i;
+      interrupt_blanking_q <= ex_wb_pipe_i.instr_valid && ex_wb_pipe_i.lsu_en;
     end
   end
 

--- a/rtl/cv32e40x_core.sv
+++ b/rtl/cv32e40x_core.sv
@@ -851,6 +851,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .lsu_err_wb_i                   ( lsu_err_wb             ),
     .lsu_busy_i                     ( lsu_busy               ),
     .lsu_interruptible_i            ( lsu_interruptible      ),
+    .lsu_valid_wb_i                 ( lsu_valid_wb           ),
 
     // jump/branch control
     .branch_decision_ex_i           ( branch_decision_ex     ),

--- a/rtl/include/cv32e40x_pkg.sv
+++ b/rtl/include/cv32e40x_pkg.sv
@@ -1204,8 +1204,8 @@ typedef struct packed {
   logic         load_stall;             // Stall due to load operation
   logic         csr_stall;
   logic         wfi_stall;
-  logic         mnxti_stall_id;         // Stall ID due to mnxti CSR access in EX
-  logic         mnxti_stall_ex;         // Stall EX due to LSU instruction in WB
+  logic         mnxti_id_stall;         // Stall ID due to mnxti CSR access in EX
+  logic         mnxti_ex_stall;         // Stall EX due to LSU instruction in WB
   logic         minstret_stall;         // Stall due to minstret/h read in EX
   logic         deassert_we;            // Deassert write enable and special insn bits
   logic         id_stage_abort;         // Same signal as deassert_we, with better name for use in the controller.

--- a/rtl/include/cv32e40x_pkg.sv
+++ b/rtl/include/cv32e40x_pkg.sv
@@ -1204,7 +1204,8 @@ typedef struct packed {
   logic         load_stall;             // Stall due to load operation
   logic         csr_stall;
   logic         wfi_stall;
-  logic         mnxti_stall;            // Stall due to mnxti CSR access in EX
+  logic         mnxti_stall_id;         // Stall ID due to mnxti CSR access in EX
+  logic         mnxti_stall_ex;         // Stall EX due to LSU instruction in WB
   logic         minstret_stall;         // Stall due to minstret/h read in EX
   logic         deassert_we;            // Deassert write enable and special insn bits
   logic         id_stage_abort;         // Same signal as deassert_we, with better name for use in the controller.

--- a/sva/cv32e40x_clic_int_controller_sva.sv
+++ b/sva/cv32e40x_clic_int_controller_sva.sv
@@ -1,0 +1,83 @@
+// Copyright 2022 Silicon Labs, Inc.
+//
+// This file, and derivatives thereof are licensed under the
+// Solderpad License, Version 2.0 (the "License").
+//
+// Use of this file means you agree to the terms and conditions
+// of the license and are in full compliance with the License.
+//
+// You may obtain a copy of the License at:
+//
+//     https://solderpad.org/licenses/SHL-2.0/
+//
+// Unless required by applicable law or agreed to in writing, software
+// and hardware implementations thereof distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESSED OR IMPLIED.
+//
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+////////////////////////////////////////////////////////////////////////////////
+// Engineer:       Arjan Bink - arjan.bink@silabs.com                         //
+//                                                                            //
+// Additional contributions by:                                               //
+//                 Øystein Knauserud - oystein.knauserud@silabs.com           //
+//                                                                            //
+// Design Name:    cv32e40x_clic_int_controller_sva                           //
+// Project Name:   CV32E40X                                                   //
+// Language:       SystemVerilog                                              //
+//                                                                            //
+// Description:    Assertions reltated to the CLIC interrupt controller       //
+//                                                                            //
+////////////////////////////////////////////////////////////////////////////////
+
+module cv32e40x_clic_int_controller_sva
+  import uvm_pkg::*;
+  import cv32e40x_pkg::*;
+#(
+    parameter bit SMCLIC = 0
+  )
+
+  (
+   input logic        clk,
+   input logic        rst_n,
+
+   input logic        irq_req_ctrl_o,
+   input logic        clic_irq_q,
+   input logic [7:0]  clic_irq_level_q,
+
+   input logic        ctrl_pending_interrupt,
+   input logic        ctrl_interrupt_allowed,
+
+   input ctrl_fsm_t   ctrl_fsm,
+   input dcsr_t       dcsr
+
+   );
+
+
+  // Check that a pending interrupt is taken as soon as possible after being enabled
+   property p_clic_enable;
+    @(posedge clk) disable iff (!rst_n)
+    ( !irq_req_ctrl_o
+       ##1
+       irq_req_ctrl_o && $stable(clic_irq_q) && $stable(clic_irq_level_q) && !(ctrl_fsm.debug_mode || (dcsr.step && !dcsr.stepie))
+       |-> (ctrl_pending_interrupt && ctrl_interrupt_allowed));
+  endproperty;
+
+  a_clic_enable: assert property(p_clic_enable)
+    else `uvm_error("core", "Interrupt not taken soon enough after enabling");
+
+  // Check a pending interrupt that is disabled is actually not taken
+  property p_clic_disable;
+    @(posedge clk) disable iff (!rst_n)
+    (  irq_req_ctrl_o
+        ##1
+        !irq_req_ctrl_o && $stable(clic_irq_q) && $stable(clic_irq_level_q)
+        |-> !(ctrl_pending_interrupt && ctrl_interrupt_allowed));
+  endproperty;
+
+  a_clic_disable: assert property(p_clic_disable)
+    else `uvm_error("core", "Interrupt taken after disabling");
+endmodule // cv32e40x_cs_registers_sva
+

--- a/sva/cv32e40x_clic_int_controller_sva.sv
+++ b/sva/cv32e40x_clic_int_controller_sva.sv
@@ -19,10 +19,7 @@
 // limitations under the License.
 
 ////////////////////////////////////////////////////////////////////////////////
-// Engineer:       Arjan Bink - arjan.bink@silabs.com                         //
-//                                                                            //
-// Additional contributions by:                                               //
-//                 Øystein Knauserud - oystein.knauserud@silabs.com           //
+// Engineer:       Øystein Knauserud - oystein.knauserud@silabs.com           //
 //                                                                            //
 // Design Name:    cv32e40x_clic_int_controller_sva                           //
 // Project Name:   CV32E40X                                                   //
@@ -35,10 +32,6 @@
 module cv32e40x_clic_int_controller_sva
   import uvm_pkg::*;
   import cv32e40x_pkg::*;
-#(
-    parameter bit SMCLIC = 0
-  )
-
   (
    input logic        clk,
    input logic        rst_n,

--- a/sva/cv32e40x_core_sva.sv
+++ b/sva/cv32e40x_core_sva.sv
@@ -72,7 +72,6 @@ module cv32e40x_core_sva
   input logic        data_req_o,
   input logic        data_we_o,
   input logic [5:0]  data_atop_o,
-  input logic        data_rvalid_i,
 
   // probed controller signals
   input logic        ctrl_debug_mode_n,

--- a/sva/cv32e40x_cs_registers_sva.sv
+++ b/sva/cv32e40x_cs_registers_sva.sv
@@ -34,9 +34,17 @@ module cv32e40x_cs_registers_sva
    input logic        rst_n,
    input ctrl_fsm_t   ctrl_fsm_i,
    input id_ex_pipe_t id_ex_pipe_i,
+   input ex_wb_pipe_t ex_wb_pipe_i,
    input logic [31:0] csr_rdata_o,
    input logic        csr_we_int,
-   input logic [1:0]  mtvec_mode_o
+   input logic [1:0]  mtvec_mode_o,
+   input logic        wb_valid_i,
+   input logic        mnxti_we,
+   input logic        mintstatus_we,
+   input logic        mcause_we,
+   input logic [31:0] clic_pa_o,
+   input logic        clic_pa_valid_o
+
    );
 
 
@@ -53,6 +61,19 @@ module cv32e40x_cs_registers_sva
     assert property (@(posedge clk) disable iff (!rst_n)
                     1'b1 |-> mtvec_mode_o == 2'b11)
       else `uvm_error("cs_registers", "mtvec_mode is not 2'b11 in CLIC mode")
+
+  // Accesses to MNXTI are stalled in EX if there is a LSU instruction in WB.
+  // Thus no mnxti should be in WB (clic_pa_valid_o) the cycle after an LSU instruction
+  // is done in WB.
+  property p_no_mnxti_after_lsu;
+    @(posedge clk) disable iff (!rst_n)
+    (  wb_valid_i && ex_wb_pipe_i.lsu_en && ex_wb_pipe_i.instr_valid
+       |=>
+       !clic_pa_valid_o);
+  endproperty;
+
+  a_no_mnxti_after_lsu: assert property(p_no_mnxti_after_lsu)
+    else `uvm_error("core", "Mnxti should not we in WB the cycle after an LSU instruction");
   end
 endmodule // cv32e40x_cs_registers_sva
 


### PR DESCRIPTION
Blanking interrupts for one cycle after a Load/Store instruction leaves WB.

Refactored some CLIC assertions (new file for clic_int_controller_sva)