### PR TITLE
Fix for issue #497

### DIFF
--- a/bhv/cv32e40x_rvfi.sv
+++ b/bhv/cv32e40x_rvfi.sv
@@ -91,6 +91,7 @@ module cv32e40x_rvfi
    input logic [4:0]                          rf_addr_wb_i,
    input logic [31:0]                         rf_wdata_wb_i,
    input logic [31:0]                         lsu_rdata_wb_i,
+   input logic                                clic_ptr_wb_i,
 
    // PC
    input logic [31:0]                         branch_addr_n_i,
@@ -788,8 +789,9 @@ module cv32e40x_rvfi
   // WFI instructions retire when their wake-up condition is present.
   // The wake-up condition is only checked in the SLEEP state of the controller FSM.
   // Other instructions retire when their last suboperation is done in WB.
-  assign wb_valid_subop    = wb_valid_i;
-  assign wb_valid_lastop   = wb_valid_i && (last_op_wb_i || abort_op_wb_i);
+  // CLIC pointers set wb_valid, but are not instructions and shall not cause rvfi_valid.
+  assign wb_valid_subop    = wb_valid_i && !clic_ptr_wb_i;
+  assign wb_valid_lastop   = wb_valid_i && (last_op_wb_i || abort_op_wb_i) && !clic_ptr_wb_i;
 
 
   // Pipeline stage model //

--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -473,6 +473,7 @@ endgenerate
          .rf_wdata_wb_i            ( core_i.wb_stage_i.rf_wdata_wb_o                                      ),
          .lsu_rdata_wb_i           ( core_i.load_store_unit_i.lsu_rdata_1_o                               ),
          .abort_op_wb_i            ( core_i.wb_stage_i.abort_op_o                                         ),
+         .clic_ptr_wb_i            ( core_i.wb_stage_i.ex_wb_pipe_i.instr_meta.clic_ptr                   ),
 
          .branch_addr_n_i          ( core_i.if_stage_i.branch_addr_n                                      ),
 

--- a/rtl/cv32e40x_if_stage.sv
+++ b/rtl/cv32e40x_if_stage.sv
@@ -302,13 +302,13 @@ module cv32e40x_if_stage import cv32e40x_pkg::*;
 
   // Sequenced instructions set last_op from the sequencer.
   // Any other instruction will be single operation, and gets last_op=1.
-  // todo: Factor CLIC pointers?
+  // CLIC pointers are single operation with first_op == last_op == 1
   assign last_op_o = seq_valid ? seq_last : 1'b1; // Any other regular instructions are single operation.
 
   // Flag first operation of a sequence.
   // Any sequenced instructions use the seq_first from the sequencer.
   // Any other instruction will be single operation, and gets first_op=1.
-  // todo: factor in CLIC pointers?
+  // CLIC pointers are single operation with first_op == last_op == 1
   assign first_op_o = seq_valid ? seq_first : 1'b1; // Any other regular instructions are single operation.
 
 

--- a/rtl/cv32e40x_wb_stage.sv
+++ b/rtl/cv32e40x_wb_stage.sv
@@ -146,7 +146,7 @@ module cv32e40x_wb_stage import cv32e40x_pkg::*;
                      ( ex_wb_pipe_i.lsu_en && lsu_valid_i)        // LSU instructions have valid result based on data_rvalid_i
                                                                   // todo: ideally a similar line is added here that delays signaling wb_valid until a WFI really retires.
                                                                   // This should be checked for bad timing paths. Currently RVFI contains a wb_valid_adjusted signal/hack to achieve the same
-                    ) && !ex_wb_pipe_i.instr_meta.clic_ptr && instr_valid;
+                    ) && instr_valid;
 
   // Letting all suboperations signal wb_valid
   assign wb_valid_o = wb_valid;


### PR DESCRIPTION
CLIC pointers will now set wb_valid. RVFI will not set rvfi_valid for CLIC pointers.

Not SEC clean:
  1: A performance counter event raises  when wb_valid == 0.
  2: Single step entry when pointer fetch fails did not happen before (bug).
     - Now single step is entered once the faulted pointer reaches WB (dpc == first instruction of exception handler).

Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>