### PR TITLE
Fix for issue #498.

### DIFF
--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -202,7 +202,8 @@ module cv32e40x_wrapper
   bind cv32e40x_controller_fsm:
     core_i.controller_i.controller_fsm_i
       cv32e40x_controller_fsm_sva
-        #(.X_EXT(X_EXT))
+        #(.X_EXT(X_EXT),
+          .SMCLIC(SMCLIC))
         controller_fsm_sva   (
                               .lsu_outstanding_cnt          (core_i.load_store_unit_i.cnt_q),
                               .rf_we_wb_i                   (core_i.wb_stage_i.rf_we_wb_o  ),

--- a/rtl/cv32e40x_controller.sv
+++ b/rtl/cv32e40x_controller.sv
@@ -93,12 +93,14 @@ module cv32e40x_controller import cv32e40x_pkg::*;
   input  logic [1:0]  irq_clic_priv_i,
 
   input logic  [1:0]  mtvec_mode_i,
+  input  mcause_t     mcause_i,
 
   input  logic        csr_wr_in_wb_flush_i,
 
   // Debug Signal
   input  logic        debug_req_i,
   input  dcsr_t       dcsr_i,
+
 
   // CSR raddr in ex
   input  logic        csr_counter_read_i,         // A performance counter is read in CSR (EX)
@@ -203,6 +205,7 @@ module cv32e40x_controller import cv32e40x_pkg::*;
     // Debug Signal
     .debug_req_i                 ( debug_req_i              ),
     .dcsr_i                      ( dcsr_i                   ),
+    .mcause_i                    ( mcause_i                 ),
 
     // Fencei flush handshake
     .fencei_flush_ack_i          ( fencei_flush_ack_i       ),

--- a/rtl/cv32e40x_core.sv
+++ b/rtl/cv32e40x_core.sv
@@ -866,6 +866,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
 
     // From CSR registers
     .mtvec_mode_i                   ( mtvec_mode             ),
+    .mcause_i                       ( mcause                 ),
 
     // CSR write strobes
     .csr_wr_in_wb_flush_i           ( csr_wr_in_wb_flush     ),

--- a/sva/cv32e40x_prefetch_unit_sva.sv
+++ b/sva/cv32e40x_prefetch_unit_sva.sv
@@ -53,7 +53,6 @@ module cv32e40x_prefetch_unit_sva import cv32e40x_pkg::*;
   a_branch_implies_req : assert property(p_branch_implies_req)
     else `uvm_error("prefetch_buffer", "Assertion a_branch_implies_req failed")
 
-
 if (SMCLIC) begin
   // Shall not fetch anything between pointer fetch and the actual instruction fetch
   // based on the pointer.


### PR DESCRIPTION
When an mret is executed when mcause.minhv==1, the controller will allow EX and WB to flush before restarting the pointer fetch, using the value in mepc as value for the pointer location.

Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>