### PR TITLE
Bugfix: LSU trigger match could cause tracking of split misaligned transactions to get out of sync

### DIFF
--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -243,6 +243,9 @@ module cv32e40x_wrapper
       // The SVA's monitor modport can't connect to a master modport, so it is connected to the interface instance directly:
       .m_c_obi_data_if(core_i.m_c_obi_data_if),
       .ex_wb_pipe_i   (core_i.ex_wb_pipe),
+      .id_valid       (core_i.id_valid),
+      .ex_ready       (core_i.ex_ready),
+      .lsu_en_id      (core_i.id_stage_i.lsu_en),
       .*);
 
   bind cv32e40x_prefetch_unit:

--- a/rtl/cv32e40x_load_store_unit.sv
+++ b/rtl/cv32e40x_load_store_unit.sv
@@ -286,20 +286,16 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
   // Tracking split (misaligned) state
   // This signals has EX timing, and indicates that the second
   // address phase of a split transfer is taking place
-  // Reset/killed on !valid_0_gated when no trigger match is present to ensure it is zero for the
+  // Reset/killed on !valid_0_gated to ensure it is zero for the
   // first phase of the next instruction. Otherwise it could stick at 1 after a killed
   // split, causing next LSU instruction to calculate wrong _be.
-  // If reset due to valid_0_gated being pulled low by trigger_match_0_i, the change from 1 to 0 in split_q
-  // would cause the align_trans.addr to change, possibly changing the value of trigger_match_0_i before the
-  // instruction goes from EX to WB.
-  // When a trigger match occurs, the split_q flag will be reset to 0 once ready_0_i goes high. (lsu_split_0_o is 0 when valid_0_gated == 0).
   always_ff @(posedge clk, negedge rst_n) begin
     if (rst_n == 1'b0) begin
       split_q    <= 1'b0;
     end else begin
-      if(!valid_0_gated && !trigger_match_0_i && !xif_req) begin
+      if(!valid_0_gated && !xif_req) begin
         split_q <= 1'b0; // Reset split_st when no valid instructions
-      end else if (ctrl_update || (trigger_match_0_i && ready_0_i)) begin // EX done, update split_q for next address phase
+      end else if (ctrl_update) begin // EX done, update split_q for next address phase
         split_q <= lsu_split_0_o;
       end
     end

--- a/rtl/cv32e40x_load_store_unit.sv
+++ b/rtl/cv32e40x_load_store_unit.sv
@@ -286,17 +286,20 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
   // Tracking split (misaligned) state
   // This signals has EX timing, and indicates that the second
   // address phase of a split transfer is taking place
-  // Reset/killed on !valid_0_gated to ensure it is zero for the
+  // Reset/killed on !valid_0_gated when no trigger match is present to ensure it is zero for the
   // first phase of the next instruction. Otherwise it could stick at 1 after a killed
   // split, causing next LSU instruction to calculate wrong _be.
-  // todo: add assertion that it is zero for the first phase (regardless of alignment)
+  // If reset due to valid_0_gated being pulled low by trigger_match_0_i, the change from 1 to 0 in split_q
+  // would cause the align_trans.addr to change, possibly changing the value of trigger_match_0_i before the
+  // instruction goes from EX to WB.
+  // When a trigger match occurs, the split_q flag will be reset to 0 once ready_0_i goes high. (lsu_split_0_o is 0 when valid_0_gated == 0).
   always_ff @(posedge clk, negedge rst_n) begin
     if (rst_n == 1'b0) begin
       split_q    <= 1'b0;
     end else begin
-      if(!valid_0_gated && !xif_req) begin
+      if(!valid_0_gated && !trigger_match_0_i && !xif_req) begin
         split_q <= 1'b0; // Reset split_st when no valid instructions
-      end else if (ctrl_update) begin // EX done, update split_q for next address phase
+      end else if (ctrl_update || (trigger_match_0_i && ready_0_i)) begin // EX done, update split_q for next address phase
         split_q <= lsu_split_0_o;
       end
     end


### PR DESCRIPTION
Suppressing LSU valid_0_i on trigger_match_0_i could cause the split_q flag to reset to zero before the last part of an LSU was allowed to go from EX to WB. This could cause an address change and change of the trigger match value.

Updated setting/resetting of split_q to take trigger matches into account.

Added assertions to check that split_q is always 0 when a new LSU instruction enters the EX stage and that the trigger match flag is stable while an LSU instruction remains in EX.

Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>

ed files: