### PR TITLE
Trigger types 0x5 and 0xF

### DIFF
--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -235,7 +235,8 @@ module cv32e40x_wrapper
     core_i.cs_registers_i
       cv32e40x_cs_registers_sva
         #(.SMCLIC(SMCLIC))
-        cs_registers_sva (.wb_valid_i (core_i.wb_valid),
+        cs_registers_sva (.wb_valid_i  (core_i.wb_valid                                 ),
+                          .ctrl_fsm_cs (core_i.controller_i.controller_fsm_i.ctrl_fsm_cs),
                           .*);
 
   bind cv32e40x_load_store_unit:

--- a/rtl/cv32e40x_controller.sv
+++ b/rtl/cv32e40x_controller.sv
@@ -97,6 +97,8 @@ module cv32e40x_controller import cv32e40x_pkg::*;
   input logic  [1:0]  mtvec_mode_i,
   input  mcause_t     mcause_i,
 
+  input  logic        etrigger_wb_i,
+
   input  logic        csr_wr_in_wb_flush_i,
 
   // Debug Signal
@@ -205,6 +207,8 @@ module cv32e40x_controller import cv32e40x_pkg::*;
     .wu_wfe_i                    ( wu_wfe_i                 ),
 
     .mtvec_mode_i                ( mtvec_mode_i             ),
+
+    .etrigger_wb_i               ( etrigger_wb_i            ),
 
     // Debug Signal
     .debug_req_i                 ( debug_req_i              ),

--- a/rtl/cv32e40x_controller_fsm.sv
+++ b/rtl/cv32e40x_controller_fsm.sv
@@ -493,7 +493,6 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
   //   - This is guarded with using the sequence_interruptible, which tracks sequence progress through the WB stage.
   // When a CLIC pointer is in the pipeline stages EX or WB, we must block interrupts.
   //   - Interrupt would otherwise kill the pointer and use the address of the pointer for mepc. A following mret would then return to the mtvt table, losing program progress.
-  // Etrigger causes debug entry, and thus should not allow interrupt as the core currently prioritizes debug over interrupts.
   assign interrupt_allowed = lsu_interruptible_i && debug_interruptible && !fencei_ongoing && !xif_in_wb && !clic_ptr_in_pipeline && sequence_interruptible && !interrupt_blanking_q;
 
   // Allowing NMI's follow the same rule as regular interrupts, except we don't need to regard blanking of NMIs after a load/store.

--- a/rtl/cv32e40x_controller_fsm.sv
+++ b/rtl/cv32e40x_controller_fsm.sv
@@ -96,6 +96,9 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
   input  dcsr_t       dcsr_i,
   input  mcause_t     mcause_i,
 
+  // Trigger module
+  input  logic        etrigger_wb_i,              // Trigger module detected match in WB (etrigger)
+
   // Toplevel input
   input  logic        debug_req_i,                // External debug request
 
@@ -173,7 +176,8 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
   logic mret_ptr_in_wb; // CLIC pointer caused by mret is in WB
   logic dret_in_wb;
   logic ebreak_in_wb;
-  logic trigger_match_in_wb;
+  logic trigger_match_in_wb;   // mcontrol6 trigger in WB
+  logic etrigger_in_wb;        // exception trigger in WB
   logic xif_in_wb;
   logic clic_ptr_in_wb;   // CLIC pointer caused by directly acking an SHV is in WB (no mret)
 
@@ -182,6 +186,7 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
   logic pending_debug;
   logic pending_single_step;
   logic pending_interrupt;
+
 
   // Flags for allowing interrupt and debug
   logic exception_allowed;
@@ -330,6 +335,8 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
                               (lsu_mpu_status_wb_i == MPU_WR_FAULT)                      ? EXC_CAUSE_STORE_FAULT     :
                               EXC_CAUSE_LOAD_FAULT; // (lsu_mpu_status_wb_i == MPU_RE_FAULT)
 
+  assign ctrl_fsm_o.exception_cause_wb = exception_cause_wb;
+
   // For now we are always allowed to take exceptions once they arrive in WB.
   // For a misaligned load/store with MPU error on the first half, the second half
   // will arrive in EX when the first half (with error) arrives in WB. The exception will
@@ -364,6 +371,11 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
   // Trigger match in wb
   // Trigger_match during debug mode is masked in the trigger logic inside cs_registers.sv
   assign trigger_match_in_wb = (ex_wb_pipe_i.trigger_match && ex_wb_pipe_i.instr_valid);
+
+  // Only set the etrigger_in_wb flag when wb_valid is true (WB is not halted or killed).
+  // If a higher priority event than taking an exception (NMI, external debug or interrupts) are present, wb_valid_i will be
+  // suppressed by either halt_wb followed by kill_wb (debug), or kill_wb (NMI/interrupt).
+  assign etrigger_in_wb = etrigger_wb_i && wb_valid_i;
 
   // An offloaded instruction is in WB
   assign xif_in_wb = (ex_wb_pipe_i.xif_en && ex_wb_pipe_i.instr_valid);
@@ -458,8 +470,8 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
   // pending_single_step may only happen if no other causes for debug are true.
   // The flopped version of this is checked during DEBUG_TAKEN state (one cycle delay)
   // todo: update priority according to updated debug spec
-  assign debug_cause_n = pending_single_step ? DBG_CAUSE_STEP :
-                         trigger_match_in_wb ? DBG_CAUSE_TRIGGER :
+  assign debug_cause_n = pending_single_step                               ? DBG_CAUSE_STEP :
+                         (trigger_match_in_wb || etrigger_wb_i)            ? DBG_CAUSE_TRIGGER :
                          (ebreak_in_wb && dcsr_i.ebreakm && !debug_mode_q) ? DBG_CAUSE_EBREAK :
                          DBG_CAUSE_HALTREQ;
 
@@ -481,7 +493,7 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
   //   - This is guarded with using the sequence_interruptible, which tracks sequence progress through the WB stage.
   // When a CLIC pointer is in the pipeline stages EX or WB, we must block interrupts.
   //   - Interrupt would otherwise kill the pointer and use the address of the pointer for mepc. A following mret would then return to the mtvt table, losing program progress.
-
+  // Etrigger causes debug entry, and thus should not allow interrupt as the core currently prioritizes debug over interrupts.
   assign interrupt_allowed = lsu_interruptible_i && debug_interruptible && !fencei_ongoing && !xif_in_wb && !clic_ptr_in_pipeline && sequence_interruptible && !interrupt_blanking_q;
 
   // Allowing NMI's follow the same rule as regular interrupts, except we don't need to regard blanking of NMIs after a load/store.
@@ -930,11 +942,11 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
           end
         end // !debug or interrupts
 
-        // Single step debug entry
+        // Single step debug entry or etrigger debug entry
           // Need to be after (in parallell with) exception/interrupt handling
-          // to ensure mepc and if_pc set correctly for use in dpc,
+          // to ensure mepc and if_pc are set correctly for use in dpc,
           // and to ensure only one instruction can retire during single step
-        if (pending_single_step) begin
+        if (pending_single_step || etrigger_in_wb) begin
           if (single_step_allowed) begin
             ctrl_fsm_ns = DEBUG_TAKEN;
           end
@@ -988,6 +1000,7 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
           ctrl_fsm_o.kill_ex = 1'b1;
           // Ebreak that causes debug entry should not be killed, otherwise RVFI will skip it
           // Trigger match should also be signalled as not killed (all write enables are suppressed in ID), otherwise RVFI/ISS will not attempt to execute and detect trigger
+          // Exception trigger match should have nothing in WB, excepted instruction finished the previous cycle and set mepc and mcause due to the exception.
           // Ebreak during debug_mode restarts from dm_halt_addr, without CSR updates. Not killing ebreak due to the same RVFI/ISS reasons.
           // Neither ebreak nor trigger match have any state updates in WB. For trigger match, all write enables are suppressed in the ID stage.
           //   Thus this change is not visible to core state, only for RVFI use.

--- a/rtl/cv32e40x_core.sv
+++ b/rtl/cv32e40x_core.sv
@@ -291,6 +291,8 @@ module cv32e40x_core import cv32e40x_pkg::*;
   logic        trigger_match_if;
   // trigger match detected in trigger module (using EX/LSU timing)
   logic        trigger_match_ex;
+  // trigger match detected in trigger module (using WB timing, etrigger)
+  logic        etrigger_wb;
 
   // Controller <-> decoder
   logic        alu_jmp_id;
@@ -811,6 +813,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
     // Debug
     .trigger_match_if_o         ( trigger_match_if       ),
     .trigger_match_ex_o         ( trigger_match_ex       ),
+    .etrigger_wb_o              ( etrigger_wb       ),
     .pc_if_i                    ( pc_if                  ),
     .ptr_in_if_i                ( ptr_in_if              ),
     .lsu_valid_ex_i             ( lsu_valid_ex           ),
@@ -902,6 +905,9 @@ module cv32e40x_core import cv32e40x_pkg::*;
     // From CSR registers
     .mtvec_mode_i                   ( mtvec_mode             ),
     .mcause_i                       ( mcause                 ),
+
+    // Trigger module
+    .etrigger_wb_i                  ( etrigger_wb            ),
 
     // CSR write strobes
     .csr_wr_in_wb_flush_i           ( csr_wr_in_wb_flush     ),

--- a/rtl/cv32e40x_core.sv
+++ b/rtl/cv32e40x_core.sv
@@ -813,7 +813,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
     // Debug
     .trigger_match_if_o         ( trigger_match_if       ),
     .trigger_match_ex_o         ( trigger_match_ex       ),
-    .etrigger_wb_o              ( etrigger_wb       ),
+    .etrigger_wb_o              ( etrigger_wb            ),
     .pc_if_i                    ( pc_if                  ),
     .ptr_in_if_i                ( ptr_in_if              ),
     .lsu_valid_ex_i             ( lsu_valid_ex           ),

--- a/rtl/cv32e40x_cs_registers.sv
+++ b/rtl/cv32e40x_cs_registers.sv
@@ -105,6 +105,7 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
   input  logic                          ptr_in_if_i,
   output logic                          trigger_match_if_o,
   output logic                          trigger_match_ex_o,
+  output logic                          etrigger_wb_o,
   input  logic                          lsu_valid_ex_i,
   input  logic [31:0]                   lsu_addr_ex_i,
   input  logic                          lsu_we_ex_i,
@@ -1530,12 +1531,16 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
       .lsu_be_ex_i      ( lsu_be_ex_i   ),
       .priv_lvl_ex_i    ( PRIV_LVL_M    ),
 
+      // WB inputs
+      .priv_lvl_wb_i    ( PRIV_LVL_M    ),
+
       // Controller inputs
       .ctrl_fsm_i       ( ctrl_fsm_i    ),
 
       // Trigger match outputs
       .trigger_match_if_o  ( trigger_match_if_o ),
-      .trigger_match_ex_o  ( trigger_match_ex_o )
+      .trigger_match_ex_o  ( trigger_match_ex_o ),
+      .etrigger_wb_o       ( etrigger_wb_o      )
     );
 
 

