### PR TITLE
Keeping WFI in WB until SLEEP mode is exited

### DIFF
--- a/sva/cv32e40x_controller_fsm_sva.sv
+++ b/sva/cv32e40x_controller_fsm_sva.sv
@@ -418,11 +418,12 @@ endgenerate
                      (ex_wb_pipe_i.instr_valid && ex_wb_pipe_i.lsu_en) |-> !debug_allowed)
       else `uvm_error("controller", "debug_allowed high while LSU is in WB")
 
-  // Ensure bubbles in EX and WB while in SLEEP mode
+  // Ensure bubble in EX while in SLEEP mode.
+  // WFI instruction will be in WB
   a_wfi_bubbles:
     assert property (@(posedge clk) disable iff (!rst_n)
-                      (ctrl_fsm_cs == SLEEP) |-> !(ex_wb_pipe_i.instr_valid || id_ex_pipe_i.instr_valid))
-      else `uvm_error("controller", "EX and WB stages not empty while in SLEEP state")
+                      (ctrl_fsm_cs == SLEEP) |-> !(id_ex_pipe_i.instr_valid))
+      else `uvm_error("controller", "EX stage not empty while in SLEEP state")
 
   // Assert correct exception cause for mpu load faults (checks default of cause mux)
   a_mpu_re_cause_mux:


### PR DESCRIPTION
Keeping WFI active in WB during SLEEP state until we wake up instead of retiring (wb_valid) the WFI when the core enters SLEEP.
This allows cleanup of the wb_valid/rvfi_valid signals inside RVFI as well.

SEC clean when assuming correct OBI (no rvalid before req)

Prerequisite to adding the WFE instruction.

Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>