### PR TITLE
Fix for missing rvfi_intr on CLIC SHV interrupts.

### DIFF
--- a/bhv/cv32e40x_rvfi.sv
+++ b/bhv/cv32e40x_rvfi.sv
@@ -42,6 +42,7 @@ module cv32e40x_rvfi
    input logic [31:0]                         prefetch_addr_if_i,
    input logic                                prefetch_compressed_if_i,
    input inst_resp_t                          prefetch_instr_if_i,
+   input logic                                clic_ptr_if_i,
 
    // ID probes
    input logic                                id_valid_i,
@@ -867,7 +868,12 @@ module cv32e40x_rvfi
         debug_cause[STAGE_ID] <= debug_cause[STAGE_IF];
 
         // Clear captured events when last operation exits IF
-        if (last_op_if_i || abort_op_if_i) begin
+        // Exception for clic pointers:
+        //   - CLIC pointers are seen as single operation (first_op && last_op),
+        //     but we still need the in_trap attached to the pointer target, which is
+        //     only fetched when the CLIC pointer is in ID. Thus we must not clear in_trap
+        //     when the pointer goes from IF to ID.
+        if ((last_op_if_i || abort_op_if_i) && !clic_ptr_if_i) begin
           in_trap    [STAGE_IF] <= 1'b0;
           debug_cause[STAGE_IF] <= '0;
         end

--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -423,6 +423,7 @@ endgenerate
          .prefetch_addr_if_i       ( core_i.if_stage_i.prefetch_unit_i.prefetch_addr_o                    ),
          .prefetch_compressed_if_i ( core_i.if_stage_i.instr_compressed                                   ),
          .prefetch_instr_if_i      ( core_i.if_stage_i.prefetch_unit_i.prefetch_instr_o                   ),
+         .clic_ptr_if_i            ( core_i.if_stage_i.prefetch_is_clic_ptr                               ),
 
          // ID Probes
          .id_valid_i               ( core_i.id_stage_i.id_valid_o                                         ),

--- a/sva/cv32e40x_rvfi_sva.sv
+++ b/sva/cv32e40x_rvfi_sva.sv
@@ -70,6 +70,21 @@ module cv32e40x_rvfi_sva
                     (irq_ack |=> in_trap[STAGE_IF].intr))
       else `uvm_error("rvfi", "irq_ack not captured by RVFI")
 
+  // Every irq_ack shall cause rvfi_intr on next rvfi_valid
+  property p_every_ack_followed_by_rvfi_intr;
+    irq_ack ##1 rvfi_valid[->1]
+      |->
+        rvfi_intr.intr
+    or
+        rvfi_trap.debug
+    or
+        rvfi_trap.exception;
+  endproperty : p_every_ack_followed_by_rvfi_intr
+
+  a_every_ack_followed_by_rvfi_intr: assert property (p_every_ack_followed_by_rvfi_intr)
+  else
+    `uvm_error("rvfi",
+      $sformatf("Every irq_ack should be followed by the corresponding rvfi_intr"));
 
 
   // Helper signal, indicating debug cause

--- a/sva/cv32e40x_rvfi_sva.sv
+++ b/sva/cv32e40x_rvfi_sva.sv
@@ -74,11 +74,7 @@ module cv32e40x_rvfi_sva
   property p_every_ack_followed_by_rvfi_intr;
     irq_ack ##1 rvfi_valid[->1]
       |->
-        rvfi_intr.intr
-    or
-        rvfi_trap.debug
-    or
-        rvfi_trap.exception;
+        rvfi_intr.intr;
   endproperty : p_every_ack_followed_by_rvfi_intr
 
   a_every_ack_followed_by_rvfi_intr: assert property (p_every_ack_followed_by_rvfi_intr)


### PR DESCRIPTION
Updated RVFI to not clear in_trap in IF when a CLIC pointers goes from ID to ID. Fixes issue #300 on CV32E40S.

Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>