--- a/rtl/cv32e40x_debug_triggers.sv
+++ b/rtl/cv32e40x_debug_triggers.sv
@@ -317,8 +317,7 @@ import cv32e40x_pkg::*;
         assign priv_lvl_match_en_wb[idx] = (tdata1_rdata[idx][ETRIGGER_M] && (priv_lvl_wb_i == PRIV_LVL_M)) ||
                                            (tdata1_rdata[idx][ETRIGGER_U] && (priv_lvl_wb_i == PRIV_LVL_U));
 
-        assign etrigger_wb[idx] = (tdata1_rdata[idx][TDATA1_TTYPE_HIGH:TDATA1_TTYPE_LOW] == TTYPE_ETRIGGER) && tdata1_rdata[idx][ETRIGGER_M] &&
-                                  priv_lvl_match_en_wb[idx] &&
+        assign etrigger_wb[idx] = (tdata1_rdata[idx][TDATA1_TTYPE_HIGH:TDATA1_TTYPE_LOW] == TTYPE_ETRIGGER) && priv_lvl_match_en_wb[idx] &&
                                   (|exception_match[idx]) && !ctrl_fsm_i.debug_mode;
 
 

--- a/rtl/cv32e40x_debug_triggers.sv
+++ b/rtl/cv32e40x_debug_triggers.sv
@@ -67,12 +67,16 @@ import cv32e40x_pkg::*;
   input  logic [3:0]  lsu_be_ex_i,
   input  privlvl_t    priv_lvl_ex_i,
 
+  // WB stage inputs
+  input  privlvl_t    priv_lvl_wb_i,
+
   // Controller inputs
   input ctrl_fsm_t    ctrl_fsm_i,
 
   // Trigger match outputs
   output logic        trigger_match_if_o,  // Instruction address match
-  output logic        trigger_match_ex_o   // Load/Store address match
+  output logic        trigger_match_ex_o,  // Load/Store address match
+  output logic        etrigger_wb_o        // Exception trigger match
 );
 
   // CSR write data
@@ -103,9 +107,10 @@ import cv32e40x_pkg::*;
       logic [31:0] tdata1_rdata[DBG_NUM_TRIGGERS];
       logic [31:0] tdata2_rdata[DBG_NUM_TRIGGERS];
 
-      // IF and EX stages trigger match
+      // IF, EX and WB stages trigger match
       logic [DBG_NUM_TRIGGERS-1 : 0] trigger_match_if;
       logic [DBG_NUM_TRIGGERS-1 : 0] trigger_match_ex;
+      logic [DBG_NUM_TRIGGERS-1 : 0] etrigger_wb;
 
       // Instruction address match
       logic [DBG_NUM_TRIGGERS-1 : 0] if_addr_match;
@@ -118,38 +123,86 @@ import cv32e40x_pkg::*;
       // Enable matching based on privilege level per trigger
       logic [DBG_NUM_TRIGGERS-1 : 0] priv_lvl_match_en_if;
       logic [DBG_NUM_TRIGGERS-1 : 0] priv_lvl_match_en_ex;
