### PR TITLE
Updates related to PR #680

### DIFF
--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -63,6 +63,7 @@ module cv32e40x_wrapper
   parameter int          NUM_MHPMCOUNTERS             = 1,
   parameter bit          SMCLIC                       = 0,
   parameter int          SMCLIC_ID_WIDTH              = 5,
+  parameter int          SMCLIC_INTTHRESHBITS         = 8,
   parameter int          DBG_NUM_TRIGGERS             = 1,
   parameter int          PMA_NUM_REGIONS              = 0,
   parameter pma_cfg_t    PMA_CFG[PMA_NUM_REGIONS-1:0] = '{default:PMA_R_DEFAULT}
@@ -675,6 +676,7 @@ endgenerate
           .NUM_MHPMCOUNTERS      ( NUM_MHPMCOUNTERS      ),
           .SMCLIC                ( SMCLIC                ),
           .SMCLIC_ID_WIDTH       ( SMCLIC_ID_WIDTH       ),
+          .SMCLIC_INTTHRESHBITS  ( SMCLIC_INTTHRESHBITS  ),
           .DBG_NUM_TRIGGERS      ( DBG_NUM_TRIGGERS      ),
           .PMA_NUM_REGIONS       ( PMA_NUM_REGIONS       ),
           .PMA_CFG               ( PMA_CFG               ))

--- a/rtl/cv32e40x_core.sv
+++ b/rtl/cv32e40x_core.sv
@@ -41,6 +41,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
   parameter pma_cfg_t                   PMA_CFG[PMA_NUM_REGIONS-1:0]            = '{default:PMA_R_DEFAULT},
   parameter bit                         SMCLIC                                  = 0,
   parameter int                         SMCLIC_ID_WIDTH                         = 5,
+  parameter int                         SMCLIC_INTTHRESHBITS                    = 8,
   parameter bit                         X_EXT                                   = 0,
   parameter int                         X_NUM_RS                                = 2,
   parameter int                         X_ID_WIDTH                              = 4,
@@ -722,6 +723,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .ZC_EXT                     ( ZC_EXT                 ),
     .SMCLIC                     ( SMCLIC                 ),
     .SMCLIC_ID_WIDTH            ( SMCLIC_ID_WIDTH        ),
+    .SMCLIC_INTTHRESHBITS       ( SMCLIC_INTTHRESHBITS   ),
     .DBG_NUM_TRIGGERS           ( DBG_NUM_TRIGGERS       ),
     .NUM_MHPMCOUNTERS           ( NUM_MHPMCOUNTERS       ),
     .MTVT_ADDR_WIDTH            ( MTVT_ADDR_WIDTH        )

--- a/rtl/cv32e40x_core.sv
+++ b/rtl/cv32e40x_core.sv
@@ -482,7 +482,8 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .B_EXT                        ( B_EXT                     ),
     .M_EXT                        ( M_EXT                     ),
     .X_EXT                        ( X_EXT                     ),
