### PR TITLE
Splitting halt_wb to fix timing issues when waking from SLEEP

### DIFF
--- a/rtl/cv32e40x_cs_registers.sv
+++ b/rtl/cv32e40x_cs_registers.sv
@@ -257,6 +257,8 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
   logic [31:0]                  mhpmcounter_write_increment;                    // Write increment of mhpmcounter_q
 
   // Local instr_valid for write portion (WB)
+  // Not factoring in ctrl_fsm_i.halt_limited_wb. This signal is only set during SLEEP mode, and while in SLEEP
+  // there cannot be any CSR instruction in WB.
   assign instr_valid = ex_wb_pipe_i.instr_valid && !ctrl_fsm_i.kill_wb && !ctrl_fsm_i.halt_wb;
 
   // CSR access. Read in EX, write in WB

--- a/rtl/cv32e40x_wb_stage.sv
+++ b/rtl/cv32e40x_wb_stage.sv
@@ -86,7 +86,9 @@ module cv32e40x_wb_stage import cv32e40x_pkg::*;
   logic                 xif_waiting;
   logic                 xif_exception;
 
-  assign instr_valid = ex_wb_pipe_i.instr_valid && !ctrl_fsm_i.kill_wb && !ctrl_fsm_i.halt_wb;
+  // WB stage has two halt sources, ctrl_fsm_i.halt_wb and ctrl_fsm_i.halt_limited_wb. The limited halt is only set during
+  // the SLEEP state, and is used to prevent timing paths from interrupt inputs to obi outputs when waking up from SLEEP.
+  assign instr_valid = ex_wb_pipe_i.instr_valid && !ctrl_fsm_i.kill_wb && !ctrl_fsm_i.halt_wb && !ctrl_fsm_i.halt_limited_wb;
 
   assign lsu_exception = (lsu_mpu_status_i != MPU_OK);
 
@@ -129,7 +131,8 @@ module cv32e40x_wb_stage import cv32e40x_pkg::*;
   //////////////////////////////////////////////////////////////////////////////
   // Stage ready/valid
 
-  assign wb_ready_o = ctrl_fsm_i.kill_wb || (lsu_ready_i && !xif_waiting && !ctrl_fsm_i.halt_wb);
+  // Using both ctrl_fsm_i.halt_wb and ctrl_fsm_i.halt_limited_wb to halt.
+  assign wb_ready_o = ctrl_fsm_i.kill_wb || (lsu_ready_i && !xif_waiting && !ctrl_fsm_i.halt_wb && !ctrl_fsm_i.halt_limited_wb);
 
   // wb_valid
   //

--- a/rtl/include/cv32e40x_pkg.sv
+++ b/rtl/include/cv32e40x_pkg.sv
@@ -1269,6 +1269,7 @@ typedef struct packed {
   logic        halt_id; // Halt ID stage
   logic        halt_ex; // Halt EX stage
   logic        halt_wb; // Halt WB stage
+  logic        halt_limited_wb; // Halt WB stage during SLEEP, but not cs_registers
 
   // Kill signals
   logic        kill_if; // Kill IF stage

--- a/sva/cv32e40x_controller_fsm_sva.sv
+++ b/sva/cv32e40x_controller_fsm_sva.sv
@@ -428,6 +428,12 @@ endgenerate
                       (ctrl_fsm_cs == SLEEP) |-> !(id_ex_pipe_i.instr_valid))
       else `uvm_error("controller", "EX stage not empty while in SLEEP state")
 
+  // When halt_limited_wb is asserted, there can only be WFI instruction in WB
+  a_halt_limited_wfi:
+    assert property (@(posedge clk) disable iff (!rst_n)
+                      (ctrl_fsm_o.halt_limited_wb) |-> (ex_wb_pipe_i.sys_en && ex_wb_pipe_i.sys_wfi_insn && ex_wb_pipe_i.instr_valid))
+      else `uvm_error("controller", "No WFI in WB while halt_limited_wb is asserted")
+
   // Check that the pipeline is interruptible when we wake up from SLEEP
   a_wakeup_interruptible:
     assert property (@(posedge clk) disable iff (!rst_n)

--- a/sva/cv32e40x_cs_registers_sva.sv
+++ b/sva/cv32e40x_cs_registers_sva.sv
@@ -129,5 +129,14 @@ module cv32e40x_cs_registers_sva
       else `uvm_error("cs_registers", "Mscratch not written by mscratchcswl");
 
   end
+
+  // Check that no csr instruction can be in WB during sleep when ctrl_fsm.halt_limited_wb is set
+  property p_halt_limited_wb;
+    @(posedge clk) disable iff (!rst_n)
+    (  ctrl_fsm_i.halt_limited_wb |-> !(ex_wb_pipe_i.csr_en && ex_wb_pipe_i.instr_valid));
+  endproperty;
+
+  a_halt_limited_wb: assert property(p_halt_limited_wb)
+    else `uvm_error("cs_registers", "CSR in WB while halt_limited_wb is set");
 endmodule
 


### PR DESCRIPTION
Split ctrl_fsm_o.halt_wb in two, with ctrl_fsm_o.halt_wb acting as normal for all cases except during sleep. During sleep, ctrl_fsm_o.halt_limited_wb will be used to make sure the WB stage does not retire any instructions.

Assertions were added to make sure no CSR instruction can be in WB while halt_limited_wb is set.

SEC clean.
Fixes timing issues.

Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>