+      logic [DBG_NUM_TRIGGERS-1 : 0] priv_lvl_match_en_wb;
 
       logic [1:0]  lsu_addr_low_lsb;  // Lower two bits of the lowest accessed address
       logic [1:0]  lsu_addr_high_lsb; // Lower two bits of the highest accessed address
       logic [31:0] lsu_addr_low;      // The lowest accessed address of an LSU transaction
       logic [31:0] lsu_addr_high;     // The highest accessed address of an LSU transaction
 
+      // Exception trigger code match
+      logic [31:0] exception_match[DBG_NUM_TRIGGERS];
+
       // Write data
       always_comb begin
         // Tselect is WARL (0 -> DBG_NUM_TRIGGERS-1)
-        tselect_n     = (csr_wdata_i < DBG_NUM_TRIGGERS) ? csr_wdata_i : tselect_rdata_o;
+        tselect_n = (csr_wdata_i < DBG_NUM_TRIGGERS) ? csr_wdata_i : tselect_rdata_o;
+        tdata1_n  = tdata1_rdata_o;
+        tdata2_n  = tdata2_rdata_o;
 
-        // todo: handle WARL based on trigger type
-        tdata1_n      = {
-                          TTYPE_MCONTROL6,       // type    : address/data match
-                          1'b1,                  // dmode   : access from D mode only
-                          2'b00,                 // zero  26:25
-                          3'b000,                // zero, vs, vu, hit 24:22
-                          1'b0,                  // zero, select 21
-                          1'b0,                  // zero, timing 20
-                          4'b0000,               // zero, size (match any size) 19:16
-                          4'b0001,               // action, WARL(1), enter debug 15:12
-                          1'b0,                  // zero, chain 11
-                          mcontrol6_match_resolve(csr_wdata_i[MCONTROL6_MATCH_HIGH:MCONTROL6_MATCH_LOW]), // match, WARL(0,2,3) 10:7
-                          csr_wdata_i[6],        // M  6
-                          1'b0,                  // zero 5
-                          1'b0,                  // zero, S 4
-                          1'b0,                  // zero, U 3
-                          csr_wdata_i[2],        // EXECUTE 2
-                          csr_wdata_i[1],        // STORE 1
-                          csr_wdata_i[0]};       // LOAD 0
+        if (csr_wdata_i[TDATA1_TTYPE_HIGH:TDATA1_TTYPE_LOW] == TTYPE_MCONTROL6) begin
+          // Mcontrol6 supports any value in tdata2, no need to check tdata2 before writing tdata1
+          tdata1_n = {
+                       TTYPE_MCONTROL6,       // type    : address/data match
+                       1'b1,                  // dmode   : access from D mode only
+                       2'b00,                 // zero  26:25
+                       3'b000,                // zero, vs, vu, hit 24:22
+                       1'b0,                  // zero, select 21
+                       1'b0,                  // zero, timing 20
+                       4'b0000,               // zero, size (match any size) 19:16
+                       4'b0001,               // action, WARL(1), enter debug 15:12
+                       1'b0,                  // zero, chain 11
+                       mcontrol6_match_resolve(csr_wdata_i[MCONTROL6_MATCH_HIGH:MCONTROL6_MATCH_LOW]), // match, WARL(0,2,3) 10:7
+                       csr_wdata_i[6],        // M  6
+                       1'b0,                  // zero 5
+                       1'b0,                  // zero, S 4
+                       1'b0,                  // zero, U 3
+                       csr_wdata_i[2],        // EXECUTE 2
+                       csr_wdata_i[1],        // STORE 1
+                       csr_wdata_i[0]         // LOAD 0
+          };
+        end else if (csr_wdata_i[TDATA1_TTYPE_HIGH:TDATA1_TTYPE_LOW] == TTYPE_ETRIGGER) begin
+          // Etrigger can only support a subset of possible values in tdata2, only update tdata1 if
+          // tdata2 contains a legal value for etrigger.
 