-    .REGFILE_NUM_READ_PORTS       ( REGFILE_NUM_READ_PORTS    )
+    .REGFILE_NUM_READ_PORTS       ( REGFILE_NUM_READ_PORTS    ),
+    .SMCLIC                       ( SMCLIC                    )
   )
   id_stage_i
   (

--- a/rtl/cv32e40x_cs_registers.sv
+++ b/rtl/cv32e40x_cs_registers.sv
@@ -656,9 +656,10 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
     priv_lvl_n    = priv_lvl_rdata;
     priv_lvl_we   = 1'b0;
 
-    mtvec_n.addr  = csr_mtvec_init_i ? mtvec_addr_i[31:7] : csr_wdata_int[31:7];
-    mtvec_n.zero0 = mtvec_rdata.zero0;
-    mtvec_we      = csr_mtvec_init_i;
+    mtvec_n.addr    = csr_mtvec_init_i ? mtvec_addr_i[31:7] : csr_wdata_int[31:7];
+    mtvec_n.zero0   = mtvec_rdata.zero0;
+    mtvec_n.submode = mtvec_rdata.submode;
+    mtvec_we        = csr_mtvec_init_i;
 
     if (SMCLIC) begin
       mtvec_n.mode             = mtvec_rdata.mode; // mode is WARL 0x3 when using CLIC

--- a/rtl/cv32e40x_cs_registers.sv
+++ b/rtl/cv32e40x_cs_registers.sv
@@ -418,7 +418,7 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
           // Safe to use mcause_rdata here (EX timing), as there is a generic stall of the ID stage
           // whenever a CSR instruction follows another CSR instruction. Alternative implementation using
           // a local forward of mcause_rdata is identical (SEC).
-          if (mcause_rdata.mpp != PRIV_LVL_M) begin
+          if (mstatus_rdata.mpp != PRIV_LVL_M) begin
             // Return mscratch for writing to GPR
             csr_rdata_int = mscratch_rdata;
           end else begin

--- a/rtl/cv32e40x_cs_registers.sv
+++ b/rtl/cv32e40x_cs_registers.sv
@@ -213,8 +213,8 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
   logic [31:0]                  mscratchcswl_n, mscratchcswl_rdata;
   logic                         mscratchcswl_we;
 
-  logic [31:0]                  mclicbase_q, mclicbase_n, mclicbase_rdata;
-  logic                         mclicbase_we;
+  logic [31:0]                  mclicbase_n, mclicbase_rdata;                   // No CSR module instance
+  logic                         mclicbase_we;                                   // Not used in RTL (used by RVFI)
 
   logic [31:0]                  mip_n, mip_rdata;                               // No CSR module instance
   logic                         mip_we;                                         // Not used in RTL (used by RVFI)
@@ -1288,19 +1288,6 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
         .rd_data_o      ( mintthresh_q          )
       );
 
-      cv32e40x_csr
-      #(
-        .WIDTH      (32),
-        .RESETVALUE (32'h0)
-      )
-      mclicbase_csr_i
-      (
-        .clk            ( clk                   ),
-        .rst_n          ( rst_n                 ),
-        .wr_data_i      ( mclicbase_n           ),
-        .wr_en_i        ( mclicbase_we          ),
-        .rd_data_o      ( mclicbase_q           )
-      );
 
     end else begin : basic_mode_csrs
 
@@ -1338,8 +1325,6 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
 
       assign mintthresh_q        = 32'h0;
 
-      assign mclicbase_q         = 32'h0;
-
     end
   endgenerate
 
