### PR TITLE
CSR stall on CLIC pointers writing to mcause.minhv

### DIFF
--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -221,6 +221,7 @@ module cv32e40x_wrapper
                               .prefetch_valid_if_i          (core_i.if_stage_i.prefetch_valid),
                               .prefetch_is_tbljmp_ptr_if_i  (core_i.if_stage_i.prefetch_is_tbljmp_ptr),
                               .lsu_trans_valid_i            (core_i.load_store_unit_i.trans_valid),
+                              .csr_en_id_i                  (core_i.id_stage_i.csr_en),
                               .*);
   bind cv32e40x_cs_registers:
     core_i.cs_registers_i

--- a/rtl/cv32e40x_controller_bypass.sv
+++ b/rtl/cv32e40x_controller_bypass.sv
@@ -131,10 +131,10 @@ module cv32e40x_controller_bypass import cv32e40x_pkg::*;
   // todo:low:Above loop reasoning only applies to halt_id; for other pipeline stages a local instr_valid signal can maybe be used.
 
   // Detect when a CSR insn  in in EX or WB
-  // mret and dret implicitly writes to CSR. (dret is killing IF/ID/EX once it is in WB and can be disregarded here.
+  // mret, dret and CLIC pointers implicitly writes to CSR. (dret is killing IF/ID/EX once it is in WB and can be disregarded here.
   assign csr_write_in_ex_wb = (
-                              (id_ex_pipe_i.instr_valid && (id_ex_pipe_i.csr_en || (id_ex_pipe_i.sys_en && id_ex_pipe_i.sys_mret_insn))) ||
-                              (ex_wb_pipe_i.instr_valid && (ex_wb_pipe_i.csr_en || (ex_wb_pipe_i.sys_en && ex_wb_pipe_i.sys_mret_insn)))
+                              (id_ex_pipe_i.instr_valid && (id_ex_pipe_i.csr_en || (id_ex_pipe_i.sys_en && id_ex_pipe_i.sys_mret_insn) || id_ex_pipe_i.instr_meta.clic_ptr)) ||
+                              (ex_wb_pipe_i.instr_valid && (ex_wb_pipe_i.csr_en || (ex_wb_pipe_i.sys_en && ex_wb_pipe_i.sys_mret_insn) || ex_wb_pipe_i.instr_meta.clic_ptr))
                               );
 
   // Stall ID when WFI or WFE is active in EX.

--- a/sva/cv32e40x_controller_fsm_sva.sv
+++ b/sva/cv32e40x_controller_fsm_sva.sv
@@ -97,7 +97,8 @@ module cv32e40x_controller_fsm_sva
   input logic           wu_wfe_i,
   input logic           sys_en_id_i,
   input logic           sys_mret_id_i,
-  input logic           clic_ptr_in_wb
+  input logic           clic_ptr_in_wb,
+  input logic           csr_en_id_i
 );
 
 
@@ -794,5 +795,15 @@ end
                   |->
                   !ctrl_fsm_o.halt_wb)
   else `uvm_error("controller", "csr_restore_mret when WB is halted")
+
+  // CSR instructions should be stalled in ID if there is a CLIC pointer in EX or WB (RAW hazard)
+  a_csr_stall_on_ptr:
+  assert property (@(posedge clk) disable iff (!rst_n)
+                  (csr_en_id_i && if_id_pipe_i.instr_valid) &&
+                  ((id_ex_pipe_i.instr_meta.clic_ptr && id_ex_pipe_i.instr_valid) ||
+                  (ex_wb_pipe_i.instr_meta.clic_ptr && ex_wb_pipe_i.instr_valid))
+                  |->
+                  !id_valid_i)
+  else `uvm_error("controller", "CSR* not stalled in ID when CLIC pointer is in EX or WB")
 endmodule
 


### PR DESCRIPTION
Including CLIC pointers in CSR hazard detection. Pointers with no exceptions clear mcause.minhv from WB. Any instructions reading mcause should be stalled in ID for this case.

Implemented in the same was as the existing CSR stalls, not checking for actual csr address read vs address written. There is a todo in the code to make this stall more specific in the future.

Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>