-        tdata2_n      = csr_wdata_i;
+          // Detect if any cleared bits in ETRIGGER_TDATA2_MASK are set in tdata2
+          if (0) begin //|(tdata2_rdata_o & (~ETRIGGER_TDATA2_MASK))) begin
+            // Unsupported exception codes enabled, keep value of tdata1
+            tdata1_n = tdata1_rdata_o;
+          end else begin
+            tdata1_n = {
+                        TTYPE_ETRIGGER,        // type  : exception trigger
+                        1'b1,                  // dmode : access from D mode only 27
+                        1'b0,                  // hit   : WARL(0) 26
+                        13'h0,                 // zero  : tied to zero 25:13
+                        1'b0,                  // vs    : WARL(0) 12
+                        1'b0,                  // vu    : WARL(0) 11
+                        1'b0,                  // zero  : tied to zero 10
+                        csr_wdata_i[9],        // m     : Match in machine mode 9
+                        1'b0,                  // zero  : tied to zero 8
+                        1'b0,                  // s     : WARL(0) 7
+                        1'b0,                  // u     : Match in user mode 7
+                        6'b000001              // action : WARL(1), enter debug on match
+            };
+          end
+        end else if (csr_wdata_i[TDATA1_TTYPE_HIGH:TDATA1_TTYPE_LOW] == TTYPE_DISABLED) begin
+          // All tdata2 values are legal for a disabled trigger, no WARL on tdata1.
+          tdata1_n = {TTYPE_DISABLED, 1'b1, {27{1'b0}}};
+        end else begin
+          // No legal trigger type, keep currently selected value
+          tdata1_n = tdata1_rdata_o;
+        end
+
+        // tdata2
+        if ((tdata1_rdata_o[TDATA1_TTYPE_HIGH:TDATA1_TTYPE_LOW] == TTYPE_DISABLED) ||
+            (tdata1_rdata_o[TDATA1_TTYPE_HIGH:TDATA1_TTYPE_LOW] == TTYPE_MCONTROL6)) begin
+          // Disabled trigger and mcontrol6 can have any value in tdata2
+          tdata2_n = csr_wdata_i;
+        end else begin
+          // Exception trigger, only allow implemented exception codes to be used
+          tdata2_n = csr_wdata_i & ETRIGGER_TDATA2_MASK;
+        end
+
         tdata3_n      = tdata3_rdata_o;   // Read only
         tinfo_n       = tinfo_rdata_o;    // Read only
         tcontrol_n    = tcontrol_rdata_o; // Read only
@@ -205,7 +258,8 @@ import cv32e40x_pkg::*;
                                            (tdata1_rdata[idx][MCONTROL6_U] && (priv_lvl_if_i == PRIV_LVL_U));
 
         // Check for trigger match from IF
-        assign trigger_match_if[idx] = tdata1_rdata[idx][MCONTROL6_EXECUTE] && priv_lvl_match_en_if[idx] && !ctrl_fsm_i.debug_mode && !ptr_in_if_i &&
+        assign trigger_match_if[idx] = (tdata1_rdata[idx][TDATA1_TTYPE_HIGH:TDATA1_TTYPE_LOW] == TTYPE_MCONTROL6) &&
+                                       tdata1_rdata[idx][MCONTROL6_EXECUTE] && priv_lvl_match_en_if[idx] && !ctrl_fsm_i.debug_mode && !ptr_in_if_i &&
                                        if_addr_match[idx];
 
         ///////////////////////////////////////
