### PR TITLE
"Fix" for issue #494.

### DIFF
--- a/sva/cv32e40x_rvfi_sva.sv
+++ b/sva/cv32e40x_rvfi_sva.sv
@@ -65,14 +65,11 @@ module cv32e40x_rvfi_sva
   // but since there can be an infinite delay between irq_ack and rvfi_intr (e.g. because of bus stalls), we're settling for asserting
   // that irq_ack leads to RVFI capturing a trap (in_trap[IF_STAGE] = 1)
 
-  // todo: for CLIC, the irq ack comes when the pointer fetch is initiated
-  // We should probably set in_trap.intr for the first intstruction of the handler, which comes after the second fetch.
-  if (!SMCLIC) begin
-    a_irq_ack_rvfi_capture :
-      assert property (@(posedge clk_i) disable iff (!rst_ni)
-                      (irq_ack |=> in_trap[STAGE_IF].intr))
-        else `uvm_error("rvfi", "irq_ack not captured by RVFI")
-  end
+  a_irq_ack_rvfi_capture :
+    assert property (@(posedge clk_i) disable iff (!rst_ni)
+                    (irq_ack |=> in_trap[STAGE_IF].intr))
+      else `uvm_error("rvfi", "irq_ack not captured by RVFI")
+
 
 
   // Helper signal, indicating debug cause


### PR DESCRIPTION
The assertion mentioned in the issue is now included regardless of the SMCLIC parameter. Assertion passes for both SMCLIC=0 and SMCLIC=1.

The cause for the failing assertion has already been fixed in earlier commits.

Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>