### PR TITLE
Removed POINTER_FETCH state from controller_fsm

### DIFF
--- a/bhv/cv32e40x_rvfi.sv
+++ b/bhv/cv32e40x_rvfi.sv
@@ -1043,8 +1043,7 @@ module cv32e40x_rvfi
         rvfi_rd_wdata   <= mret_clic_pointer_wb ? rd_wdata_wb_past : rd_wdata_wb;
 
         // Read/Write CSRs
-        // mret with CLIC pointer: If pointer has no exceptions, original mret CSR r/w must be used.
-        //                         If pointer has exceptions, CSR r/w for exception must be used
+        // No clic pointer muxing, CSR updates for mret with CLIC pointer happens when the pointer reachces WB.
         rvfi_csr_rdata  <= rvfi_csr_rdata_d;
         rvfi_csr_wdata  <= rvfi_csr_wdata_d;
         rvfi_csr_wmask  <= rvfi_csr_wmask_d;
@@ -1070,17 +1069,17 @@ module cv32e40x_rvfi
       // Update state for suboperations - also valid for the last operation
       if (wb_valid_subop) begin
         // Set entries in *[STAGE_WB_PAST]
-        in_trap  [STAGE_WB_PAST] <= in_trap  [STAGE_WB];
-        rs1_addr [STAGE_WB_PAST] <= rs1_addr [STAGE_WB];
-        rs2_addr [STAGE_WB_PAST] <= rs1_addr [STAGE_WB];
-        rs1_rdata[STAGE_WB_PAST] <= rs1_rdata[STAGE_WB];
-        rs2_rdata[STAGE_WB_PAST] <= rs1_rdata[STAGE_WB];
+        in_trap  [STAGE_WB_PAST]    <= in_trap  [STAGE_WB];
+        rs1_addr [STAGE_WB_PAST]    <= rs1_addr [STAGE_WB];
+        rs2_addr [STAGE_WB_PAST]    <= rs1_addr [STAGE_WB];
+        rs1_rdata[STAGE_WB_PAST]    <= rs1_rdata[STAGE_WB];
+        rs2_rdata[STAGE_WB_PAST]    <= rs1_rdata[STAGE_WB];
         debug_cause [STAGE_WB_PAST] <= debug_cause [STAGE_WB];
-        debug_mode [STAGE_WB_PAST] <= debug_mode[STAGE_WB];
-        pc_wb_past               <= pc_wb_i;
-        instr_rdata_wb_past      <= instr_rdata_wb_i;
-        rd_addr_wb_past          <= rd_addr_wb;
-        rd_wdata_wb_past          <= rd_wdata_wb;
+        debug_mode [STAGE_WB_PAST]  <= debug_mode[STAGE_WB];
+        pc_wb_past                  <= pc_wb_i;
+        instr_rdata_wb_past         <= instr_rdata_wb_i;
+        rd_addr_wb_past             <= rd_addr_wb;
+        rd_wdata_wb_past            <= rd_wdata_wb;
 
         // Clear rvfi_mem and rvfi_gpr on first op
         if (first_op_wb_i) begin

--- a/bhv/cv32e40x_rvfi.sv
+++ b/bhv/cv32e40x_rvfi.sv
@@ -891,7 +891,7 @@ module cv32e40x_rvfi
         //     but we still need the in_trap attached to the pointer target, which is
         //     only fetched when the CLIC pointer is in ID. Thus we must not clear in_trap
         //     when the pointer goes from IF to ID.
-        if ((last_op_if_i || abort_op_if_i) && !(clic_ptr_if_i || mret_ptr_if_i)) begin
+        if ((last_op_if_i || abort_op_if_i) && !clic_ptr_if_i) begin
           in_trap    [STAGE_IF] <= 1'b0;
           debug_cause[STAGE_IF] <= '0;
         end

--- a/bhv/cv32e40x_rvfi.sv
+++ b/bhv/cv32e40x_rvfi.sv
@@ -42,7 +42,7 @@ module cv32e40x_rvfi
    input logic [31:0]                         prefetch_addr_if_i,
    input logic                                prefetch_compressed_if_i,
    input inst_resp_t                          prefetch_instr_if_i,
-   input logic                                clic_ptr_if_i,
+   input logic [1:0]                          clic_ptr_if_i,
 
    // ID probes
    input logic                                id_valid_i,
@@ -893,7 +893,7 @@ module cv32e40x_rvfi
         //     but we still need the in_trap attached to the pointer target, which is
         //     only fetched when the CLIC pointer is in ID. Thus we must not clear in_trap
         //     when the pointer goes from IF to ID.
-        if ((last_op_if_i || abort_op_if_i) && !clic_ptr_if_i) begin
+        if ((last_op_if_i || abort_op_if_i) && !clic_ptr_if_i[0]) begin
           in_trap    [STAGE_IF] <= 1'b0;
           debug_cause[STAGE_IF] <= '0;
         end

--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -219,9 +219,10 @@ module cv32e40x_wrapper
                               .first_op_ex_i                (core_i.first_op_ex),
                               .prefetch_valid_if_i          (core_i.if_stage_i.prefetch_valid),
                               .prefetch_is_tbljmp_ptr_if_i  (core_i.if_stage_i.prefetch_is_tbljmp_ptr),
-                              .prefetch_is_clic_ptr_if_i    (core_i.if_stage_i.prefetch_is_clic_ptr),
+                              .prefetch_is_mret_ptr_if_i    (core_i.if_stage_i.prefetch_is_mret_ptr),
                               .lsu_trans_valid_i            (core_i.load_store_unit_i.trans_valid),
                               .csr_en_id_i                  (core_i.id_stage_i.csr_en),
+                              .ptr_in_if_i                  (core_i.if_stage_i.ptr_in_if_o),
                               .*);
   bind cv32e40x_cs_registers:
     core_i.cs_registers_i
@@ -427,6 +428,7 @@ endgenerate
          .prefetch_compressed_if_i ( core_i.if_stage_i.instr_compressed                                   ),
          .prefetch_instr_if_i      ( core_i.if_stage_i.prefetch_unit_i.prefetch_instr_o                   ),
          .clic_ptr_if_i            ( core_i.if_stage_i.prefetch_is_clic_ptr                               ),
+         .mret_ptr_if_i            ( core_i.if_stage_i.prefetch_is_mret_ptr                               ),
 
          // ID Probes
          .id_valid_i               ( core_i.id_stage_i.id_valid_o                                         ),
@@ -478,6 +480,7 @@ endgenerate
          .lsu_rdata_wb_i           ( core_i.load_store_unit_i.lsu_rdata_1_o                               ),
          .abort_op_wb_i            ( core_i.wb_stage_i.abort_op_o                                         ),
          .clic_ptr_wb_i            ( core_i.wb_stage_i.ex_wb_pipe_i.instr_meta.clic_ptr                   ),