@@ -1359,7 +1344,7 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
   assign mintstatus_rdata   = mintstatus_q;
   // Implemented threshold bits are left justified, unimplemented bits are tied to 1.
   assign mintthresh_rdata   = {mintthresh_q[31:(7-(SMCLIC_INTTHRESHBITS-1))], {(8-SMCLIC_INTTHRESHBITS) {1'b1}}};
-  assign mclicbase_rdata    = mclicbase_q;
+  assign mclicbase_rdata    = 32'h00000000;
   assign mie_rdata          = mie_q;
 
   // mnxti_rdata breaks the regular convension for CSRs. The read data used for read-modify-write is the mstatus_rdata,
@@ -1771,6 +1756,6 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
 
   assign unused_signals = tselect_we | tinfo_we | tcontrol_we | mstatush_we | misa_we | mip_we | mvendorid_we |
     marchid_we | mimpid_we | mhartid_we | mconfigptr_we | mtval_we | (|mnxti_n) | mscratchcsw_we | mscratchcswl_we |
-    (|mscratchcsw_rdata) | (|mscratchcswl_rdata) | (|mscratchcsw_n) | (|mscratchcswl_n);
+    (|mscratchcsw_rdata) | (|mscratchcswl_rdata) | (|mscratchcsw_n) | (|mscratchcswl_n) | (|mclicbase_n) | mclicbase_we;
 
 endmodule

--- a/rtl/cv32e40x_decoder.sv
+++ b/rtl/cv32e40x_decoder.sv
@@ -30,7 +30,8 @@ module cv32e40x_decoder import cv32e40x_pkg::*;
   parameter bit          A_EXT                  = 0,
   parameter b_ext_e      B_EXT                  = B_NONE,
   parameter m_ext_e      M_EXT                  = M,
-  parameter              DEBUG_TRIGGER_EN       = 1
+  parameter              DEBUG_TRIGGER_EN       = 1,
+  parameter bit          SMCLIC                 = 1
 )
 (
   // singals running to/from controller
@@ -119,7 +120,8 @@ module cv32e40x_decoder import cv32e40x_pkg::*;
   // RV32I Base instruction set decoder
   cv32e40x_i_decoder
   #(
-    .DEBUG_TRIGGER_EN (DEBUG_TRIGGER_EN)
+    .DEBUG_TRIGGER_EN (DEBUG_TRIGGER_EN),
+    .SMCLIC           (SMCLIC          )
   )
   i_decoder_i
   (

--- a/rtl/cv32e40x_id_stage.sv
+++ b/rtl/cv32e40x_id_stage.sv
@@ -37,7 +37,8 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
   parameter m_ext_e      M_EXT                  = M,
   parameter bit          X_EXT                  = 0,
   parameter              DEBUG_TRIGGER_EN       = 1,
-  parameter int unsigned REGFILE_NUM_READ_PORTS = 2
+  parameter int unsigned REGFILE_NUM_READ_PORTS = 2,
+  parameter bit          SMCLIC                 = 1
 )
 (
   input  logic        clk,                    // Gated clock
@@ -406,7 +407,8 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
     .A_EXT                           ( A_EXT                     ),
     .B_EXT                           ( B_EXT                     ),
     .M_EXT                           ( M_EXT                     ),
-    .DEBUG_TRIGGER_EN                ( DEBUG_TRIGGER_EN          )
+    .DEBUG_TRIGGER_EN                ( DEBUG_TRIGGER_EN          ),
+    .SMCLIC                          ( SMCLIC                    )
   )
   decoder_i
   (

--- a/rtl/include/cv32e40x_pkg.sv
+++ b/rtl/include/cv32e40x_pkg.sv
@@ -585,7 +585,8 @@ typedef struct packed {
 
 typedef struct packed {
   logic [31:7] addr;
-  logic [ 6:2] zero0;
+  logic        zero0;
+  logic [ 5:2] submode;
   logic [ 1:0] mode;
 } mtvec_t;
 
@@ -611,11 +612,13 @@ parameter dcsr_t DCSR_RESET_VAL = '{
 parameter mtvec_t MTVEC_BASIC_RESET_VAL = '{
   addr: 'd0,
   zero0: 'd0,
+  submode: 'd0,
   mode:  MTVEC_MODE_BASIC};
 
 parameter mtvec_t MTVEC_CLIC_RESET_VAL = '{
   addr: 'd0,
   zero0: 'd0,
+  submode: 'd0,
   mode:  MTVEC_MODE_CLIC};
 
 parameter mtvt_t MTVT_RESET_VAL = '{

--- a/rtl/include/cv32e40x_pkg.sv
+++ b/rtl/include/cv32e40x_pkg.sv
@@ -428,7 +428,6 @@ typedef enum logic[11:0] {
 parameter CSR_JVT_MASK          = 32'hFFFFFC00;
 parameter CSR_MEPC_MASK         = 32'hFFFFFFFE;
 parameter CSR_DPC_MASK          = 32'hFFFFFFFE;
-parameter CSR_MINTTHRESH_MASK   = 32'h000000FF;
 
 // CSR operations
 


### PR DESCRIPTION
- Added SUBMODE field to mtvec - tied to 0 (SEC CLEAN)
- CSR accesses to mnxti with immediate bits 0, 2 or 4 set will cause an illegal instruction
- Number of implemented bits in mintthresh depend on SMCLIC_INTTHRESHBITS. Unused bits are tied to 1. Implemented bits are left justified. (SEC CLEAN when SMCLIC_INTTHRESHBITS = 8)
- mscratchcsw now depend om mstatus.mpp instead of mcause.mpp (SEC CLEAN)
- Removed instantiated CSR for read-only mclicbase (not directly relevant to PR 680)

From earlier PR #686 and #687, the legalness of accesses to mscratchcsw[l] are updated to reflect the CLIC spec.