### PR TITLE
Mscratchcsw[l] illegal if rs1==x0 with CSRRW.

### DIFF
--- a/rtl/cv32e40x_i_decoder.sv
+++ b/rtl/cv32e40x_i_decoder.sv
@@ -365,7 +365,7 @@ module cv32e40x_i_decoder import cv32e40x_pkg::*;
           unique case (instr_rdata_i[13:12])
             2'b01: begin
               // Detect true CSRRW with rd != x0 for use with mscratchcsw[l] accesses
-              if ((instr_rdata_i[14] != 1'b1) && (instr_rdata_i[11:7] != 5'b0)) begin
+              if ((instr_rdata_i[14] != 1'b1) && (instr_rdata_i[11:7] != 5'b0) && (instr_rdata_i[19:15] != 5'b0)) begin
                 decoder_ctrl_o.csr_op = CSR_OP_CSRRW;
               end else begin
                 decoder_ctrl_o.csr_op = CSR_OP_WRITE;


### PR DESCRIPTION
Updated CSR access to mscratchcsw[l] to also flag illegal instruction if rs1 == x0.

Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>