+         .mret_ptr_wb_i            ( core_i.wb_stage_i.ex_wb_pipe_i.instr_meta.mret_ptr                   ),
 
          .branch_addr_n_i          ( core_i.if_stage_i.branch_addr_n                                      ),
 

--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -215,11 +215,11 @@ module cv32e40x_wrapper
                               .csr_illegal_i                (core_i.cs_registers_i.csr_illegal_o),
                               .xif_commit_kill              (core_i.xif_commit_if.commit.commit_kill),
                               .xif_commit_valid             (core_i.xif_commit_if.commit_valid),
-                              .last_op_id_i                 (core_i.if_id_pipe.last_op),
                               .first_op_if_i                (core_i.first_op_if),
                               .first_op_ex_i                (core_i.first_op_ex),
                               .prefetch_valid_if_i          (core_i.if_stage_i.prefetch_valid),
                               .prefetch_is_tbljmp_ptr_if_i  (core_i.if_stage_i.prefetch_is_tbljmp_ptr),
+                              .prefetch_is_clic_ptr_if_i    (core_i.if_stage_i.prefetch_is_clic_ptr),
                               .lsu_trans_valid_i            (core_i.load_store_unit_i.trans_valid),
                               .csr_en_id_i                  (core_i.id_stage_i.csr_en),
                               .*);

--- a/bhv/include/cv32e40x_rvfi_pkg.sv
+++ b/bhv/include/cv32e40x_rvfi_pkg.sv
@@ -21,10 +21,11 @@
 package cv32e40x_rvfi_pkg;
   import cv32e40x_pkg::*;
 
-  parameter STAGE_IF = 0;
-  parameter STAGE_ID = 1;
-  parameter STAGE_EX = 2;
-  parameter STAGE_WB = 3;
+  parameter STAGE_IF      = 0;
+  parameter STAGE_ID      = 1;
+  parameter STAGE_EX      = 2;
+  parameter STAGE_WB      = 3;
+  parameter STAGE_WB_PAST = 4;
 
   parameter NMEM = 128;   // Maximum number of memory transactions per instruction is currently 13 when ZC_EXT=1
 

--- a/rtl/cv32e40x_alignment_buffer.sv
+++ b/rtl/cv32e40x_alignment_buffer.sv
@@ -56,9 +56,8 @@ module cv32e40x_alignment_buffer import cv32e40x_pkg::*;
   input  logic                       instr_ready_i,
   output inst_resp_t                 instr_instr_o,
   output logic [31:0]                instr_addr_o,
-  // instr_is_clic_ptr_o[0] is always high when a CLIC pointer is being output
-  // instr_is_clic_ptr_o[1] will only be high when a CLIC pointer is a result of an mret
-  output logic [1:0]                 instr_is_clic_ptr_o,
+  output logic                       instr_is_clic_ptr_o, // True CLIC pointer after taking a CLIC SHV interrupt
+  output logic                       instr_is_mret_ptr_o, // CLIC pointer due to restarting pionter fetch during mret
   output logic                       instr_is_tbljmp_ptr_o,
   output logic [ALBUF_CNT_WIDTH-1:0] outstnd_cnt_q_o
 );
@@ -104,9 +103,9 @@ module cv32e40x_alignment_buffer import cv32e40x_pkg::*;
 
   // CLIC vectoring
   // Flag for signalling that results is a CLIC function pointer
-  // is_clic_ptr_q[0] is always high when a CLIC pointer is being output
-  // is_clic_ptr_q[1] will only be high when a CLIC pointer is a result of an mret
-  logic [1:0] is_clic_ptr_q;
+  logic is_clic_ptr_q;
+  logic is_mret_ptr_q;
+
   // Flag for table jump pointer
   logic is_tbljmp_ptr_q;
   logic ptr_fetch_accepted_q;
@@ -498,7 +497,8 @@ module cv32e40x_alignment_buffer import cv32e40x_pkg::*;
       rptr              <= 'd0;
       wptr              <= 'd0;
       pop_q             <= 1'b0;
-      is_clic_ptr_q     <= 2'b00;
+      is_clic_ptr_q     <= 1'b0;
+      is_mret_ptr_q     <= 1'b0;
       is_tbljmp_ptr_q   <= 1'b0;
       ptr_fetch_accepted_q  <= 1'b0;
     end
@@ -529,8 +529,8 @@ module cv32e40x_alignment_buffer import cv32e40x_pkg::*;
         // Reset pointers on branch
         wptr <= 'd0;
         rptr <= 'd0;
-        is_clic_ptr_q[0] <= ctrl_fsm_i.pc_set_clicv;
-        is_clic_ptr_q[1] <= ctrl_fsm_i.pc_set_clicv && (ctrl_fsm_i.pc_mux == PC_MRET); // Only set when an mret restarts pointer fetch. Used to manipulate first_op/last_op
+        is_clic_ptr_q <= ctrl_fsm_i.pc_set_clicv && (ctrl_fsm_i.pc_mux == PC_TRAP_CLICV);
+        is_mret_ptr_q <= ctrl_fsm_i.pc_set_clicv && (ctrl_fsm_i.pc_mux == PC_MRET); // Only set when an mret restarts pointer fetch. Used to manipulate first_op/last_op
         is_tbljmp_ptr_q <= ctrl_fsm_i.pc_set_tbljmp;
       end else begin
         // Update write pointer on a valid response
@@ -571,6 +571,9 @@ module cv32e40x_alignment_buffer import cv32e40x_pkg::*;
 
   // Signal that result is a CLIC pointer
   assign instr_is_clic_ptr_o   = is_clic_ptr_q;
+
+  // Signal that result is an mret pointer
+  assign instr_is_mret_ptr_o   = is_mret_ptr_q;
 
   // Signal that result is a table jump pointer
   assign instr_is_tbljmp_ptr_o = is_tbljmp_ptr_q;

--- a/rtl/cv32e40x_alignment_buffer.sv
+++ b/rtl/cv32e40x_alignment_buffer.sv
@@ -56,6 +56,8 @@ module cv32e40x_alignment_buffer import cv32e40x_pkg::*;
   input  logic                       instr_ready_i,
   output inst_resp_t                 instr_instr_o,
   output logic [31:0]                instr_addr_o,
+  // instr_is_clic_ptr_o[0] is always high when a CLIC pointer is being output
+  // instr_is_clic_ptr_o[1] will only be high when a CLIC pointer is a result of an mret
   output logic [1:0]                 instr_is_clic_ptr_o,
   output logic                       instr_is_tbljmp_ptr_o,
   output logic [ALBUF_CNT_WIDTH-1:0] outstnd_cnt_q_o
@@ -102,6 +104,8 @@ module cv32e40x_alignment_buffer import cv32e40x_pkg::*;
 
   // CLIC vectoring
   // Flag for signalling that results is a CLIC function pointer