@@ -243,10 +297,30 @@ import cv32e40x_pkg::*;
                                            (tdata1_rdata[idx][MCONTROL6_U] && (priv_lvl_ex_i == PRIV_LVL_U));
 
         // Enable LSU address matching
-        assign lsu_addr_match_en[idx] = lsu_valid_ex_i && ((tdata1_rdata[idx][MCONTROL6_LOAD] && !lsu_we_ex_i) || (tdata1_rdata[idx][MCONTROL6_STORE] && lsu_we_ex_i));
+        assign lsu_addr_match_en[idx] = lsu_valid_ex_i && (tdata1_rdata[idx][TDATA1_TTYPE_HIGH:TDATA1_TTYPE_LOW] == TTYPE_MCONTROL6) &&
+                                        ((tdata1_rdata[idx][MCONTROL6_LOAD] && !lsu_we_ex_i) || (tdata1_rdata[idx][MCONTROL6_STORE] && lsu_we_ex_i));
 
         // Signal trigger match for LSU address
         assign trigger_match_ex[idx] = priv_lvl_match_en_ex[idx] &&  lsu_addr_match_en[idx] && lsu_addr_match[idx] && !ctrl_fsm_i.debug_mode;
+
+        /////////////////////////////
+        // Exception trigger
+        /////////////////////////////
+
+        always_comb begin
+          exception_match[idx] = 32'd0;
+          for (int i=0; i<32; i++) begin
+            exception_match[idx][i] = tdata2_rdata[idx][i] && ctrl_fsm_i.exception_in_wb && (ctrl_fsm_i.exception_cause_wb == 11'(i));
+          end
+        end
+
+        assign priv_lvl_match_en_wb[idx] = (tdata1_rdata[idx][ETRIGGER_M] && (priv_lvl_wb_i == PRIV_LVL_M)) ||
+                                           (tdata1_rdata[idx][ETRIGGER_U] && (priv_lvl_wb_i == PRIV_LVL_U));
+
+        assign etrigger_wb[idx] = (tdata1_rdata[idx][TDATA1_TTYPE_HIGH:TDATA1_TTYPE_LOW] == TTYPE_ETRIGGER) && tdata1_rdata[idx][ETRIGGER_M] &&
+                                  priv_lvl_match_en_wb[idx] &&
+                                  (|exception_match[idx]) && !ctrl_fsm_i.debug_mode;
+
 
 
         cv32e40x_csr
@@ -282,7 +356,6 @@ import cv32e40x_pkg::*;
         assign tdata2_we_int[idx] = tdata2_we_i && (tselect_rdata_o == idx);
 
         // Assign read data
-        // todo: WARL
         assign tdata1_rdata[idx] = tdata1_q[idx];
         assign tdata2_rdata[idx] = tdata2_q[idx];
       end // for
@@ -318,7 +391,7 @@ import cv32e40x_pkg::*;
 
       assign tdata3_rdata_o   = 32'h00000000;
       assign tselect_rdata_o  = tselect_q;
-      assign tinfo_rdata_o    = 32'h4; // todo: update
+      assign tinfo_rdata_o    = 32'h00008060; // Supported types 0x5, 0x6 and 0xF
       assign tcontrol_rdata_o = 32'h00000000;
 
       // Set trigger match for IF
@@ -326,6 +399,9 @@ import cv32e40x_pkg::*;
 
       // Set trigger match for EX
       assign trigger_match_ex_o = |trigger_match_ex;
+
+      // Set trigger match for WB
+      assign etrigger_wb_o = |etrigger_wb;
 
       assign unused_signals = tinfo_we_i | tcontrol_we_i | tdata3_we_i | (|tinfo_n) | (|tdata3_n) | (|tcontrol_n);
 
@@ -339,6 +415,7 @@ import cv32e40x_pkg::*;
       assign tcontrol_rdata_o = '0;
       assign trigger_match_if_o = '0;
       assign trigger_match_ex_o = '0;
+      assign etrigger_wb_o = '0;
       assign tdata1_n = '0;
       assign tdata2_n = '0;
       assign tdata3_n = '0;

--- a/rtl/include/cv32e40x_pkg.sv
+++ b/rtl/include/cv32e40x_pkg.sv
@@ -669,6 +669,14 @@ parameter logic [31:0] TDATA1_RST_VAL = {
   parameter MCONTROL6_STORE      = 1;
   parameter MCONTROL6_LOAD       = 0;
 
+  parameter ETRIGGER_M = 9;
+  parameter ETRIGGER_U = 7;
+
+  // Bit position parameters for trigger type within tdata1
+  parameter TDATA1_TTYPE_HIGH = 31;
+  parameter TDATA1_TTYPE_LOW  = 28;
+
+
 ///////////////////////////////////////////////
 //   ___ ____    ____  _                     //
 //  |_ _|  _ \  / ___|| |_ __ _  __ _  ___   //
@@ -878,6 +886,9 @@ parameter EXC_CAUSE_LOAD_FAULT      = 11'h05;
 parameter EXC_CAUSE_STORE_FAULT     = 11'h07;
 parameter EXC_CAUSE_ECALL_MMODE     = 11'h0B;
 parameter EXC_CAUSE_INSTR_BUS_FAULT = 11'h30;
+
+parameter logic [31:0] ETRIGGER_TDATA2_MASK = (1 << EXC_CAUSE_INSTR_BUS_FAULT) | (1 << EXC_CAUSE_ECALL_MMODE) | (1 << EXC_CAUSE_STORE_FAULT) |
+                                              (1 << EXC_CAUSE_LOAD_FAULT) | (1 << EXC_CAUSE_BREAKPOINT) | (1 << EXC_CAUSE_ILLEGAL_INSN) | (1 << EXC_CAUSE_INSTR_FAULT);
 
 parameter INT_CAUSE_LSU_LOAD_FAULT  = 11'h400;
 parameter INT_CAUSE_LSU_STORE_FAULT = 11'h401;
@@ -1295,6 +1306,7 @@ typedef struct packed {
 
   // Signal that an exception is in WB
   logic        exception_in_wb;
+  logic [10:0] exception_cause_wb;
 } ctrl_fsm_t;
 
   ////////////////////////////////////////

--- a/rtl/include/cv32e40x_pkg.sv
+++ b/rtl/include/cv32e40x_pkg.sv
@@ -670,7 +670,7 @@ parameter logic [31:0] TDATA1_RST_VAL = {
   parameter MCONTROL6_LOAD       = 0;
 
   parameter ETRIGGER_M = 9;
-  parameter ETRIGGER_U = 7;
+  parameter ETRIGGER_U = 6;
 
   // Bit position parameters for trigger type within tdata1
   parameter TDATA1_TTYPE_HIGH = 31;

--- a/sva/cv32e40x_controller_fsm_sva.sv
+++ b/sva/cv32e40x_controller_fsm_sva.sv
@@ -104,7 +104,8 @@ module cv32e40x_controller_fsm_sva
   input logic           clic_ptr_in_progress_id_set,
   input logic           clic_ptr_in_progress_id,
   input pipe_pc_mux_e   pipe_pc_mux_ctrl,
-  input logic           ptr_in_if_i
+  input logic           ptr_in_if_i,
+  input logic           etrigger_in_wb
 );
 
 
@@ -827,5 +828,11 @@ end
                     ((pipe_pc_mux_ctrl == PC_ID) && (if_id_pipe_i.instr_meta.clic_ptr || if_id_pipe_i.instr_meta.mret_ptr || (if_id_pipe_i.instr_meta.tbljmp && last_op_id_i))) ||
                     ((pipe_pc_mux_ctrl == PC_IF) && ptr_in_if_i)))
   else `uvm_error("controller", "Pointer used for context storage")
+
+  // etrigger_in_wb shall only be set when there is an exception in wb
+  a_etrig_exception:
+  assert property (@(posedge clk) disable iff (!rst_n)
+                    etrigger_in_wb |-> exception_in_wb)
+    else `uvm_error("controller", "etrigger_in_wb when there is no exception in WB")
 endmodule
 

