### PR TITLE
Turned on ZC_EXT.

### DIFF
--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -379,12 +379,11 @@ endgenerate
                .PMA_CFG(PMA_CFG))
       write_buffer_sva(.*);
 
-/* todo: reintroduce once ZC_EXT is set to 1 by default.
   bind cv32e40x_sequencer:
     core_i.if_stage_i.gen_seq.sequencer_i
       cv32e40x_sequencer_sva
         sequencer_sva (.*);
-*/
+
 `ifndef FORMAL
   bind cv32e40x_rvfi:
     rvfi_i

--- a/rtl/cv32e40x_core.sv
+++ b/rtl/cv32e40x_core.sv
@@ -137,8 +137,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
   localparam int unsigned REGFILE_NUM_READ_PORTS = X_EXT ? X_NUM_RS : 2;
 
   // Zc is always present
-  // todo: turn on when Zc is ready for core-v-verif
-  localparam bit ZC_EXT = 0;
+  localparam bit ZC_EXT = 1;
 
   // Determine alignedness of mtvt
   // mtvt[31:N] holds mtvt table entry


### PR DESCRIPTION
ZC_EXT localpram in toplevel is now 1, and sequencer assertions bound by default in the wrapper

Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>