+  // is_clic_ptr_q[0] is always high when a CLIC pointer is being output
+  // is_clic_ptr_q[1] will only be high when a CLIC pointer is a result of an mret
   logic [1:0] is_clic_ptr_q;
   // Flag for table jump pointer
   logic is_tbljmp_ptr_q;

--- a/rtl/cv32e40x_alignment_buffer.sv
+++ b/rtl/cv32e40x_alignment_buffer.sv
@@ -56,7 +56,7 @@ module cv32e40x_alignment_buffer import cv32e40x_pkg::*;
   input  logic                       instr_ready_i,
   output inst_resp_t                 instr_instr_o,
   output logic [31:0]                instr_addr_o,
-  output logic                       instr_is_clic_ptr_o,
+  output logic [1:0]                 instr_is_clic_ptr_o,
   output logic                       instr_is_tbljmp_ptr_o,
   output logic [ALBUF_CNT_WIDTH-1:0] outstnd_cnt_q_o
 );
@@ -102,7 +102,7 @@ module cv32e40x_alignment_buffer import cv32e40x_pkg::*;
 
   // CLIC vectoring
   // Flag for signalling that results is a CLIC function pointer
-  logic is_clic_ptr_q;
+  logic [1:0] is_clic_ptr_q;
   // Flag for table jump pointer
   logic is_tbljmp_ptr_q;
   logic ptr_fetch_accepted_q;
@@ -494,7 +494,7 @@ module cv32e40x_alignment_buffer import cv32e40x_pkg::*;
       rptr              <= 'd0;
       wptr              <= 'd0;
       pop_q             <= 1'b0;
-      is_clic_ptr_q     <= 1'b0;
+      is_clic_ptr_q     <= 2'b00;
       is_tbljmp_ptr_q   <= 1'b0;
       ptr_fetch_accepted_q  <= 1'b0;
     end
@@ -525,7 +525,8 @@ module cv32e40x_alignment_buffer import cv32e40x_pkg::*;
         // Reset pointers on branch
         wptr <= 'd0;
         rptr <= 'd0;
-        is_clic_ptr_q   <= ctrl_fsm_i.pc_set_clicv;
+        is_clic_ptr_q[0] <= ctrl_fsm_i.pc_set_clicv;
+        is_clic_ptr_q[1] <= ctrl_fsm_i.pc_set_clicv && (ctrl_fsm_i.pc_mux == PC_MRET); // Only set when an mret restarts pointer fetch. Used to manipulate first_op/last_op
         is_tbljmp_ptr_q <= ctrl_fsm_i.pc_set_tbljmp;
       end else begin
         // Update write pointer on a valid response

--- a/rtl/cv32e40x_controller_bypass.sv
+++ b/rtl/cv32e40x_controller_bypass.sv
@@ -133,8 +133,8 @@ module cv32e40x_controller_bypass import cv32e40x_pkg::*;
   // Detect when a CSR insn  in in EX or WB
   // mret, dret and CLIC pointers implicitly writes to CSR. (dret is killing IF/ID/EX once it is in WB and can be disregarded here.
   assign csr_write_in_ex_wb = (
-                              (id_ex_pipe_i.instr_valid && (id_ex_pipe_i.csr_en || (id_ex_pipe_i.sys_en && id_ex_pipe_i.sys_mret_insn) || id_ex_pipe_i.instr_meta.clic_ptr)) ||
-                              (ex_wb_pipe_i.instr_valid && (ex_wb_pipe_i.csr_en || (ex_wb_pipe_i.sys_en && ex_wb_pipe_i.sys_mret_insn) || ex_wb_pipe_i.instr_meta.clic_ptr))
+                              (id_ex_pipe_i.instr_valid && (id_ex_pipe_i.csr_en || (id_ex_pipe_i.sys_en && id_ex_pipe_i.sys_mret_insn) || id_ex_pipe_i.instr_meta.clic_ptr || id_ex_pipe_i.instr_meta.mret_ptr)) ||
+                              (ex_wb_pipe_i.instr_valid && (ex_wb_pipe_i.csr_en || (ex_wb_pipe_i.sys_en && ex_wb_pipe_i.sys_mret_insn) || ex_wb_pipe_i.instr_meta.clic_ptr || ex_wb_pipe_i.instr_meta.mret_ptr))
                               );
 
   // Stall ID when WFI or WFE is active in EX.
@@ -184,7 +184,7 @@ module cv32e40x_controller_bypass import cv32e40x_pkg::*;
     // Also deassert for trigger match, as with dcsr.timing==0 we do not execute before entering debug mode
     // CLIC pointer fetches go through the pipeline, but no write enables should be active.
     if (if_id_pipe_i.instr.bus_resp.err || !(if_id_pipe_i.instr.mpu_status == MPU_OK) || if_id_pipe_i.trigger_match ||
-        if_id_pipe_i.instr_meta.clic_ptr) begin
+        if_id_pipe_i.instr_meta.clic_ptr || if_id_pipe_i.instr_meta.mret_ptr) begin
       ctrl_byp_o.deassert_we = 1'b1;
     end
 

--- a/rtl/cv32e40x_controller_fsm.sv
+++ b/rtl/cv32e40x_controller_fsm.sv
@@ -1208,15 +1208,10 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
           sequence_in_progress_id <= 1'b1;
         end
       end else begin
-        // sequence_in_progress_id is set, clear when last_op retires
-        if (id_valid_i && ex_ready_i && (last_op_id_i || abort_op_id_i)) begin
+        // sequence_in_progress_id is set, clear when last_op retires or ID stage is killed
+        if ((id_valid_i && ex_ready_i && (last_op_id_i || abort_op_id_i)) || ctrl_fsm_o.kill_id) begin
           sequence_in_progress_id <= 1'b0;
         end
-      end
-
-      // Reset flag if ID stage is killed
-      if (ctrl_fsm_o.kill_id) begin
-        sequence_in_progress_id <= 1'b0;
       end
     end
   end

--- a/rtl/cv32e40x_controller_fsm.sv
+++ b/rtl/cv32e40x_controller_fsm.sv
@@ -682,7 +682,8 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
           ctrl_fsm_o.csr_save_cause  = 1'b1;
           ctrl_fsm_o.csr_cause.irq = 1'b1;
 
-          // Keep mcause.minhv when taking exceptions and interrupts, only cleared on successful pointer fetches or CSR writes.
+          // Default to keeping mcause.minhv. It will only be set to 1 when taking a CLIC SHV interrupt (or by a CSR write).
+          // For all other cases it keeps its value.
           ctrl_fsm_o.csr_cause.minhv  = mcause_i.minhv;
 
 
@@ -695,6 +696,8 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
               ctrl_fsm_o.pc_mux = PC_TRAP_CLICV;
               clic_ptr_fetching_n = 1'b1;
               ctrl_fsm_o.pc_set_clicv = 1'b1;