--- a/sva/cv32e40x_cs_registers_sva.sv
+++ b/sva/cv32e40x_cs_registers_sva.sv
@@ -33,6 +33,7 @@ module cv32e40x_cs_registers_sva
    input logic        clk,
    input logic        rst_n,
    input ctrl_fsm_t   ctrl_fsm_i,
+   input ctrl_state_e ctrl_fsm_cs,
    input id_ex_pipe_t id_ex_pipe_i,
    input ex_wb_pipe_t ex_wb_pipe_i,
    input logic [31:0] csr_rdata_o,
@@ -52,7 +53,13 @@ module cv32e40x_cs_registers_sva
    csr_num_e          csr_waddr,
    input logic        mscratch_we,
    input logic        instr_valid,
-   input csr_opcode_e csr_op
+   input csr_opcode_e csr_op,
+   input logic        etrigger_wb_o,
+   input logic        mepc_we,
+   input logic [31:0] mepc_n,
+   input logic [24:0] mtvec_addr_o,
+   input logic [31:0] dpc_n,
+   input logic        dpc_we
 
    );
 
@@ -158,5 +165,29 @@ module cv32e40x_cs_registers_sva
     else `uvm_error("cs_registers", "csr_save_cause at the same time as csr_clear_minhv.");
 
 
+  // Exception trigger shall have mepc written to oldest instruction
+  property p_etrigger_mepc_write;
+    @(posedge clk) disable iff (!rst_n)
+    (  (ctrl_fsm_cs == FUNCTIONAL) && etrigger_wb_o && !(ctrl_fsm_i.halt_wb || ctrl_fsm_i.kill_wb)
+        |->
+        (mepc_we && (mepc_n == ctrl_fsm_i.pipe_pc)));
+  endproperty;
+
+  a_etrigger_mepc_write: assert property(p_etrigger_mepc_write)
+    else `uvm_error("cs_registers", "mepc not written with ctrl_fsm.pipe_pc when etrigger fires.");
+
+  // Exception trigger shall cause dpc to point to first handler instruction and no instruction shall signal wb_valid the cycle after (while in DEBUG_TAKEN state)
+  // Excluding external debug and interrupts (halt_wb, kill_wb) as they (currently) both take priority over etrigger
+  // todo: update when debug causes are updated, trigger match will not be highest priority
+  property p_etrigger_dpc_write;
+    logic [24:0] mtvec_at_trap;
+    @(posedge clk) disable iff (!rst_n)
+    (  ((ctrl_fsm_cs == FUNCTIONAL) && etrigger_wb_o && !(ctrl_fsm_i.halt_wb || ctrl_fsm_i.kill_wb), mtvec_at_trap = mtvec_addr_o)
+        |=>
+        (!wb_valid_i && dpc_we && (dpc_n == {mtvec_at_trap, {7'd0}}) && (ctrl_fsm_cs == DEBUG_TAKEN)));
+  endproperty;
+
+  a_etrigger_dpc_write: assert property(p_etrigger_dpc_write)
+    else `uvm_error("cs_registers", "dpc not written with first handler instruction when etrigger fires.");
 endmodule
 

--- a/sva/cv32e40x_cs_registers_sva.sv
+++ b/sva/cv32e40x_cs_registers_sva.sv
@@ -178,13 +178,14 @@ module cv32e40x_cs_registers_sva
 
   // Exception trigger shall cause dpc to point to first handler instruction and no instruction shall signal wb_valid the cycle after (while in DEBUG_TAKEN state)
   // Excluding external debug and interrupts (halt_wb, kill_wb) as they (currently) both take priority over etrigger
+  // Also checking that WB stage is empty after an exception trigger has been taken.
   // todo: update when debug causes are updated, trigger match will not be highest priority
   property p_etrigger_dpc_write;
     logic [24:0] mtvec_at_trap;
     @(posedge clk) disable iff (!rst_n)
     (  ((ctrl_fsm_cs == FUNCTIONAL) && etrigger_wb_o && !(ctrl_fsm_i.halt_wb || ctrl_fsm_i.kill_wb), mtvec_at_trap = mtvec_addr_o)
         |=>
-        (!wb_valid_i && dpc_we && (dpc_n == {mtvec_at_trap, {7'd0}}) && (ctrl_fsm_cs == DEBUG_TAKEN)));
+        (!wb_valid_i && !ex_wb_pipe_i.instr_valid && dpc_we && (dpc_n == {mtvec_at_trap, {7'd0}}) && (ctrl_fsm_cs == DEBUG_TAKEN)));
   endproperty;
 
   a_etrigger_dpc_write: assert property(p_etrigger_dpc_write)


### PR DESCRIPTION
Implemented trigger type 0x5 (exception trigger) and 0xF (disabled trigger).

- WARL handling of both tdata1 and tdata2 to ensure no invalid combination of tdata1 and tdata2 can occure.
- Exception trigger uses same logic as single step debug entry to allow for exception side effects to happen before debug entry is done.

Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>