+              // When taking an SHV interrupt, always set minhv.
+              // Mcause.minhv will only be cleared when a successful pointer fetch is done, or when it is cleared by a CSR write.
               ctrl_fsm_o.csr_cause.minhv = 1'b1;
             end else begin
               ctrl_fsm_o.pc_mux = PC_TRAP_IRQ;

--- a/rtl/cv32e40x_controller_fsm.sv
+++ b/rtl/cv32e40x_controller_fsm.sv
@@ -1215,7 +1215,7 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
         end
       end
 
-      // Reset flag on a kill_id. May happen before sequence_in_progress_wb gets set, or if a sequence gets an exception in the middle
+      // Reset flag on a kill_id. May happen before sequence_in_progress_id gets set, or if a sequence gets an exception in the middle
       if (ctrl_fsm_o.kill_id) begin
         sequence_in_progress_id <= 1'b0;
       end
@@ -1239,7 +1239,7 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
       end
 
       // When clic_ptr_in_progress_id is high, the ID stage can never be killed and thus no reset on kill_id is needed.
-      // This is checked by an assertion. Taking an SHV interrupt killes the pipeline ensuring no exceptions may happen, and
+      // This is checked by an assertion. Taking an SHV interrupt kills the pipeline ensuring no exceptions may happen, and
       // the flag itself keeps debug or interrupts from killing the pipeline.
     end
   end

--- a/rtl/cv32e40x_core.sv
+++ b/rtl/cv32e40x_core.sv
@@ -506,6 +506,8 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .ctrl_byp_i                   ( ctrl_byp                  ),
     .ctrl_fsm_i                   ( ctrl_fsm                  ),
 
+    .mcause_i                     ( mcause                    ),
+
     // Register file write back and forwards
     .rf_wdata_ex_i                ( rf_wdata_ex               ),
     .rf_wdata_wb_i                ( rf_wdata_wb               ),

--- a/rtl/cv32e40x_cs_registers.sv
+++ b/rtl/cv32e40x_cs_registers.sv
@@ -1033,7 +1033,8 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
         end
       end //ctrl_fsm_i.csr_save_cause
 
-      ctrl_fsm_i.csr_restore_mret: begin // MRET
+      ctrl_fsm_i.csr_restore_mret,
+      ctrl_fsm_i.csr_restore_mret_pointer: begin // MRET
         priv_lvl_n     = privlvl_t'(mstatus_rdata.mpp);
         priv_lvl_we    = 1'b1;
 
@@ -1060,19 +1061,18 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
         mstatus_we     = 1'b1;
 
       end //ctrl_fsm_i.csr_restore_dret
-
-      ctrl_fsm_i.csr_clear_minhv: begin
-        if (SMCLIC) begin
-          // Keep mcause values, only clear minhv bit.
-          mcause_n = mcause_rdata;
-          mcause_n.minhv = 1'b0;
-          mcause_we = 1'b1;
-        end // SMCLIC
-      end // ctrl_fsm_i.csr_clear_minhv
       default:;
     endcase
 
-
+    // Keep clear_minhv out of unique case as it may happen at the same time as csr_restore_mret
+    if (SMCLIC) begin
+      if (ctrl_fsm_i.csr_clear_minhv) begin
+        // Keep mcause values, only clear minhv bit.
+        mcause_n = mcause_rdata;
+        mcause_n.minhv = 1'b0;
+        mcause_we = 1'b1;
+      end
+    end
   end
 
   // Mirroring mstatus_n to mnxti_n for RVFI

--- a/rtl/cv32e40x_cs_registers.sv
+++ b/rtl/cv32e40x_cs_registers.sv
@@ -1034,7 +1034,7 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
       end //ctrl_fsm_i.csr_save_cause
 
       ctrl_fsm_i.csr_restore_mret,
-      ctrl_fsm_i.csr_restore_mret_pointer: begin // MRET
+      ctrl_fsm_i.csr_restore_mret_ptr: begin // MRET
         priv_lvl_n     = privlvl_t'(mstatus_rdata.mpp);
         priv_lvl_we    = 1'b1;
 
@@ -1048,7 +1048,7 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
           mintstatus_n.mil = mcause_rdata.mpil;
           mintstatus_we = 1'b1;
 
-          if (ctrl_fsm_i.csr_restore_mret_pointer) begin
+          if (ctrl_fsm_i.csr_restore_mret_ptr) begin
             // Clear mcause.minhv if the mret also caused a successful CLIC pointer fetch
             mcause_n = mcause_rdata;
             mcause_n.minhv = 1'b0;
@@ -1072,7 +1072,7 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
       // Clear mcause.minhv on successful CLIC pointer fetches
       // This only happens for CLIC pointer that did not originate from an mret.
       // In the case of mret restarting CLIC pointer fetchces, minhv is cleared while
-      // ctrl_fsm_i.csr_restore_mret_pointer is asserted.
+      // ctrl_fsm_i.csr_restore_mret_ptr is asserted.
       ctrl_fsm_i.csr_clear_minhv: begin
         if (SMCLIC) begin
           // Keep mcause values, only clear minhv bit.

--- a/rtl/cv32e40x_cs_registers.sv
+++ b/rtl/cv32e40x_cs_registers.sv
@@ -1071,7 +1071,7 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
 
       // Clear mcause.minhv on successful CLIC pointer fetches
       // This only happens for CLIC pointer that did not originate from an mret.
-      // In the case of mret restarting CLIC pointer fetchces, minhv is cleared while
+      // In the case of mret restarting CLIC pointer fetches, minhv is cleared while
       // ctrl_fsm_i.csr_restore_mret_ptr is asserted.
       ctrl_fsm_i.csr_clear_minhv: begin
         if (SMCLIC) begin

--- a/rtl/cv32e40x_ex_stage.sv
+++ b/rtl/cv32e40x_ex_stage.sv
@@ -455,6 +455,7 @@ module cv32e40x_ex_stage import cv32e40x_pkg::*;
                        (id_ex_pipe_i.lsu_en && lsu_valid_i) ||
                        (id_ex_pipe_i.xif_en && xif_valid)   ||
                        (id_ex_pipe_i.instr_meta.clic_ptr)   || // todo: Should this instead have it's own _valid?
+                       (id_ex_pipe_i.instr_meta.mret_ptr)   || // todo: Should this instead have it's own _valid?
                        previous_exception // todo:ab:remove
                       ) && instr_valid;
 

--- a/rtl/cv32e40x_id_stage.sv
+++ b/rtl/cv32e40x_id_stage.sv
@@ -693,6 +693,8 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
   assign first_op_o  = if_id_pipe_i.first_op;
   // An mret with mcause.minhv set and mcause.mpp = PRIV_LVL_M will cause a pointer fetch, and that pointer fetch is the last operation of the mret.
   // Mrets with the mcause conditions not true will be normal single operation instructions.
+  // Using CSR signals below is safe, as any implicit or explicit CSR read in ID stage is halted if there is an implicit or explicit CSR write
+  // in either EX or WB at the same time.
   assign last_op_o   = (sys_en && sys_mret_insn && mcause_i.minhv && (mcause_i.mpp == PRIV_LVL_M)) ? 1'b0 : if_id_pipe_i.last_op;
   assign abort_op_o  = if_id_pipe_i.abort_op || ctrl_byp_i.id_stage_abort;
   //---------------------------------------------------------------------------

--- a/rtl/cv32e40x_id_stage.sv
+++ b/rtl/cv32e40x_id_stage.sv
@@ -60,6 +60,8 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
   input  ctrl_byp_t   ctrl_byp_i,
   input  ctrl_fsm_t   ctrl_fsm_i,
 
+  input  mcause_t     mcause_i,
+
   // Register file write data from WB stage
   input  logic [31:0] rf_wdata_wb_i,
 
@@ -689,7 +691,9 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
   assign id_valid_o = (instr_valid && !xif_waiting) || (multi_cycle_id_stall && !ctrl_fsm_i.kill_id && !ctrl_fsm_i.halt_id);
 
   assign first_op_o  = if_id_pipe_i.first_op;
-  assign last_op_o   = if_id_pipe_i.last_op;
+  // An mret with mcause.minhv set and mcause.mpp = PRIV_LVL_M will cause a pointer fetch, and that pointer fetch is the last operation of the mret.
+  // Mrets with the mcause conditions not true will be normal single operation instructions.
+  assign last_op_o   = (sys_en && sys_mret_insn && mcause_i.minhv && (mcause_i.mpp == PRIV_LVL_M)) ? 1'b0 : if_id_pipe_i.last_op;
   assign abort_op_o  = if_id_pipe_i.abort_op || ctrl_byp_i.id_stage_abort;
   //---------------------------------------------------------------------------
   // eXtension interface

--- a/rtl/cv32e40x_if_stage.sv
+++ b/rtl/cv32e40x_if_stage.sv
@@ -305,14 +305,16 @@ module cv32e40x_if_stage import cv32e40x_pkg::*;
 
   // Sequenced instructions set last_op from the sequencer.
   // Any other instruction will be single operation, and gets last_op=1.
-  // CLIC pointers are single operation with first_op == last_op == 1
+  // Regular CLIC pointers are single operation with first_op == last_op == 1
+  // CLIC pointers that are a side effect of mret instructions will have first_op == 0 and last_op == 1
   assign last_op_o = prefetch_is_clic_ptr[1] ? 1'b1 :           // clic pointer caused by mret, must be !first && last
                      seq_valid               ? seq_last : 1'b1; // Any other regular instructions are single operation.
 
   // Flag first operation of a sequence.
   // Any sequenced instructions use the seq_first from the sequencer.
   // Any other instruction will be single operation, and gets first_op=1.
-  // CLIC pointers are single operation with first_op == last_op == 1
+  // Regular CLIC pointers are single operation with first_op == last_op == 1
+  // CLIC pointers that are a side effect of mret instructions will have first_op == 0 and last_op == 1
   assign first_op_o =  prefetch_is_clic_ptr[1] ? 1'b0 :            // clic pointer caused by mret, must be !first && last
                        seq_valid               ? seq_first : 1'b1; // Any other regular instructions are single operation.
 

--- a/rtl/cv32e40x_if_stage.sv
+++ b/rtl/cv32e40x_if_stage.sv
@@ -97,6 +97,9 @@ module cv32e40x_if_stage import cv32e40x_pkg::*;
   logic              prefetch_valid;
   logic              prefetch_ready;
   inst_resp_t        prefetch_instr;
+
+  // prefetch_is_clic_ptr[0] is always high when a CLIC pointer is being output
+  // prefetch_is_clic_ptr[1] will only be high when a CLIC pointer is a result of an mret
   logic [1:0]        prefetch_is_clic_ptr;
   logic              prefetch_is_tbljmp_ptr;
 

--- a/rtl/cv32e40x_prefetch_unit.sv
+++ b/rtl/cv32e40x_prefetch_unit.sv
@@ -44,7 +44,7 @@ module cv32e40x_prefetch_unit import cv32e40x_pkg::*;
   output logic        prefetch_valid_o,
   output inst_resp_t  prefetch_instr_o,
   output logic [31:0] prefetch_addr_o,
-  output logic        prefetch_is_clic_ptr_o,
+  output logic [1:0]  prefetch_is_clic_ptr_o,
   output logic        prefetch_is_tbljmp_ptr_o,
 
   // Transaction interface to obi interface

--- a/rtl/cv32e40x_prefetch_unit.sv
+++ b/rtl/cv32e40x_prefetch_unit.sv
@@ -44,7 +44,8 @@ module cv32e40x_prefetch_unit import cv32e40x_pkg::*;
   output logic        prefetch_valid_o,
   output inst_resp_t  prefetch_instr_o,
   output logic [31:0] prefetch_addr_o,
-  output logic [1:0]  prefetch_is_clic_ptr_o,
+  output logic        prefetch_is_clic_ptr_o,
+  output logic        prefetch_is_mret_ptr_o,
   output logic        prefetch_is_tbljmp_ptr_o,
 
   // Transaction interface to obi interface
@@ -132,6 +133,7 @@ module cv32e40x_prefetch_unit import cv32e40x_pkg::*;
     .instr_instr_o         ( prefetch_instr_o        ),
     .instr_addr_o          ( prefetch_addr_o         ),
     .instr_is_clic_ptr_o   ( prefetch_is_clic_ptr_o  ),
+    .instr_is_mret_ptr_o   ( prefetch_is_mret_ptr_o  ),
     .instr_is_tbljmp_ptr_o ( prefetch_is_tbljmp_ptr_o)
 
   );

--- a/rtl/cv32e40x_sequencer.sv
+++ b/rtl/cv32e40x_sequencer.sv
@@ -39,6 +39,7 @@ import cv32e40x_pkg::*;
 
     input  inst_resp_t instr_i,               // Instruction from prefetch unit
     input  logic       instr_is_clic_ptr_i,   // CLIC pointer flag, instr_i does not contain an instruction
+    input  logic       instr_is_mret_ptr_i,   // mret pointer flag, instr_i does not contain an instruction
     input  logic       instr_is_tbljmp_ptr_i, // Tablejump pointer flag, instr_i does not contain an instruction
 
     input  logic       valid_i,               // valid input from if stage
@@ -82,7 +83,7 @@ import cv32e40x_pkg::*;
   assign instr = instr_i.bus_resp.rdata;
   assign rlist = instr[7:4];
 
-  assign instr_is_pointer = instr_is_clic_ptr_i || instr_is_tbljmp_ptr_i;
+  assign instr_is_pointer = instr_is_clic_ptr_i || instr_is_mret_ptr_i || instr_is_tbljmp_ptr_i;
 
   // Count number of instructions emitted and set next state for FSM.
   always_ff @(posedge clk, negedge rst_n) begin

--- a/rtl/include/cv32e40x_pkg.sv
+++ b/rtl/include/cv32e40x_pkg.sv
@@ -169,7 +169,7 @@ typedef enum logic [DIV_OP_WIDTH-1:0]
  } div_opcode_e;
 
 // FSM state encoding
-typedef enum logic [2:0] { RESET, BOOT_SET, FUNCTIONAL, SLEEP, DEBUG_TAKEN, POINTER_FETCH} ctrl_state_e;
+typedef enum logic [2:0] { RESET, BOOT_SET, FUNCTIONAL, SLEEP, DEBUG_TAKEN} ctrl_state_e;
 
 // Debug FSM state encoding
 // State encoding done one-hot to ensure that debug_havereset_o, debug_running_o, debug_halted_o

--- a/rtl/include/cv32e40x_pkg.sv
+++ b/rtl/include/cv32e40x_pkg.sv
@@ -1032,7 +1032,8 @@ typedef struct packed {
 typedef struct packed
 {
   logic        compressed;
-  logic        clic_ptr;
+  logic        clic_ptr;   // "True" CLIC pointer due to taking a CLIC SHV interrupt
+  logic        mret_ptr;   // CLIC pointer due to an mret restarting pointer fetch
   logic        tbljmp;
 } instr_meta_t;
 
@@ -1263,7 +1264,7 @@ typedef struct packed {
   logic [31:0] pipe_pc;             // PC from pipeline
   mcause_t     csr_cause;           // CSR cause (saves to mcause CSR)
   logic        csr_restore_mret;    // Restore CSR due to mret
-  logic        csr_restore_mret_pointer; // Restore CSR due to mret followed by CLIC
+  logic        csr_restore_mret_ptr; // Restore CSR due to mret followed by CLIC
   logic        csr_restore_dret;    // Restore CSR due to dret
   logic        csr_save_cause;      // Update CSRs
   logic        csr_clear_minhv;     // Clear the mcause.minhv field

--- a/rtl/include/cv32e40x_pkg.sv
+++ b/rtl/include/cv32e40x_pkg.sv
@@ -1263,6 +1263,7 @@ typedef struct packed {
   logic [31:0] pipe_pc;             // PC from pipeline
   mcause_t     csr_cause;           // CSR cause (saves to mcause CSR)
   logic        csr_restore_mret;    // Restore CSR due to mret
+  logic        csr_restore_mret_pointer; // Restore CSR due to mret followed by CLIC
   logic        csr_restore_dret;    // Restore CSR due to dret
   logic        csr_save_cause;      // Update CSRs
   logic        csr_clear_minhv;     // Clear the mcause.minhv field

--- a/sva/cv32e40x_controller_fsm_sva.sv
+++ b/sva/cv32e40x_controller_fsm_sva.sv
@@ -98,7 +98,8 @@ module cv32e40x_controller_fsm_sva
   input logic           wu_wfe_i,
   input logic           sys_en_id_i,
   input logic           sys_mret_id_i,
-  input logic           clic_ptr_in_wb,
+  input logic           mret_clic_ptr_in_wb,
+  input logic           non_mret_clic_ptr_in_wb,
   input logic           csr_en_id_i,
   input logic           clic_ptr_fetching_n
 );
@@ -612,7 +613,7 @@ if (SMCLIC) begin
   assert property (@(posedge clk) disable iff (!rst_n)
                   ((ctrl_fsm_cs != FUNCTIONAL)
                   |->
-                  !(clic_ptr_in_wb && !ctrl_fsm_o.kill_wb)))
+                  !((mret_clic_ptr_in_wb || non_mret_clic_ptr_in_wb) && !ctrl_fsm_o.kill_wb)))
     else `uvm_error("controller", "clic_ptr_in_wb && !kill_wb while not in FUNCTIONAL state.")
 
 end else begin // SMCLIC

--- a/sva/cv32e40x_core_sva.sv
+++ b/sva/cv32e40x_core_sva.sv
@@ -59,6 +59,7 @@ module cv32e40x_core_sva
   input logic [31:0]   operand_a_id_i,
   input logic [31:0]   operand_b_id_i,
   input logic [31:0]   jalr_fw_id_i,
+  input logic          last_op_id,
   input logic [31:0]   rf_wdata_wb,
   input logic          rf_we_wb,
 
@@ -301,7 +302,7 @@ always_ff @(posedge clk , negedge rst_ni)
   // For checking single step, ID stage is used as it contains a 'multi_cycle_id_stall' signal.
   // This makes it easy to count misaligned LSU ins as one instruction instead of two.
   logic inst_taken;
-  assign inst_taken = id_stage_id_valid && ex_ready && if_id_pipe.last_op && !id_stage_multi_cycle_id_stall; // todo: the && !id_stage_multi_cycle_id_stall signal should now no longer be needed
+  assign inst_taken = id_stage_id_valid && ex_ready && last_op_id && !id_stage_multi_cycle_id_stall; // todo: the && !id_stage_multi_cycle_id_stall signal should now no longer be needed
 
   // Support for single step assertion
   // In case of single step + taken interrupt, the first instruction

--- a/sva/cv32e40x_core_sva.sv
+++ b/sva/cv32e40x_core_sva.sv
@@ -128,7 +128,10 @@ end else begin
   // Assert that no pointer can be in any pipeline stage when SMCLIC == 0
   property p_clic_noptr_in_pipeline;
     @(posedge clk) disable iff (!rst_ni)
-      1'b1 |-> (!if_id_pipe.instr_meta.clic_ptr && !id_ex_pipe.instr_meta.clic_ptr && !ex_wb_pipe.instr_meta.clic_ptr);
+      1'b1
+      |->
+      (!if_id_pipe.instr_meta.clic_ptr && !id_ex_pipe.instr_meta.clic_ptr && !ex_wb_pipe.instr_meta.clic_ptr &&
+       !if_id_pipe.instr_meta.mret_ptr && !id_ex_pipe.instr_meta.mret_ptr && !ex_wb_pipe.instr_meta.mret_ptr);
   endproperty
 
   a_clic_noptr_in_pipeline : assert property(p_clic_noptr_in_pipeline) else `uvm_error("core", "CLIC pointer in pipeline when CLIC is not configured.")
@@ -356,7 +359,7 @@ if (SMCLIC) begin
   // a live pointer in WB (IF-ID: guarded by POINTER_FETCH STATE, EX-WB: guarded by clic_ptr_in_pipeline).
   //   - this could cause the address of the pointer to end up in DPC, making dret jumping to a mtvt entry instead of an instruction.
   /*
-      todo: Reintroduce (and update) when debug single step logic has been updated.
+      todo: Reintroduce (and update) when debug single step logic has been updated and POINTER_FETCH state removed.
              -should likely flop the event that causes single step entry to evaluate all debug reasons
               when the pipeline is guaranteed to not disallow any debug reason to enter debug.
   a_single_step_with_irq_shv :

--- a/sva/cv32e40x_decoder_sva.sv
+++ b/sva/cv32e40x_decoder_sva.sv
@@ -54,10 +54,10 @@ module cv32e40x_decoder_sva
 
   // Check that the two LSB of the incoming instructions word is always 2'b11
   // Predecoder should always emit uncompressed instructions
-  // Exclude CLIC pointers
+  // Exclude CLIC and mret pointers
   property p_uncompressed_lsb;
     @(posedge clk) disable iff(!rst_n)
-      !if_id_pipe.instr_meta.clic_ptr |-> (instr_rdata[1:0] == 2'b11);
+      !(if_id_pipe.instr_meta.clic_ptr || if_id_pipe.instr_meta.mret_ptr) |-> (instr_rdata[1:0] == 2'b11);
   endproperty
 
   a_uncompressed_lsb: assert property(p_uncompressed_lsb) else `uvm_error("decoder", "2 LSBs not 2'b11")
@@ -104,17 +104,17 @@ module cv32e40x_decoder_sva
       else `uvm_error("decoder", "Unexpected C operand usage")
 
   // Ensure that functional unit enables are one-hot (including illegal)
-  // CLIC pointers in ID will deassert all write enables.
+  // CLIC and mret pointers in ID will deassert all write enables.
   // This deassert is using the decoder_ctrl_mux as inputs, and deasserting
   // the decoder outputs instead. Disregarding the case of clic_ptr for now, but
   // could make the $onehot look at the decoder outputs instead and include the clic_ptr in $onehot
   a_functional_unit_enable_onehot :
     assert property (@(posedge clk) disable iff (!rst_n)
-                     !if_id_pipe.instr_meta.clic_ptr
+                     !(if_id_pipe.instr_meta.clic_ptr || if_id_pipe.instr_meta.mret_ptr)
                      |->
                      $onehot({decoder_ctrl_mux.alu_en, decoder_ctrl_mux.div_en, decoder_ctrl_mux.mul_en,
                               decoder_ctrl_mux.csr_en, decoder_ctrl_mux.sys_en, decoder_ctrl_mux.lsu_en,
-                              decoder_ctrl_mux.illegal_insn, if_id_pipe.instr_meta.clic_ptr}))
+                              decoder_ctrl_mux.illegal_insn, if_id_pipe.instr_meta.clic_ptr, if_id_pipe.instr_meta.mret_ptr}))
       else `uvm_error("decoder", "Multiple functional units enabled")
 
 

--- a/sva/cv32e40x_decoder_sva.sv
+++ b/sva/cv32e40x_decoder_sva.sv
@@ -38,7 +38,14 @@ module cv32e40x_decoder_sva
   input decoder_ctrl_t  decoder_b_ctrl,
   input decoder_ctrl_t  decoder_ctrl_mux,
   input logic [31:0]    instr_rdata,
-  input if_id_pipe_t    if_id_pipe
+  input if_id_pipe_t    if_id_pipe,
+  input logic           alu_en_o,
+  input logic           div_en_o,
+  input logic           mul_en_o,
+  input logic           csr_en_o,
+  input logic           sys_en_o,
+  input logic           lsu_en_o,
+  input logic           illegal_insn_o
 );
 
   // Check sub decoders have their outputs idle when there is no instruction match
@@ -103,21 +110,25 @@ module cv32e40x_decoder_sva
                       |-> ((decoder_ctrl_mux.alu_en || (decoder_ctrl_mux.lsu_en && decoder_ctrl_mux.lsu_we))))
       else `uvm_error("decoder", "Unexpected C operand usage")
 
-  // Ensure that functional unit enables are one-hot (including illegal)
-  // CLIC and mret pointers in ID will deassert all write enables.
-  // This deassert is using the decoder_ctrl_mux as inputs, and deasserting
-  // the decoder outputs instead. Disregarding the case of clic_ptr for now, but
-  // could make the $onehot look at the decoder outputs instead and include the clic_ptr in $onehot
-  a_functional_unit_enable_onehot :
+  // Ensure that functional unit enables are one-hot (including illegal) when no pointer is in the ID stage
+  a_functional_unit_enable_onehot_noptr :
     assert property (@(posedge clk) disable iff (!rst_n)
                      !(if_id_pipe.instr_meta.clic_ptr || if_id_pipe.instr_meta.mret_ptr)
                      |->
                      $onehot({decoder_ctrl_mux.alu_en, decoder_ctrl_mux.div_en, decoder_ctrl_mux.mul_en,
                               decoder_ctrl_mux.csr_en, decoder_ctrl_mux.sys_en, decoder_ctrl_mux.lsu_en,
-                              decoder_ctrl_mux.illegal_insn, if_id_pipe.instr_meta.clic_ptr, if_id_pipe.instr_meta.mret_ptr}))
+                              decoder_ctrl_mux.illegal_insn}))
       else `uvm_error("decoder", "Multiple functional units enabled")
 
-
+  // Check that all functional units are disabled when a pointer is in the ID stage
+  a_functional_unit_disable_ptr :
+    assert property (@(posedge clk) disable iff (!rst_n)
+                      (if_id_pipe.instr_meta.clic_ptr || if_id_pipe.instr_meta.mret_ptr)
+                      |->
+                      !(|{alu_en_o, div_en_o, mul_en_o,
+                         csr_en_o, sys_en_o, lsu_en_o,
+                         illegal_insn_o}))
+      else `uvm_error("decoder", "Functional units enable when a pointer is in the ID stage")
 
   // Check that branch/jump related signals can be used from I decoder directly (bypassing other decoders)
   a_branch_jump_decode :

--- a/sva/cv32e40x_if_stage_sva.sv
+++ b/sva/cv32e40x_if_stage_sva.sv
@@ -35,7 +35,9 @@ module cv32e40x_if_stage_sva
   input  logic          seq_ready,
   input  logic          illegal_c_insn,
   input  logic          instr_compressed,
-  input  logic          prefetch_is_tbljmp_ptr
+  input  logic          prefetch_is_tbljmp_ptr,
+  input  logic          prefetch_is_clic_ptr,
+  input  logic          prefetch_is_mret_ptr
 );
 
   // Check that bus interface transactions are halfword aligned (will be forced word aligned at core boundary)
@@ -82,5 +84,12 @@ module cv32e40x_if_stage_sva
                       ctrl_fsm_i.kill_if |-> (seq_ready && !seq_valid))
         else `uvm_error("if_stage", "Kill should imply ready and not valid.")
 
+  // CLIC pointers and mret pointers can't both be set at the same time
+  a_clic_mret_ptr_unique:
+    assert property (@(posedge clk) disable iff (!rst_n)
+                      (prefetch_is_mret_ptr || prefetch_is_clic_ptr)
+                      |->
+                      prefetch_is_mret_ptr != prefetch_is_clic_ptr)
+        else `uvm_error("if_stage", "prefetch_is_mret_ptr high at the same time as prefetch_is_clic_ptr.")
 endmodule // cv32e40x_if_stage
 

--- a/sva/cv32e40x_prefetcher_sva.sv
+++ b/sva/cv32e40x_prefetcher_sva.sv
@@ -51,7 +51,7 @@ module cv32e40x_prefetcher_sva import cv32e40x_pkg::*;
   input  logic        fetch_valid_i,
 
   input  prefetch_state_e  state_q,
-  input  logic        prefetch_is_clic_ptr
+  input  logic [1:0]  prefetch_is_clic_ptr
 
 
 );
@@ -179,7 +179,7 @@ if (SMCLIC) begin
   //   For this case, the PC of the tablejump instruction is available in the pipeline.
 
   property p_data_q_no_branch;
-    @(posedge clk) disable iff (!rst_n) (((state_q == BRANCH_WAIT) && trans_ptr_access_q) && prefetch_is_clic_ptr |-> !fetch_branch_i);
+    @(posedge clk) disable iff (!rst_n) (((state_q == BRANCH_WAIT) && trans_ptr_access_q) && prefetch_is_clic_ptr[0] |-> !fetch_branch_i);
   endproperty
 
   a_p_data_q_no_branch:

--- a/sva/cv32e40x_prefetcher_sva.sv
+++ b/sva/cv32e40x_prefetcher_sva.sv
@@ -51,7 +51,7 @@ module cv32e40x_prefetcher_sva import cv32e40x_pkg::*;
   input  logic        fetch_valid_i,
 
   input  prefetch_state_e  state_q,
-  input  logic [1:0]  prefetch_is_clic_ptr
+  input  logic        prefetch_is_clic_ptr
 
 
 );
@@ -179,7 +179,7 @@ if (SMCLIC) begin
   //   For this case, the PC of the tablejump instruction is available in the pipeline.
 
   property p_data_q_no_branch;
-    @(posedge clk) disable iff (!rst_n) (((state_q == BRANCH_WAIT) && trans_ptr_access_q) && prefetch_is_clic_ptr[0] |-> !fetch_branch_i);
+    @(posedge clk) disable iff (!rst_n) (((state_q == BRANCH_WAIT) && trans_ptr_access_q) && prefetch_is_clic_ptr |-> !fetch_branch_i);
   endproperty
 
   a_p_data_q_no_branch:

--- a/sva/cv32e40x_rvfi_sva.sv
+++ b/sva/cv32e40x_rvfi_sva.sv
@@ -49,16 +49,23 @@ module cv32e40x_rvfi_sva
    input logic             irq_ack,
    input logic             dbg_ack,
    input logic             ebreak_in_wb_i,
-   input rvfi_intr_t [3:0] in_trap,
-   input logic [3:0] [2:0] debug_cause,
+   input rvfi_intr_t [4:0] in_trap,
+   input logic [4:0] [2:0] debug_cause,
 
    input logic             if_valid_i,
    input logic             id_ready_i,
    input logic [31:0]      pc_if_i,
    input inst_resp_t       prefetch_instr_if_i,
    input logic             prefetch_compressed_if_i,
-   input rvfi_obi_instr_t  obi_instr_if
+   input rvfi_obi_instr_t  obi_instr_if,
+   input logic             mret_clic_pointer_wb,
+   input logic [31:0]      instr_rdata_wb_past
 );
+
+  a_mret_clic_pointer :
+    assert property (@(posedge clk_i) disable iff (!rst_ni)
+                  (mret_clic_pointer_wb |-> (instr_rdata_wb_past == 32'h30200073)))
+    else `uvm_error("rvfi", "mret not in STAGE_WB_PAST when CLIC pointer arrived in WB")
 
   // Check that irq_ack results in RVFI capturing a trap
   // Ideally, we should assert that every irq_ack eventually leads to rvfi_intr,

--- a/sva/cv32e40x_rvfi_sva.sv
+++ b/sva/cv32e40x_rvfi_sva.sv
@@ -58,14 +58,14 @@ module cv32e40x_rvfi_sva
    input inst_resp_t       prefetch_instr_if_i,
    input logic             prefetch_compressed_if_i,
    input rvfi_obi_instr_t  obi_instr_if,
-   input logic             mret_clic_pointer_wb,
+   input logic             mret_ptr_wb,
    input logic [31:0]      instr_rdata_wb_past
 );
 
-  a_mret_clic_pointer :
+  a_mret_pointer :
     assert property (@(posedge clk_i) disable iff (!rst_ni)
-                  (mret_clic_pointer_wb |-> (instr_rdata_wb_past == 32'h30200073)))
-    else `uvm_error("rvfi", "mret not in STAGE_WB_PAST when CLIC pointer arrived in WB")
+                  (mret_ptr_wb |-> (instr_rdata_wb_past == 32'h30200073)))
+    else `uvm_error("rvfi", "mret not in STAGE_WB_PAST when mret pointer arrived in WB")
 
   // Check that irq_ack results in RVFI capturing a trap
   // Ideally, we should assert that every irq_ack eventually leads to rvfi_intr,

--- a/sva/cv32e40x_sequencer_sva.sv
+++ b/sva/cv32e40x_sequencer_sva.sv
@@ -45,6 +45,7 @@ module cv32e40x_sequencer_sva
   input  seq_instr_e     seq_instr,
   input  logic           instr_is_tbljmp_ptr_i,
   input  logic           instr_is_clic_ptr_i,
+  input  logic           instr_is_mret_ptr_i,
   input  logic           seq_tbljmp_o
 );
 
@@ -159,7 +160,7 @@ module cv32e40x_sequencer_sva
   // Check that the sequencer does not decode any instructions from pointers
   a_ptr_illegal:
     assert property (@(posedge clk) disable iff (!rst_n)
-                    (instr_is_tbljmp_ptr_i || instr_is_clic_ptr_i)
+                    (instr_is_tbljmp_ptr_i || instr_is_clic_ptr_i || instr_is_mret_ptr_i)
                     |->
                     (seq_instr == INVALID_INST))
         else `uvm_error("sequencer", "Instruction should not be decoded from a pointer")


### PR DESCRIPTION
POINTER_FETCH fsm state replaced by a separate state flop. Controller stays in FUNCTIONAL while handling CLIC SHV interrupts.

Mret which restarts CLIC pointer fetch due to mcause.minhv and mcause.mpp will now get its 'last_op' bit set to 0 in the ID stage, and the following CLIC pointer will complete the sequence. CSR updates only happen when the pointer reaches WB.

NOT SEC clean
- Master has bugs (possible deadlock while single stepping mret with CLIC pointers, wrong pipeline stage used for excluding CLIC pointers from incrementing minstret).
- Minstret will now only update for mret when the CLIC pointer is done (or when the mret reaches WB if no CLIC pointer fetch is restarted)