### PR TITLE
Watchpoint triggers refactor

### DIFF
--- a/bhv/cv32e40x_rvfi.sv
+++ b/bhv/cv32e40x_rvfi.sv
@@ -109,7 +109,6 @@ module cv32e40x_rvfi
    input logic                                single_step_allowed_i,
    input logic                                nmi_pending_i,          // regular NMI pending
    input logic                                nmi_is_store_i,         // regular NMI type
-   input logic                                pending_debug_i,
    input logic                                debug_mode_q_i,
 
    // Interrupt Controller probes

--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -247,6 +247,8 @@ module cv32e40x_wrapper
       .id_valid       (core_i.id_valid),
       .ex_ready       (core_i.ex_ready),
       .lsu_en_id      (core_i.id_stage_i.lsu_en),
+      .ctrl_fsm_cs    (core_i.controller_i.controller_fsm_i.ctrl_fsm_cs),
+      .ctrl_fsm_ns    (core_i.controller_i.controller_fsm_i.ctrl_fsm_ns),
       .*);
 
   bind cv32e40x_prefetch_unit:
@@ -289,8 +291,10 @@ module cv32e40x_wrapper
                 .exc_cause                        (core_i.controller_i.controller_fsm_i.exc_cause),
                 // probed controller signals
                 .ctrl_debug_mode_n                (core_i.controller_i.controller_fsm_i.debug_mode_n),
-                .ctrl_pending_debug               (core_i.controller_i.controller_fsm_i.pending_debug),
-                .ctrl_debug_allowed               (core_i.controller_i.controller_fsm_i.debug_allowed),
+                .ctrl_pending_async_debug         (core_i.controller_i.controller_fsm_i.pending_async_debug),
+                .ctrl_async_debug_allowed         (core_i.controller_i.controller_fsm_i.async_debug_allowed),
+                .ctrl_pending_sync_debug          (core_i.controller_i.controller_fsm_i.pending_sync_debug),
+                .ctrl_sync_debug_allowed          (core_i.controller_i.controller_fsm_i.sync_debug_allowed),
                 .ctrl_pending_interrupt           (core_i.controller_i.controller_fsm_i.pending_interrupt),
                 .ctrl_interrupt_allowed           (core_i.controller_i.controller_fsm_i.interrupt_allowed),
                 .ctrl_debug_cause_n               (core_i.controller_i.controller_fsm_i.debug_cause_n),
@@ -504,7 +508,6 @@ endgenerate
          .single_step_allowed_i    ( core_i.controller_i.controller_fsm_i.single_step_allowed             ),
          .nmi_pending_i            ( core_i.controller_i.controller_fsm_i.nmi_pending_q                   ),
          .nmi_is_store_i           ( core_i.controller_i.controller_fsm_i.nmi_is_store_q                  ),
-         .pending_debug_i          ( core_i.controller_i.controller_fsm_i.pending_debug                   ),
          .debug_mode_q_i           ( core_i.controller_i.controller_fsm_i.debug_mode_q                    ),
          .irq_i                    ( core_i.irq_i & IRQ_MASK                                              ),
          .irq_wu_ctrl_i            ( core_i.irq_wu_ctrl                                                   ),

--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -249,6 +249,8 @@ module cv32e40x_wrapper
       .lsu_en_id      (core_i.id_stage_i.lsu_en),
       .ctrl_fsm_cs    (core_i.controller_i.controller_fsm_i.ctrl_fsm_cs),
       .ctrl_fsm_ns    (core_i.controller_i.controller_fsm_i.ctrl_fsm_ns),
+      .mpu_state      (core_i.load_store_unit_i.mpu_i.state_q),
+      .wpt_state      (core_i.load_store_unit_i.wpt_i.state_q),
       .*);
 
   bind cv32e40x_prefetch_unit:

--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -35,6 +35,7 @@
   `include "cv32e40x_sequencer_sva.sv"
   `include "cv32e40x_clic_int_controller_sva.sv"
   `include "cv32e40x_register_file_sva.sv"
+  `include "cv32e40x_wpt_sva.sv"
 `endif
 
 `include "cv32e40x_wrapper.vh"
@@ -249,10 +250,17 @@ module cv32e40x_wrapper
       .lsu_en_id      (core_i.id_stage_i.lsu_en),
       .ctrl_fsm_cs    (core_i.controller_i.controller_fsm_i.ctrl_fsm_cs),
       .ctrl_fsm_ns    (core_i.controller_i.controller_fsm_i.ctrl_fsm_ns),
-      .mpu_state      (core_i.load_store_unit_i.mpu_i.state_q),
-      .wpt_state      (core_i.load_store_unit_i.wpt_i.state_q),
       .*);
 
+  generate
+    if (DBG_NUM_TRIGGERS > 0) begin : wpt_sva
+      bind cv32e40x_wpt:
+        core_i.load_store_unit_i.gen_wpt.wpt_i
+          cv32e40x_wpt_sva wpt_sva(
+            .mpu_state (core_i.load_store_unit_i.mpu_i.state_q),
+            .*);
+    end
+  endgenerate
   bind cv32e40x_prefetch_unit:
     core_i.if_stage_i.prefetch_unit_i
       cv32e40x_prefetch_unit_sva

--- a/cv32e40x_manifest.flist
+++ b/cv32e40x_manifest.flist
@@ -73,6 +73,7 @@ ${DESIGN_RTL_DIR}/cv32e40x_core.sv
 ${DESIGN_RTL_DIR}/cv32e40x_mpu.sv
 ${DESIGN_RTL_DIR}/cv32e40x_pma.sv
 ${DESIGN_RTL_DIR}/cv32e40x_pc_target.sv
+${DESIGN_RTL_DIR}/cv32e40x_wpt.sv
 
 ${DESIGN_RTL_DIR}/../bhv/cv32e40x_sim_clock_gate.sv
 ${DESIGN_RTL_DIR}/../bhv/cv32e40x_rvfi_instr_obi.sv

--- a/rtl/cv32e40x_controller.sv
+++ b/rtl/cv32e40x_controller.sv
@@ -80,6 +80,7 @@ module cv32e40x_controller import cv32e40x_pkg::*;
   input  logic        lsu_busy_i,                 // LSU is busy with outstanding transfers
   input  logic        lsu_interruptible_i,        // LSU may be interrupted
   input  logic        lsu_valid_wb_i,             // LSU is valid in WB (factors in rvalid from either OBI bus or write buffer)
+  input  logic        lsu_wpt_match_wb_i,         // LSU watchpoint trigger in WB
 
   // jump/branch signals
   input  logic        branch_decision_ex_i,       // branch decision signal from EX ALU
@@ -190,6 +191,7 @@ module cv32e40x_controller import cv32e40x_pkg::*;
     .last_op_wb_i                ( last_op_wb_i             ),
     .abort_op_wb_i               ( abort_op_wb_i            ),
     .lsu_valid_wb_i              ( lsu_valid_wb_i           ),
+    .lsu_wpt_match_wb_i          ( lsu_wpt_match_wb_i       ),
 
     .lsu_interruptible_i         ( lsu_interruptible_i      ),
 

--- a/rtl/cv32e40x_controller_fsm.sv
+++ b/rtl/cv32e40x_controller_fsm.sv
@@ -80,6 +80,8 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
   input  logic        lsu_busy_i,                 // LSU is busy with outstanding transfers
   input  logic        lsu_interruptible_i,        // LSU can be interrupted
 
+  input  logic        lsu_wpt_match_wb_i,         // LSU watchpoint trigger (WB)
+
   // Interrupt Controller Signals
   input  logic        irq_wu_ctrl_i,              // Irq wakeup control
   input  logic        irq_req_ctrl_i,             // Irq request
@@ -183,7 +185,8 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
 
   logic pending_nmi;
   logic pending_nmi_early;
-  logic pending_debug;
+  logic pending_async_debug;
+  logic pending_sync_debug;
   logic pending_single_step;
   logic pending_interrupt;
 
@@ -192,7 +195,8 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
   logic exception_allowed;
   logic interrupt_allowed;
   logic nmi_allowed;
-  logic debug_allowed;
+  logic async_debug_allowed;
+  logic sync_debug_allowed;
   logic single_step_allowed;
 
   // Flag for blocking interrupts due to debug conditions
@@ -370,7 +374,7 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
 
   // Trigger match in wb
   // Trigger_match during debug mode is masked in the trigger logic inside cs_registers.sv
-  assign trigger_match_in_wb = (ex_wb_pipe_i.trigger_match && ex_wb_pipe_i.instr_valid);
+  assign trigger_match_in_wb = ((ex_wb_pipe_i.trigger_match || lsu_wpt_match_wb_i) && ex_wb_pipe_i.instr_valid);
 
   // Only set the etrigger_in_wb flag when wb_valid is true (WB is not halted or killed).
   // If a higher priority event than taking an exception (NMI, external debug or interrupts) are present, wb_valid_i will be
@@ -431,7 +435,8 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
   //   - For un-faulted pointer fetches, the second fetch of the CLIC vectoring took place in ID, and the final SHV handler target address will be available from IF.
   //   - A faulted pointer fetch does not perform the second fetch. Instead the exception handler fetch will occur before entering debug due to stepping.
   // todo: Likely flop the wb_valid/last_op/abort_op to be able to evaluate all debug reasons (debug_req when pointer is in WB is not allowed, while single step is allowed)
-  assign pending_single_step = (!debug_mode_q && dcsr_i.step && ((wb_valid_i && (last_op_wb_i || abort_op_wb_i)) || non_shv_irq_ack)) && !pending_debug;
+  // todo: can this be merged with pending_sync_debug in the future?
+  assign pending_single_step = (!debug_mode_q && dcsr_i.step && ((wb_valid_i && (last_op_wb_i || abort_op_wb_i)) || non_shv_irq_ack)) && !(pending_async_debug || pending_sync_debug);
 
 
   // Detect if there is a live CLIC pointer in the pipeline
@@ -458,18 +463,31 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
   //   - If trigger_match_in_wb is caused by instruction address match, then no side effects will happen for a sequence, and debug mode is entered when the first operation is in WB.
   // When a CLIC pointer is in the pipeline stages EX or WB, we must block debug.
   //   - Debug would otherwise kill the pointer and use the address of the pointer for dpc. A following dret would then return to the mtvt table, losing program progress.
-  assign debug_allowed = lsu_interruptible_i && !fencei_ongoing && !xif_in_wb && !clic_ptr_in_pipeline && (sequence_interruptible || trigger_match_in_wb);
+  assign async_debug_allowed = lsu_interruptible_i && !fencei_ongoing && !xif_in_wb && !clic_ptr_in_pipeline && sequence_interruptible;
 
-  // Debug pending for any other reason than single step
-  assign pending_debug = (trigger_match_in_wb) ||
-                         ((debug_req_i || debug_req_q) && !debug_mode_q)   || // External request
-                         (ebreak_in_wb && dcsr_i.ebreakm && !debug_mode_q) || // Ebreak with dcsr.ebreakm==1
-                         (ebreak_in_wb && debug_mode_q); // Ebreak during debug_mode restarts execution from dm_halt_addr, as a regular debug entry without CSR updates.
+  // synchronous debug entry have far fewer restrictions than asynchronous entries. In principle synchronous debug entry should have the same
+  // 'allowed' signal as exceptions - that is it should always be possible.
+  // todo: When XIF is being finished, debug entry vs xif must be reevaluated.
+  assign sync_debug_allowed = !xif_in_wb;
+
+  // Debug pending for any other synchronous reason than single step
+  assign pending_sync_debug = (trigger_match_in_wb) ||
+                              (ebreak_in_wb && dcsr_i.ebreakm && !debug_mode_q) || // Ebreak with dcsr.ebreakm==1
+                              (ebreak_in_wb && debug_mode_q); // Ebreak during debug_mode restarts execution from dm_halt_addr, as a regular debug entry without CSR updates.
+
+  // Debug pending for external debug request
+  assign pending_async_debug = ((debug_req_i || debug_req_q) && !debug_mode_q);
 
   // Determine cause of debug
   // pending_single_step may only happen if no other causes for debug are true.
   // The flopped version of this is checked during DEBUG_TAKEN state (one cycle delay)
   // todo: update priority according to updated debug spec
+  // 1: resethaltreq (0x5)
+  // 2: halt group (0x6)
+  // 3: haltreq (0x3)
+  // 4: trigger match (0x2)
+  // 5: ebreak (0x1)
+  // 6: single step (0x4)
   assign debug_cause_n = pending_single_step                               ? DBG_CAUSE_STEP :
                          (trigger_match_in_wb || etrigger_wb_i)            ? DBG_CAUSE_TRIGGER :
                          (ebreak_in_wb && dcsr_i.ebreakm && !debug_mode_q) ? DBG_CAUSE_EBREAK :
@@ -578,7 +596,7 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
     //                           may cause a deadlock.
     ctrl_fsm_o.halt_id          = ctrl_byp_i.jalr_stall || ctrl_byp_i.load_stall || ctrl_byp_i.csr_stall || ctrl_byp_i.wfi_wfe_stall || ctrl_byp_i.mnxti_id_stall ||
       (((pending_interrupt && !interrupt_allowed) || (pending_nmi && !nmi_allowed) || (pending_nmi_early)) && debug_interruptible && id_stage_haltable) ||
-      (pending_debug && !debug_allowed && id_stage_haltable);
+      (((pending_async_debug && !async_debug_allowed) ||(pending_sync_debug && !sync_debug_allowed)) && id_stage_haltable);
 
 
     // Halting EX if minstret_stall occurs. Otherwise we would read the wrong minstret value
@@ -675,8 +693,15 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
           end
 
         // Debug entry (except single step which is handled later)
-        end else if (pending_debug && debug_allowed) begin
+        // todo: may split this into two separate if's, and then prioritize synchronous debug entry below interrupts.
+        end else if ((pending_async_debug && async_debug_allowed) ||
+                     (pending_sync_debug && sync_debug_allowed)) begin
           // Halt the whole pipeline
+          // Halting makes sure instructions stay in the pipeline stage without propagating to the next.
+          //  This is needed by the debug entry code in the DEBUG_STAKEN state to pick the correct PC for storing in dpc.
+          //  Note that signals like lsu_wpt_match_wb_i and lsu_mpu_status_wb_i will not be constant while WB is halted as
+          //  these behave as an rvalid. In general LSU instruction shall not be allowed to be halted, unless there is a
+          //  watchpoint address match.
           ctrl_fsm_o.halt_if = 1'b1;
           ctrl_fsm_o.halt_id = 1'b1;
           ctrl_fsm_o.halt_ex = 1'b1;
@@ -1056,7 +1081,7 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
   end
 
   // Wakeup from sleep
-  assign ctrl_fsm_o.wake_from_sleep        = irq_wu_ctrl_i || pending_debug || debug_mode_q || (wfe_in_wb && wu_wfe_i); // Only WFE wakes up for wfe_wu_i
+  assign ctrl_fsm_o.wake_from_sleep        = irq_wu_ctrl_i || pending_async_debug || debug_mode_q || (wfe_in_wb && wu_wfe_i); // Only WFE wakes up for wfe_wu_i
   assign ctrl_fsm_o.debug_wfi_wfe_no_sleep = debug_mode_q || dcsr_i.step;
 
   ////////////////////
@@ -1198,7 +1223,7 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
           sequence_in_progress_wb <= 1'b1;
         end
       end else begin
-        // sequence_in_progress_wb is set, clear when last_op retires or sequence is aborted.
+        // sequence_in_progress_wb is set, clear when last_op retires or sequence is aborted due to exceptions.
         if (wb_valid_i && (last_op_wb_i || abort_op_wb_i)) begin
           sequence_in_progress_wb <= 1'b0;
         end
@@ -1206,6 +1231,14 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
         // No need to reset this flag on kill_wb.
         // When flag is high, there should be no reason to kill WB as they are blocked by the flag itself.
         // This is checked by an assertion, no killing while !sequence_interruptible
+
+        // If debug entry is caused by a watchpoint address trigger, then abort_op_wb_i will be 1 and the
+        // fsm goes to DEBUG_TAKEN the next cycle. This must also cause the sequence_in_progress_wb to be reset
+        // as the sequence is effectively terminated, although the instruction itself is not killed or completed
+        // in a normal manner. While ctrl_fsm_ns == DEBUG_TAKEN, the WB stage is halted and thus wb_valid_i is zero.
+        if (ex_wb_pipe_i.instr_valid && lsu_wpt_match_wb_i && abort_op_wb_i && (ctrl_fsm_ns == DEBUG_TAKEN)) begin
+          sequence_in_progress_wb <= 1'b0;
+        end
       end
     end
   end

--- a/rtl/cv32e40x_core.sv
+++ b/rtl/cv32e40x_core.sv
@@ -623,7 +623,8 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .X_EXT                 (X_EXT               ),
     .X_ID_WIDTH            (X_ID_WIDTH          ),
     .PMA_NUM_REGIONS       (PMA_NUM_REGIONS     ),
-    .PMA_CFG               (PMA_CFG             )
+    .PMA_CFG               (PMA_CFG             ),
+    .DBG_NUM_TRIGGERS      (DBG_NUM_TRIGGERS    )
   )
   load_store_unit_i
   (

--- a/rtl/cv32e40x_core.sv
+++ b/rtl/cv32e40x_core.sv
@@ -243,6 +243,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
   logic        lsu_first_op_ex;
   logic        lsu_last_op_ex;
   mpu_status_e lsu_mpu_status_wb;
+  logic        lsu_wpt_match_wb;
   logic [31:0] lsu_rdata_wb;
   logic [1:0]  lsu_err_wb;
 
@@ -581,9 +582,6 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .csr_illegal_i              ( csr_illegal                  ),
     .csr_mnxti_read_i           ( csr_mnxti_read               ),
 
-    // trigger input
-    .trigger_match_i            ( trigger_match_ex             ),
-
     // Branch decision
     .branch_decision_o          ( branch_decision_ex           ),
     .branch_target_o            ( branch_target_ex             ),
@@ -662,6 +660,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .lsu_err_1_o           ( lsu_err_wb         ), // To controller (has WB timing, but does not pass through WB stage)
     .lsu_rdata_1_o         ( lsu_rdata_wb       ),
     .lsu_mpu_status_1_o    ( lsu_mpu_status_wb  ),
+    .lsu_wpt_match_1_o     ( lsu_wpt_match_wb   ),
 
     // Valid/ready
     .valid_0_i             ( lsu_valid_ex       ), // First LSU stage (EX)
@@ -698,6 +697,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
     // LSU
     .lsu_rdata_i                ( lsu_rdata_wb                 ),
     .lsu_mpu_status_i           ( lsu_mpu_status_wb            ),
+    .lsu_wpt_match_i            ( lsu_wpt_match_wb             ),
 
     // Write back to register file
     .rf_we_wb_o                 ( rf_we_wb                     ),
@@ -888,6 +888,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .lsu_busy_i                     ( lsu_busy               ),
     .lsu_interruptible_i            ( lsu_interruptible      ),
     .lsu_valid_wb_i                 ( lsu_valid_wb           ),
+    .lsu_wpt_match_wb_i             ( lsu_wpt_match_wb       ),
 
     // jump/branch control
     .branch_decision_ex_i           ( branch_decision_ex     ),

--- a/rtl/cv32e40x_ex_stage.sv
+++ b/rtl/cv32e40x_ex_stage.sv
@@ -47,8 +47,6 @@ module cv32e40x_ex_stage import cv32e40x_pkg::*;
   input  logic        csr_illegal_i,
   input  logic        csr_mnxti_read_i,
 
-  input  logic        trigger_match_i,
-
   // EX/WB pipeline
   output ex_wb_pipe_t ex_wb_pipe_o,
 
@@ -366,12 +364,12 @@ module cv32e40x_ex_stage import cv32e40x_pkg::*;
 
         ex_wb_pipe_o.last_op     <= last_op_o;
         ex_wb_pipe_o.first_op    <= first_op_o;
-        ex_wb_pipe_o.abort_op    <= id_ex_pipe_i.abort_op || trigger_match_i; // MPU exceptions have WB timing and will not impact ex_wb_pipe.abort_op
+        ex_wb_pipe_o.abort_op    <= id_ex_pipe_i.abort_op; // MPU exceptions have WB timing and will not impact ex_wb_pipe.abort_op
         // Deassert rf_we in case of illegal csr instruction,
         // when the first half of a misaligned/split LSU goes to WB or when there is a trigger match on the LSU address.
         // Also deassert if CSR was accepted both by eXtension if and pipeline
-        ex_wb_pipe_o.rf_we       <= (csr_is_illegal || lsu_split_i || trigger_match_i) ? 1'b0 : id_ex_pipe_i.rf_we;
-        ex_wb_pipe_o.lsu_en      <= trigger_match_i ? 1'b0 : id_ex_pipe_i.lsu_en;
+        ex_wb_pipe_o.rf_we       <= (csr_is_illegal || lsu_split_i) ? 1'b0 : id_ex_pipe_i.rf_we;
+        ex_wb_pipe_o.lsu_en      <= id_ex_pipe_i.lsu_en;
 
         if (id_ex_pipe_i.rf_we) begin
           ex_wb_pipe_o.rf_waddr <= id_ex_pipe_i.rf_waddr;
@@ -413,7 +411,7 @@ module cv32e40x_ex_stage import cv32e40x_pkg::*;
 
         // CSR illegal instruction detected in this stage, OR'ing in the status
         ex_wb_pipe_o.illegal_insn   <= id_ex_pipe_i.illegal_insn || csr_is_illegal;
-        ex_wb_pipe_o.trigger_match  <= id_ex_pipe_i.trigger_match || trigger_match_i;
+        ex_wb_pipe_o.trigger_match  <= id_ex_pipe_i.trigger_match;
 
         // eXtension interface
         ex_wb_pipe_o.xif_en         <= ctrl_fsm_i.kill_xif ? 1'b0 : id_ex_pipe_i.xif_en;
@@ -457,7 +455,6 @@ module cv32e40x_ex_stage import cv32e40x_pkg::*;
                        (id_ex_pipe_i.mul_en && mul_valid)       ||
                        (id_ex_pipe_i.div_en && div_valid)       ||
                        (id_ex_pipe_i.lsu_en && lsu_valid_i)     ||
-                       (id_ex_pipe_i.lsu_en && trigger_match_i) || // LSU trigger match causes no side effects in EX, raise ex_valid
                        (id_ex_pipe_i.xif_en && xif_valid)       ||
                        (id_ex_pipe_i.instr_meta.clic_ptr)       || // todo: Should this instead have it's own _valid?
                        (id_ex_pipe_i.instr_meta.mret_ptr)       || // todo: Should this instead have it's own _valid?

--- a/rtl/cv32e40x_ex_stage.sv
+++ b/rtl/cv32e40x_ex_stage.sv
@@ -364,9 +364,8 @@ module cv32e40x_ex_stage import cv32e40x_pkg::*;
 
         ex_wb_pipe_o.last_op     <= last_op_o;
         ex_wb_pipe_o.first_op    <= first_op_o;
-        ex_wb_pipe_o.abort_op    <= id_ex_pipe_i.abort_op; // MPU exceptions have WB timing and will not impact ex_wb_pipe.abort_op
-        // Deassert rf_we in case of illegal csr instruction,
-        // when the first half of a misaligned/split LSU goes to WB or when there is a trigger match on the LSU address.
+        ex_wb_pipe_o.abort_op    <= id_ex_pipe_i.abort_op; // MPU exceptions and watchpoint triggers have WB timing and will not impact ex_wb_pipe.abort_op
+        // Deassert rf_we in case of illegal csr instruction or when the first half of a misaligned/split LSU goes to WB.
         // Also deassert if CSR was accepted both by eXtension if and pipeline
         ex_wb_pipe_o.rf_we       <= (csr_is_illegal || lsu_split_i) ? 1'b0 : id_ex_pipe_i.rf_we;
         ex_wb_pipe_o.lsu_en      <= id_ex_pipe_i.lsu_en;

--- a/rtl/cv32e40x_load_store_unit.sv
+++ b/rtl/cv32e40x_load_store_unit.sv
@@ -464,7 +464,7 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
 
   // Set handshake signals for wpt_trans (same as for trans, but kept separate for clean naming)
   assign wpt_trans_valid = trans_valid;
-  assign trans_ready       = wpt_trans_ready;
+  assign trans_ready     = wpt_trans_ready;
 
   // Transaction request generation
   // OBI compatible (avoids combinatorial path from data_rvalid_i to data_req_o). Multiple trans_* transactions can be
@@ -542,7 +542,7 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
   //////////////////////////////////////////////////////////////////////////////
 
   assign count_up = trans_valid && trans_ready;         // Increment upon accepted transfer request
-  assign count_down = wpt_resp_valid;                       // Decrement upon accepted transfer response
+  assign count_down = wpt_resp_valid;                   // Decrement upon accepted transfer response
 
   always_comb begin
     case ({count_up, count_down})

--- a/rtl/cv32e40x_load_store_unit.sv
+++ b/rtl/cv32e40x_load_store_unit.sv
@@ -67,6 +67,7 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
   output logic [1:0]  lsu_err_1_o,
   output logic [31:0] lsu_rdata_1_o,            // LSU read data
   output mpu_status_e lsu_mpu_status_1_o,       // MPU (PMA) status, response/WB timing. To controller and wb_stage
+  output logic        lsu_wpt_match_1_o,        // Address match trigger, WB timing.
 
   // Handshakes
   input  logic        valid_0_i,                // Handshakes for first LSU stage (EX)
@@ -91,9 +92,6 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
   logic           trans_valid;
   logic           trans_ready;
 
-  // Gated version of valid_0_i, suppressed on trigger matches
-  logic           valid_0_gated;
-
   // Aligned transaction request (to cv32e40x_wpt)
   logic           wpt_trans_valid;
   logic           wpt_trans_ready;
@@ -104,10 +102,14 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
   logic           mpu_trans_ready;
   obi_data_req_t  mpu_trans;
 
+  // Transaction response interface (from cv32e40x_wpt)
+  logic           wpt_resp_valid;
+  logic [31:0]    wpt_resp_rdata;
+  data_resp_t     wpt_resp;
+
   // Transaction response interface (from cv32e40x_mpu)
-  logic           resp_valid;
-  logic [31:0]    resp_rdata;
-  data_resp_t     resp;
+  logic           mpu_resp_valid;
+  data_resp_t     mpu_resp;
 
   // Transaction request (from cv32e40x_mpu to cv32e40x_write_buffer)
   logic           buffer_trans_valid;
@@ -163,13 +165,12 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
 
   logic                  xif_req;       // The ongoing memory request comes from the XIF interface
   logic                  xif_mpu_err;   // The ongoing memory request caused an MPU error
+  logic                  xif_wpt_match; // The ongoing memory request caused a watchpoint trigger match
   logic                  xif_ready_1;   // The LSU second stage is ready for an XIF transaction
   logic                  xif_res_q;     // The next memory result is for the XIF interface
   logic [X_ID_WIDTH-1:0] xif_id_q;      // Instruction ID of an XIF memory transaction
 
   assign xif_req = X_EXT && xif_mem_if.mem_valid;
-
-  assign valid_0_gated = valid_0_i && !trigger_match_0_i;
 
   // Transaction (before aligner)
   // Generate address from operands (atomic memory transactions do not use an address offset computation)
@@ -293,14 +294,14 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
   // Tracking split (misaligned) state
   // This signals has EX timing, and indicates that the second
   // address phase of a split transfer is taking place
-  // Reset/killed on !valid_0_gated to ensure it is zero for the
+  // Reset/killed on !valid_0_i to ensure it is zero for the
   // first phase of the next instruction. Otherwise it could stick at 1 after a killed
   // split, causing next LSU instruction to calculate wrong _be.
   always_ff @(posedge clk, negedge rst_n) begin
     if (rst_n == 1'b0) begin
       split_q    <= 1'b0;
     end else begin
-      if(!valid_0_gated && !xif_req) begin
+      if(!valid_0_i && !xif_req) begin
         split_q <= 1'b0; // Reset split_st when no valid instructions
       end else if (ctrl_update) begin // EX done, update split_q for next address phase
         split_q <= lsu_split_0_o;
@@ -344,8 +345,8 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
                           ((lsu_size_q == 2'b01) && (rdata_offset_q == 2'b11));   // Split halfword
 
   // Assemble full rdata
-  assign rdata_full  = rdata_is_split ? {resp_rdata, rdata_q} :   // Use lsb data from previous access if split
-                                        {resp_rdata, resp_rdata}; // Set up data for shifting resp_data LSBs into MSBs of rdata_aligned
+  assign rdata_full  = rdata_is_split ? {wpt_resp_rdata, rdata_q} :   // Use lsb data from previous access if split
+                                        {wpt_resp_rdata, wpt_resp_rdata}; // Set up data for shifting resp_data LSBs into MSBs of rdata_aligned
 
   // Realign rdata
   assign rdata_aligned = rdata_full >> (8*rdata_offset_q);
@@ -365,14 +366,14 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
   begin
     if (rst_n == 1'b0) begin
       rdata_q <= '0;
-    end else if (resp_valid && !lsu_we_q) begin
+    end else if (wpt_resp_valid && !lsu_we_q) begin
       // if we have detected a split access, and we are
       // currently doing the first part of this access, then
       // store the data coming from memory in rdata_q.
       // In all other cases, rdata_q gets the value that we are
       // writing to the register file
       if (split_q || lsu_split_0_o) begin
-        rdata_q <= resp_rdata;
+        rdata_q <= wpt_resp_rdata;
       end else begin
         rdata_q <= rdata_ext;
       end
@@ -398,7 +399,7 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
   begin
     lsu_split_0_o = 1'b0;
     misaligned_halfword = 1'b0;
-    if (valid_0_gated && !xif_req && !split_q)
+    if (valid_0_i && !xif_req && !split_q)
     begin
       case (trans.size)
         2'b10: // word
@@ -468,18 +469,18 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
   // Transaction request generation
   // OBI compatible (avoids combinatorial path from data_rvalid_i to data_req_o). Multiple trans_* transactions can be
   // issued (and accepted) before a response (resp_*) is received.
-  assign trans_valid = (valid_0_gated || xif_req) && (cnt_q < DEPTH);
+  assign trans_valid = (valid_0_i || xif_req) && (cnt_q < DEPTH);
 
   // LSU second stage is ready if it is not being used (i.e. no outstanding transfers, cnt_q = 0),
   // or if it is being used and the awaited response arrives (resp_rvalid).
   // XIF transactions bypass the pipeline, hence ready_1_i is not required for the second stage to
   // be ready for XIF transactions.
-  assign ready_1_o   = ((cnt_q == 2'b00) ? 1'b1 : resp_valid) && ready_1_i;
-  assign xif_ready_1 = ((cnt_q == 2'b00) ? 1'b1 : resp_valid);
+  assign ready_1_o   = ((cnt_q == 2'b00) ? 1'b1 : wpt_resp_valid) && ready_1_i;
+  assign xif_ready_1 = ((cnt_q == 2'b00) ? 1'b1 : wpt_resp_valid);
 
-  // LSU second stage is valid when resp_valid (typically data_rvalid_i) is received. Both parts of a misaligned transfer will signal valid_1_o.
-  assign valid_1_o                          = resp_valid && valid_1_i && !xif_res_q;
-  assign xif_mem_result_if.mem_result_valid = last_q && resp_valid && xif_res_q; // todo: last_q or not?
+  // LSU second stage is valid when wpt_resp_valid (typically data_rvalid_i) is received. Both parts of a misaligned transfer will signal valid_1_o.
+  assign valid_1_o                          = wpt_resp_valid && valid_1_i && !xif_res_q;
+  assign xif_mem_result_if.mem_result_valid = last_q && wpt_resp_valid && xif_res_q; // todo: last_q or not?
 
   // LSU EX stage readyness requires two criteria to be met:
   //
@@ -496,7 +497,7 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
   // Indicates that address phase in EX is complete.
   // XIF request bypasses pipeline, ignores ready_0_i but requires xif_ready_1 instead.
   assign done_0    = (
-                      !(valid_0_gated || xif_req) ? 1'b1 :
+                      !(valid_0_i || xif_req) ? 1'b1 :
                       (cnt_q == 2'b00)        ? (trans_valid && trans_ready) :
                       (cnt_q == 2'b01)        ? (trans_valid && trans_ready) :
                       1'b1
@@ -508,7 +509,7 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
                        (cnt_q == 2'b00) ? (trans_valid && trans_ready) :
                        (cnt_q == 2'b01) ? (trans_valid && trans_ready) :
                        1'b1
-                      ) && valid_0_gated && !xif_req;
+                      ) && valid_0_i && !xif_req;
 
 
   // External (EX) ready only when not handling multi cycle split accesses
@@ -525,10 +526,10 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
   endgenerate
 
   // Export mpu status to WB stage/controller
-  assign lsu_mpu_status_1_o = resp.mpu_status;
+  assign lsu_mpu_status_1_o = wpt_resp.mpu_status;
 
   // Update signals for EX/WB registers (when EX has valid data itself and is ready for next)
-  assign ctrl_update = done_0 && (valid_0_gated || xif_req);
+  assign ctrl_update = done_0 && (valid_0_i || xif_req);
 
 
   //////////////////////////////////////////////////////////////////////////////
@@ -536,12 +537,12 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
   // (maximum = DEPTH)
   //
   // Counter overflow is prevented by limiting the number of outstanding transactions
-  // to DEPTH. Counter underflow is prevented by the assumption that resp_valid = 1
+  // to DEPTH. Counter underflow is prevented by the assumption that wpt_resp_valid = 1
   // will only occur in response to accepted transfer request (as per the OBI protocol).
   //////////////////////////////////////////////////////////////////////////////
 
   assign count_up = trans_valid && trans_ready;         // Increment upon accepted transfer request
-  assign count_down = resp_valid;                       // Decrement upon accepted transfer response
+  assign count_down = wpt_resp_valid;                       // Decrement upon accepted transfer response
 
   always_comb begin
     case ({count_up, count_down})
@@ -628,11 +629,47 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
   //////////////////////////////////////////////////////////////////////////////
   // WPT
   //////////////////////////////////////////////////////////////////////////////
-  // Placeholder assignmenst before introducing the watchpoint trigger module
-  assign mpu_trans = wpt_trans;
-  assign mpu_trans_valid = wpt_trans_valid;
-  assign wpt_trans_ready = mpu_trans_ready;
 
+  // Watchpint trigger "gate". If a watchpoint trigger is detected, this module will
+  // consume the transaction, not letting it through to the MPU. The triger match will
+  // be returned with the response with WB timing.
+
+  cv32e40x_wpt wpt_i
+    (
+     .clk                 ( clk               ),
+     .rst_n               ( rst_n             ),
+
+     // Input from debug_triggers module
+     .trigger_match_i     ( trigger_match_0_i ),
+
+     // Interface towards mpu interface
+     .mpu_trans_ready_i   ( mpu_trans_ready   ),
+     .mpu_trans_valid_o   ( mpu_trans_valid   ),
+     .mpu_trans_o         ( mpu_trans         ),
+
+     .mpu_resp_valid_i    ( mpu_resp_valid    ),
+     .mpu_resp_i          ( mpu_resp          ),
+
+     // Interface towards core
+     .core_trans_valid_i  ( wpt_trans_valid   ),
+     .core_trans_ready_o  ( wpt_trans_ready   ),
+     .core_trans_i        ( wpt_trans         ),
+
+     .core_resp_valid_o   ( wpt_resp_valid    ),
+     .core_resp_o         ( wpt_resp          ),
+
+     // Indication from the core that there will be one pending transaction in the next cycle
+     .core_one_txn_pend_n ( cnt_is_one_next   ),
+
+     // Indication from the core that watchpoint triggers should be reported after all in flight transactions
+     // are complete (default behavior for main core requests, but not used for XIF requests)
+     .core_wpt_wait_i     ( !xif_req          ),
+
+     // Report watchpoint triggers to the core immediatly (used in case core_wpt_wait_i is not asserted)
+     .core_wpt_match_o    ( xif_wpt_match     )
+     );
+
+  assign lsu_wpt_match_1_o = wpt_resp.wpt_match;
   //////////////////////////////////////////////////////////////////////////////
   // MPU
   //////////////////////////////////////////////////////////////////////////////
@@ -660,8 +697,8 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
     .core_trans_valid_i   ( mpu_trans_valid    ),
     .core_trans_ready_o   ( mpu_trans_ready    ),
     .core_trans_i         ( mpu_trans          ),
-    .core_resp_valid_o    ( resp_valid         ),
-    .core_resp_o          ( resp               ),
+    .core_resp_valid_o    ( mpu_resp_valid     ),
+    .core_resp_o          ( mpu_resp           ),
 
     .bus_trans_valid_o    ( filter_trans_valid ),
     .bus_trans_ready_i    ( filter_trans_ready ),
@@ -671,7 +708,7 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
   );
 
   // Extract rdata and err from response struct
-  assign resp_rdata = resp.bus_resp.rdata;
+  assign wpt_resp_rdata = wpt_resp.bus_resp.rdata;
 
 
   //////////////////////////////////////////////////////////////////////////////
@@ -754,7 +791,7 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
       assign xif_mem_if.mem_resp.exccode = xif_mpu_err ? (
                                             trans.we ? EXC_CAUSE_STORE_FAULT : EXC_CAUSE_LOAD_FAULT
                                            ) : '0;
-      assign xif_mem_if.mem_resp.dbg     = '0; // TODO forward debug triggers
+      assign xif_mem_if.mem_resp.dbg     = xif_wpt_match;
 
       // XIF memory result
       assign xif_mem_result_if.mem_result.id    = xif_id_q;

--- a/rtl/cv32e40x_load_store_unit.sv
+++ b/rtl/cv32e40x_load_store_unit.sv
@@ -686,12 +686,19 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
       assign lsu_wpt_match_1_o = resp.wpt_match;
     end else begin : gen_no_wpt
       // Bypass WPT in case DBG_NUM_TRIGGERS is zero
-      assign mpu_trans_valid = wpt_trans_valid;
-      assign mpu_trans       = wpt_trans;
-      assign wpt_trans_ready = mpu_trans_ready;
-      assign wpt_resp_valid  = mpu_resp_valid;
-      assign wpt_resp        = mpu_resp;
-      assign xif_wpt_match   = 1'b0;
+      assign lsu_wpt_match_1_o = resp.wpt_match;
+      assign mpu_trans_valid   = wpt_trans_valid;
+      assign mpu_trans         = wpt_trans;
+      assign wpt_trans_ready   = mpu_trans_ready;
+      assign wpt_resp_valid    = mpu_resp_valid;
+      assign wpt_resp          = mpu_resp;
+      assign xif_wpt_match     = 1'b0;
+
+      assign wpt_resp_rdata = wpt_resp.bus_resp.rdata;
+
+      assign resp_valid = wpt_resp_valid;
+      assign resp_rdata = wpt_resp_rdata;
+      assign resp       = wpt_resp;
     end
   endgenerate
   //////////////////////////////////////////////////////////////////////////////

--- a/rtl/cv32e40x_mpu.sv
+++ b/rtl/cv32e40x_mpu.sv
@@ -78,6 +78,7 @@ module cv32e40x_mpu import cv32e40x_pkg::*;
   logic        core_trans_we;
   logic        instr_fetch_access;
   logic        load_access;
+  logic        wpt_match;
 
   // FSM that will "consume" transfers failing PMA checks.
   // Upon failing checks, this FSM will prevent the transfer from going out on the bus
@@ -207,9 +208,10 @@ module cv32e40x_mpu import cv32e40x_pkg::*;
       assign core_trans_we      = 1'b0;
     end
     else begin: mpu_lsu
-      assign instr_fetch_access = 1'b0;
-      assign load_access        = !core_trans_i.we;
-      assign core_trans_we      = core_trans_i.we;
+      assign instr_fetch_access    = 1'b0;
+      assign load_access           = !core_trans_i.we;
+      assign core_trans_we         = core_trans_i.we;
+      assign core_resp_o.wpt_match = 1'b0; // Will be set by upstream wpt-module within load_store_unit
     end
   endgenerate
 

--- a/rtl/cv32e40x_wb_stage.sv
+++ b/rtl/cv32e40x_wb_stage.sv
@@ -48,6 +48,7 @@ module cv32e40x_wb_stage import cv32e40x_pkg::*;
   // LSU
   input  logic [31:0]   lsu_rdata_i,
   input  mpu_status_e   lsu_mpu_status_i,
+  input  logic          lsu_wpt_match_i,
 
   // Register file interface
   output logic          rf_we_wb_o,     // Register file write enable
@@ -110,7 +111,7 @@ module cv32e40x_wb_stage import cv32e40x_pkg::*;
   // rf_we_wb_o is deasserted if lsu_mpu_status is not equal to MPU_OK
 
   // TODO: Could use result interface.we into account if out of order completion is allowed.
-  assign rf_we_wb_o     = ex_wb_pipe_i.rf_we && !lsu_exception && !xif_waiting && !xif_exception && instr_valid;
+  assign rf_we_wb_o     = ex_wb_pipe_i.rf_we && !lsu_exception && !xif_waiting && !xif_exception && !lsu_wpt_match_i && instr_valid;
   // TODO: Could use result interface.rd into account if out of order completion is allowed.
   assign rf_waddr_wb_o  = ex_wb_pipe_i.rf_waddr;
   // TODO: Could use result interface.rd into account if out of order completion is allowed.
@@ -156,7 +157,7 @@ module cv32e40x_wb_stage import cv32e40x_pkg::*;
 
   // Append any MPU exception to abort_op
   // An abort_op_o = 1 will terminate a sequence, either to take an exception or debug due to trigger match.
-  assign abort_op_o = ex_wb_pipe_i.abort_op || ( ex_wb_pipe_i.lsu_en && lsu_exception);
+  assign abort_op_o = ex_wb_pipe_i.abort_op || ( ex_wb_pipe_i.lsu_en && lsu_exception) || lsu_wpt_match_i;
 
   // Export signal indicating WB stage stalled by load/store
   assign data_stall_o = ex_wb_pipe_i.lsu_en && !lsu_valid_i && instr_valid;

--- a/rtl/cv32e40x_wb_stage.sv
+++ b/rtl/cv32e40x_wb_stage.sv
@@ -157,7 +157,7 @@ module cv32e40x_wb_stage import cv32e40x_pkg::*;
 
   // Append any MPU exception to abort_op
   // An abort_op_o = 1 will terminate a sequence, either to take an exception or debug due to trigger match.
-  assign abort_op_o = ex_wb_pipe_i.abort_op || ( ex_wb_pipe_i.lsu_en && lsu_exception) || lsu_wpt_match_i;
+  assign abort_op_o = ex_wb_pipe_i.abort_op || ( ex_wb_pipe_i.lsu_en && lsu_exception) || (ex_wb_pipe_i.lsu_en && lsu_wpt_match_i);
 
   // Export signal indicating WB stage stalled by load/store
   assign data_stall_o = ex_wb_pipe_i.lsu_en && !lsu_valid_i && instr_valid;

--- a/rtl/cv32e40x_wpt.sv
+++ b/rtl/cv32e40x_wpt.sv
@@ -67,7 +67,7 @@ module cv32e40x_wpt import cv32e40x_pkg::*;
   logic        wpt_block_bus;
   logic        wpt_trans_valid;
   logic        wpt_trans_ready;
-  logic        wpt_match_resp;
+  logic        wpt_match;
   wpt_state_e  state_q, state_n;
 
   // FSM that will "consume" transfers with firing watchpoint triggers.
@@ -85,7 +85,7 @@ module cv32e40x_wpt import cv32e40x_pkg::*;
     wpt_block_bus   = 1'b0;
     wpt_trans_valid = 1'b0;
     wpt_trans_ready = 1'b0;
-    wpt_match_resp  = 1'b0;
+    wpt_match       = 1'b0;
 
     case(state_q)
       WPT_IDLE: begin
@@ -121,7 +121,7 @@ module cv32e40x_wpt import cv32e40x_pkg::*;
 
         // Set up WPT response towards the core
         wpt_trans_valid = 1'b1;
-        wpt_match_resp = 1'b1;
+        wpt_match       = 1'b1;
 
         // Go back to IDLE uncoditionally.
         // The core is expected to always be ready for the response
@@ -150,7 +150,7 @@ module cv32e40x_wpt import cv32e40x_pkg::*;
   assign core_resp_valid_o      = mpu_resp_valid_i || wpt_trans_valid;
   assign core_resp_o.bus_resp   = mpu_resp_i.bus_resp;
   assign core_resp_o.mpu_status = mpu_resp_i.mpu_status;
-  assign core_resp_o.wpt_match  = wpt_match_resp;
+  assign core_resp_o.wpt_match  = wpt_match;
 
 
   // Report WPT matches to the core immediatly

--- a/rtl/cv32e40x_wpt.sv
+++ b/rtl/cv32e40x_wpt.sv
@@ -1,0 +1,164 @@
+// Copyright 2022 Silicon Labs, Inc.
+//
+// This file, and derivatives thereof are licensed under the
+// Solderpad License, Version 2.0 (the "License");
+// Use of this file means you agree to the terms and conditions
+// of the license and are in full compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://solderpad.org/licenses/SHL-2.0/
+//
+// Unless required by applicable law or agreed to in writing, software
+// and hardware implementations thereof
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESSED OR IMPLIED.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+////////////////////////////////////////////////////////////////////////////////
+//                                                                            //
+// Authors:        Oystein Knauserud - oystein.knauserud@silabs.com           //
+//                                                                            //
+// Description:    WPT                                                        //
+//                 Module blocks any trans to the MPU if a watchpoint trigger //
+//                 fires for the current address. Trigger match is reported   //
+//                 with WB timing similar to how the MPU reports status.      //
+//                 cv32e40x_wpt is inherited from cv32e40x_mpu and adataped   //
+//                 for watchpoint triggers.                                   //
+//                                                                            //
+////////////////////////////////////////////////////////////////////////////////
+
+module cv32e40x_wpt import cv32e40x_pkg::*;
+  (
+   input logic  clk,
+   input logic  rst_n,
+
+   // Input from debug_triggers module
+   input  logic           trigger_match_i,
+
+   // Interface towards mpu interface
+   input  logic           mpu_trans_ready_i,
+   output logic           mpu_trans_valid_o,
+   output obi_data_req_t  mpu_trans_o,
+
+   input  logic           mpu_resp_valid_i,
+   input  data_resp_t     mpu_resp_i,
+
+   // Interface towards core
+   input  logic           core_trans_valid_i,
+   output logic           core_trans_ready_o,
+   input  obi_data_req_t  core_trans_i,
+
+   output logic           core_resp_valid_o,
+   output data_resp_t     core_resp_o,
+
+   // Indication from the core that there will be one pending transaction in the next cycle
+   input logic  core_one_txn_pend_n,
+
+   // Indication from the core that watchpoint triggers should be reported after all in flight transactions
+   // are complete (default behavior for main core requests, but not used for XIF requests)
+   input logic  core_wpt_wait_i,
+
+   // Report watchpoint triggers to the core immediatly (used in case core_wpt_wait_i is not asserted)
+   output logic core_wpt_match_o
+   );
+
+  logic        wpt_block_core;
+  logic        wpt_block_bus;
+  logic        wpt_trans_valid;
+  logic        wpt_trans_ready;
+  logic        wpt_match_resp;
+  wpt_state_e  state_q, state_n;
+
+  // FSM that will "consume" transfers with firing watchpoint triggers.
+  // Upon trigger match, this FSM will prevent the transfer from going out on the bus
+  // and wait for all in flight bus transactions to complete while blocking new transfers.
+  // When all in flight transactions are complete, it will respond with the correct status before
+  // allowing new transfers to go through.
+  // The input signal core_one_txn_pend_n indicates that there, from the core's point of view,
+  // will be one pending transaction in the next cycle. Upon watchpoint match, this transaction
+  // will be completed by this FSM
+  always_comb begin
+
+    state_n         = state_q;
+    wpt_block_core  = 1'b0;
+    wpt_block_bus   = 1'b0;
+    wpt_trans_valid = 1'b0;
+    wpt_trans_ready = 1'b0;
+    wpt_match_resp  = 1'b0;
+
+    case(state_q)
+      WPT_IDLE: begin
+        if (trigger_match_i && core_trans_valid_i) begin
+
+          // Block transfer from going out on the bus.
+          wpt_block_bus  = 1'b1;
+
+          // Signal to the core that the transfer was accepted (but will be consumed by the WPT)
+          wpt_trans_ready = 1'b1;
+
+          if (core_wpt_wait_i) begin
+            state_n = core_one_txn_pend_n ? WPT_MATCH_RESP : WPT_MATCH_WAIT;
+          end
+
+        end
+      end
+      WPT_MATCH_WAIT: begin
+
+        // Block new transfers while waiting for in flight transfers to complete
+        wpt_block_bus  = 1'b1;
+        wpt_block_core = 1'b1;
+
+        if (core_one_txn_pend_n) begin
+          state_n = WPT_MATCH_RESP;
+        end
+      end
+      WPT_MATCH_RESP: begin
+
+        // Keep blocking new transfers
+        wpt_block_bus  = 1'b1;
+        wpt_block_core = 1'b1;
+
+        // Set up WPT response towards the core
+        wpt_trans_valid = 1'b1;
+        wpt_match_resp = 1'b1;
+
+        // Go back to IDLE uncoditionally.
+        // The core is expected to always be ready for the response
+        state_n = WPT_IDLE;
+
+      end
+      default: ;
+    endcase
+  end
+
+  always_ff @(posedge clk, negedge rst_n) begin
+    if (rst_n == 1'b0) begin
+      state_q     <= WPT_IDLE;
+    end
+    else begin
+      state_q <= state_n;
+    end
+  end
+
+  // Forward transaction request towards MPU
+  assign mpu_trans_valid_o = core_trans_valid_i && !wpt_block_bus;
+  assign mpu_trans_o       = core_trans_i;
+
+
+  // Forward transaction response towards core
+  assign core_resp_valid_o      = mpu_resp_valid_i || wpt_trans_valid;
+  assign core_resp_o.bus_resp   = mpu_resp_i.bus_resp;
+  assign core_resp_o.mpu_status = mpu_resp_i.mpu_status;
+  assign core_resp_o.wpt_match  = wpt_match_resp;
+
+
+  // Report WPT matches to the core immediatly
+  assign core_wpt_match_o = trigger_match_i;
+
+  // Signal ready towards core
+  assign core_trans_ready_o     = (mpu_trans_ready_i && !wpt_block_core) || wpt_trans_ready;
+
+
+
+endmodule

--- a/rtl/include/cv32e40x_pkg.sv
+++ b/rtl/include/cv32e40x_pkg.sv
@@ -948,6 +948,9 @@ typedef enum logic [1:0] {
 
 typedef enum logic [2:0] {MPU_IDLE, MPU_RE_ERR_RESP, MPU_RE_ERR_WAIT, MPU_WR_ERR_RESP, MPU_WR_ERR_WAIT} mpu_state_e;
 
+// WPT state machine
+typedef enum logic [1:0] {WPT_IDLE, WPT_MATCH_WAIT, WPT_MATCH_RESP} wpt_state_e;
+
 // OBI bus and internal data types
 
 parameter INSTR_ADDR_WIDTH = 32;
@@ -1018,10 +1021,11 @@ parameter obi_inst_req_t OBI_INST_REQ_RESET_VAL = '{
   dbg     : 1'b0
 };
 
-// Data transfer bundeled with MPU status
+// Data transfer bundeled with MPU status and watchpoint trigger match
 typedef struct packed {
   obi_data_resp_t             bus_resp;
   mpu_status_e                mpu_status;
+  logic                       wpt_match;
 } data_resp_t;
 
 // LSU transaction

--- a/sva/cv32e40x_controller_fsm_sva.sv
+++ b/sva/cv32e40x_controller_fsm_sva.sv
@@ -859,5 +859,14 @@ end
                   |->
                   lsu_wpt_match_wb_i)
     else `uvm_error("controller", "LSU in WB halted without watchpoint trigger match")
+
+
+  // Check that debug is always taken when a watchpoint trigger is arrives in WB
+  a_wpt_debug_entry:
+  assert property (@(posedge clk) disable iff (!rst_n)
+                  (ex_wb_pipe_i.instr_valid && lsu_wpt_match_wb_i)
+                  |->
+                  (abort_op_wb_i && (ctrl_fsm_ns == DEBUG_TAKEN)))
+    else `uvm_error("controller", "Debug not entered on a WPT match")
 endmodule
 

--- a/sva/cv32e40x_controller_fsm_sva.sv
+++ b/sva/cv32e40x_controller_fsm_sva.sv
@@ -64,8 +64,9 @@ module cv32e40x_controller_fsm_sva
   input logic           fencei_flush_req_o,
   input logic           fencei_flush_ack_i,
   input logic           fencei_req_and_ack_q,
-  input logic           pending_debug,
-  input logic           debug_allowed,
+  input logic           pending_async_debug,
+  input logic           async_debug_allowed,
+  input logic           sync_debug_allowed,
   input logic           pending_interrupt,
   input logic           interrupt_allowed,
   input logic           pending_nmi,
@@ -105,7 +106,8 @@ module cv32e40x_controller_fsm_sva
   input logic           clic_ptr_in_progress_id,
   input pipe_pc_mux_e   pipe_pc_mux_ctrl,
   input logic           ptr_in_if_i,
-  input logic           etrigger_in_wb
+  input logic           etrigger_in_wb,
+  input logic           lsu_wpt_match_wb_i
 );
 
 
@@ -243,7 +245,7 @@ module cv32e40x_controller_fsm_sva
   // Assert that the fencei request is set the cycle after fencei instruction enters WB (if fencei_ready=1 and there are no higher priority events)
   a_fencei_hndshk_req_when_fencei_wb :
     assert property (@(posedge clk) disable iff (!rst_n)
-           $rose(fencei_in_wb && fencei_ready) && !(pending_nmi || (pending_debug && debug_allowed) || (pending_interrupt && interrupt_allowed))
+           $rose(fencei_in_wb && fencei_ready) && !(pending_nmi || (pending_async_debug && async_debug_allowed) || (pending_interrupt && interrupt_allowed))
                      |=> $rose(fencei_flush_req_o))
       else `uvm_error("controller", "Fencei in WB did not result in fencei_flush_req_o")
 
@@ -426,12 +428,21 @@ generate;
 endgenerate
 
   // Assert that debug is not allowed when WB stage has an LSU
-  // instruction (cnt_q != 0)
+  // instruction (cnt_q != 0) with no watchpoint match attached to it.
+
   a_block_debug:
     assert property (@(posedge clk) disable iff (!rst_n)
-                     (ex_wb_pipe_i.instr_valid && ex_wb_pipe_i.lsu_en) |-> !debug_allowed)
+                     (ex_wb_pipe_i.instr_valid && ex_wb_pipe_i.lsu_en) && (ctrl_fsm_cs == FUNCTIONAL)
+                     |->
+                     !async_debug_allowed)
       else `uvm_error("controller", "debug_allowed high while LSU is in WB")
 
+  a_lsu_wp_debug:
+    assert property (@(posedge clk) disable iff (!rst_n)
+                    (ctrl_fsm_cs == DEBUG_TAKEN) && (ex_wb_pipe_i.lsu_en && ex_wb_pipe_i.instr_valid)
+                    |->
+                    $past(lsu_wpt_match_wb_i))
+      else `uvm_error("conroller", "LSU active in WB during DEBUG_TAKEN with no preceeding watchpoint trigger")
   // Ensure bubble in EX while in SLEEP mode.
   // WFI or WFE instruction will be in WB
   // Bubble is needed to avoid any LSU instructions to go on the bus while handling the WFI, as this
@@ -471,7 +482,7 @@ endgenerate
   a_no_wfi_wakeup_on_wfe:
   assert property (@(posedge clk) disable iff (!rst_n)
                     (ctrl_fsm_cs == SLEEP) && ex_wb_pipe_i.instr_valid && ex_wb_pipe_i.sys_en && ex_wb_pipe_i.sys_wfi_insn &&
-                    !irq_wu_ctrl_i && wu_wfe_i && !pending_debug
+                    !irq_wu_ctrl_i && wu_wfe_i && !pending_async_debug
                     |=>
                     (ctrl_fsm_cs == SLEEP))
     else `uvm_error("controller", "WFI instruction woke up to wu_wfe_i")
@@ -481,7 +492,7 @@ endgenerate
   a_wfe_wakeup:
   assert property (@(posedge clk) disable iff (!rst_n)
                     (ctrl_fsm_cs == SLEEP) && ex_wb_pipe_i.instr_valid && ex_wb_pipe_i.sys_en && ex_wb_pipe_i.sys_wfe_insn &&
-                    (irq_wu_ctrl_i || wu_wfe_i) && !pending_debug
+                    (irq_wu_ctrl_i || wu_wfe_i) && !pending_async_debug
                     |->
                     (ctrl_fsm_ns == FUNCTIONAL))
     else `uvm_error("controller", "WFE must wake up to interuppts or wu_wfe_i")
@@ -651,7 +662,13 @@ end
   // Used to determine if we are allowed to take debug or interrupts
   logic sequence_interruptible_alt;
   always_comb begin
-    if (ex_wb_pipe_i.instr_valid) begin
+    // Excluding the case of the current state being DEBUG_TAKEN. In this state, we may have a
+    // lsu instruction in WB with !first_op if this instruction caused a watchpoint trigger.
+    // The controller will reset the flop based flag when this is detected and the code below
+    // would not match if not detecting the same case.
+    if (ex_wb_pipe_i.instr_valid && (ctrl_fsm_cs == DEBUG_TAKEN)) begin
+      sequence_interruptible_alt = 1'b1;
+    end else if (ex_wb_pipe_i.instr_valid) begin
       sequence_interruptible_alt = ex_wb_pipe_i.first_op;
     end else if (id_ex_pipe_i.instr_valid) begin
       sequence_interruptible_alt = first_op_ex_i;
@@ -834,5 +851,13 @@ end
   assert property (@(posedge clk) disable iff (!rst_n)
                     etrigger_in_wb |-> exception_in_wb)
     else `uvm_error("controller", "etrigger_in_wb when there is no exception in WB")
+
+  // Only halt LSU instruction in WB for watchpoint trigger matches
+  a_halt_lsu_wb:
+  assert property (@(posedge clk) disable iff (!rst_n)
+                  (ex_wb_pipe_i.instr_valid && ex_wb_pipe_i.lsu_en) && ctrl_fsm_o.halt_wb
+                  |->
+                  lsu_wpt_match_wb_i)
+    else `uvm_error("controller", "LSU in WB halted without watchpoint trigger match")
 endmodule
 

--- a/sva/cv32e40x_core_sva.sv
+++ b/sva/cv32e40x_core_sva.sv
@@ -76,8 +76,10 @@ module cv32e40x_core_sva
 
   // probed controller signals
   input logic        ctrl_debug_mode_n,
-  input logic        ctrl_pending_debug,
-  input logic        ctrl_debug_allowed,
+  input logic        ctrl_pending_async_debug,
+  input logic        ctrl_async_debug_allowed,
+  input logic        ctrl_pending_sync_debug,
+  input logic        ctrl_sync_debug_allowed,
   input logic        ctrl_interrupt_allowed,
   input logic        ctrl_pending_interrupt,
   input ctrl_byp_t   ctrl_byp,
@@ -149,6 +151,9 @@ logic [31:0]  expected_ebrk_mepc;
 logic [31:0]  expected_instr_err_mepc;
 logic [31:0]  expected_instr_mpuerr_mepc;
 
+logic pending_debug;
+assign pending_debug = (ctrl_pending_async_debug && ctrl_async_debug_allowed) || (ctrl_pending_sync_debug && ctrl_sync_debug_allowed);
+
 always_ff @(posedge clk , negedge rst_ni)
   begin
     if (rst_ni == 1'b0) begin
@@ -167,35 +172,35 @@ always_ff @(posedge clk , negedge rst_ni)
       // The code below checks for first occurence of each exception type in WB
       // Multiple exceptions may occur at the same time, so the following
       // code needs to check priority of what to expect
-      if (!first_illegal_found && ex_wb_pipe.instr_valid && !irq_ack && !(ctrl_pending_debug && ctrl_debug_allowed) &&
+      if (!first_illegal_found && ex_wb_pipe.instr_valid && !irq_ack && !pending_debug &&
         !(ex_wb_pipe.instr.bus_resp.err || (ex_wb_pipe.instr.mpu_status != MPU_OK)) &&
         !(ctrl_fsm.pc_mux == PC_TRAP_NMI) &&
           ex_wb_pipe.illegal_insn && !ctrl_debug_mode_n) begin
         first_illegal_found   <= 1'b1;
         expected_illegal_mepc <= ex_wb_pipe.pc;
       end
-      if (!first_ecall_found && ex_wb_pipe.instr_valid && !irq_ack && !(ctrl_pending_debug && ctrl_debug_allowed) &&
+      if (!first_ecall_found && ex_wb_pipe.instr_valid && !irq_ack && !pending_debug &&
         !(ex_wb_pipe.instr.bus_resp.err || (ex_wb_pipe.instr.mpu_status != MPU_OK) || ex_wb_pipe.illegal_insn) &&
         !(ctrl_fsm.pc_mux == PC_TRAP_NMI) &&
           ex_wb_pipe.sys_en &&  ex_wb_pipe.sys_ecall_insn && !ctrl_debug_mode_n) begin
         first_ecall_found   <= 1'b1;
         expected_ecall_mepc <= ex_wb_pipe.pc;
       end
-      if (!first_ebrk_found && ex_wb_pipe.instr_valid && !irq_ack && !(ctrl_pending_debug && ctrl_debug_allowed) &&
+      if (!first_ebrk_found && ex_wb_pipe.instr_valid && !irq_ack && !pending_debug &&
         !(ex_wb_pipe.instr.bus_resp.err || (ex_wb_pipe.instr.mpu_status != MPU_OK) || ex_wb_pipe.illegal_insn || (ex_wb_pipe.sys_en && ex_wb_pipe.sys_ecall_insn)) &&
         !(ctrl_fsm.pc_mux == PC_TRAP_NMI) && ex_wb_pipe.sys_en && ex_wb_pipe.sys_ebrk_insn) begin
         first_ebrk_found   <= 1'b1;
         expected_ebrk_mepc <= ex_wb_pipe.pc;
       end
 
-      if (!first_instr_err_found && (ex_wb_pipe.instr.mpu_status == MPU_OK) && !irq_ack && !(ctrl_pending_debug && ctrl_debug_allowed) &&
+      if (!first_instr_err_found && (ex_wb_pipe.instr.mpu_status == MPU_OK) && !irq_ack && !pending_debug &&
          !(ctrl_fsm.pc_mux == PC_TRAP_NMI) &&
           ex_wb_pipe.instr_valid && ex_wb_pipe.instr.bus_resp.err && !ctrl_debug_mode_n ) begin
         first_instr_err_found   <= 1'b1;
         expected_instr_err_mepc <= ex_wb_pipe.pc;
       end
 
-      if (!first_instr_mpuerr_found && ex_wb_pipe.instr_valid && !irq_ack && !(ctrl_pending_debug && ctrl_debug_allowed) &&
+      if (!first_instr_mpuerr_found && ex_wb_pipe.instr_valid && !irq_ack && !pending_debug &&
          !(ctrl_fsm.pc_mux == PC_TRAP_NMI) &&
           (ex_wb_pipe.instr.mpu_status != MPU_OK) && !ctrl_debug_mode_n) begin
         first_instr_mpuerr_found   <= 1'b1;

--- a/sva/cv32e40x_load_store_unit_sva.sv
+++ b/sva/cv32e40x_load_store_unit_sva.sv
@@ -48,9 +48,7 @@ module cv32e40x_load_store_unit_sva
    input logic       valid_0_i,
    input logic       ready_0_i,
    input logic       trigger_match_0_i,
-   input logic       lsu_wpt_match_1_o,
-   input mpu_state_e mpu_state,
-   input wpt_state_e wpt_state
+   input logic       lsu_wpt_match_1_o
   );
 
   // Check that outstanding transaction count will not overflow DEPTH
@@ -170,15 +168,7 @@ module cv32e40x_load_store_unit_sva
                   $stable(trigger_match_0_i) until_with(ready_0_i))
     else `uvm_error("load_store_unit", "trigger_match_0_i changed before ready_0_i became 1")
 
-  // WPT and MPU cannot both wait for a response at the sime time
-  // If they could both wait for a response, then they would need separate counters for the
-  // "one-transaction-left" inputs - otherwise they may share the counter.
-  a_wpt_mpu_cnt_share:
-  assert property (@(posedge clk) disable iff (!rst_n)
-                  ((wpt_state == WPT_MATCH_WAIT) || (mpu_state == MPU_RE_ERR_WAIT) || (mpu_state == MPU_WR_ERR_WAIT))
-                  |->
-                  (wpt_state == WPT_MATCH_WAIT) != ((mpu_state == MPU_RE_ERR_WAIT) || (mpu_state == MPU_WR_ERR_WAIT)))
-    else `uvm_error("load_store_unit", "WPT and MPU both wait for responses")
+
 
 endmodule // cv32e40x_load_store_unit_sva
 

--- a/sva/cv32e40x_load_store_unit_sva.sv
+++ b/sva/cv32e40x_load_store_unit_sva.sv
@@ -32,6 +32,8 @@ module cv32e40x_load_store_unit_sva
    input logic       count_up,
    input logic       count_down,
    input ctrl_fsm_t  ctrl_fsm_i,
+   input ctrl_state_e ctrl_fsm_ns,
+   input ctrl_state_e ctrl_fsm_cs,
    input logic       trans_valid,
    input logic       split_q,
    input mpu_status_e lsu_mpu_status_1_o, // WB mpu status
@@ -45,7 +47,8 @@ module cv32e40x_load_store_unit_sva
    input logic       lsu_first_op_0_o,
    input logic       valid_0_i,
    input logic       ready_0_i,
-   input logic       trigger_match_0_i
+   input logic       trigger_match_0_i,
+   input logic       lsu_wpt_match_1_o
   );
 
   // Check that outstanding transaction count will not overflow DEPTH
@@ -124,10 +127,20 @@ module cv32e40x_load_store_unit_sva
     else `uvm_error("load_store_unit", "Second half of split transaction was killed")
 
   // cnt_q == 2'b00 shall be the same as !(ex_wb_pipe.lsu_en && ex_wb_pipe_i.instr_valid)
+  // With a watchpoint match, the LSU counter may clear while WB is halted for synchronous debug entry, leaving cnt=0 while lsu_en in WB is true.
   a_cnt_zero:
   assert property (@(posedge clk) disable iff (!rst_n)
-                    (cnt_q == 2'b00) |-> !(ex_wb_pipe_i.lsu_en && ex_wb_pipe_i.instr_valid))
+                    (cnt_q == 2'b00) && !(ctrl_fsm_cs == DEBUG_TAKEN) |-> !(ex_wb_pipe_i.lsu_en && ex_wb_pipe_i.instr_valid))
       else `uvm_error("load_store_unit", "cnt_q is zero when WB contains a valid LSU instruction")
+
+  // The only cause of (cnt_q==0) with a valid LSU instruction in WB is a watchpoint trigger.
+  // Assertions checks that this is the case and that a debug entry is taking place.
+  a_lsu_cnt_nonzero_wpt:
+  assert property (@(posedge clk) disable iff (!rst_n)
+                  (cnt_q == 2'b00) && (ex_wb_pipe_i.lsu_en && ex_wb_pipe_i.instr_valid)
+                  |->
+                  $past(lsu_wpt_match_1_o) && (ctrl_fsm_cs == DEBUG_TAKEN))
+      else `uvm_error("load_store_unit", "Illegal cause of cnt_q=0 while a valid LSU instruction is in WB")
 
   // Check that no XIF request or result are produced if X_EXT is disabled
   a_lsu_no_xif_req_if_xext_disabled:

--- a/sva/cv32e40x_wpt_sva.sv
+++ b/sva/cv32e40x_wpt_sva.sv
@@ -1,0 +1,46 @@
+// Copyright 2022 Silicon Labs, Inc.
+//
+// This file, and derivatives thereof are licensed under the
+// Solderpad License, Version 2.0 (the "License");
+// Use of this file means you agree to the terms and conditions
+// of the license and are in full compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://solderpad.org/licenses/SHL-2.0/
+//
+// Unless required by applicable law or agreed to in writing, software
+// and hardware implementations thereof
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESSED OR IMPLIED.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+////////////////////////////////////////////////////////////////////////////////
+//                                                                            //
+// Authors:        Oystein Knauserud - oystein.knauserud@silabs.com           //
+//                                                                            //
+// Description:    WPT assertions                    //
+//                                                                            //
+////////////////////////////////////////////////////////////////////////////////
+
+module cv32e40x_wpt_sva import cv32e40x_pkg::*; import uvm_pkg::*;
+  (
+   input logic        clk,
+   input logic        rst_n,
+
+   input wpt_state_e  state_q,
+   input mpu_state_e  mpu_state
+
+   );
+
+  // WPT and MPU cannot both wait for a response at the sime time
+  // If they could both wait for a response, then they would need separate counters for the
+  // "one-transaction-left" inputs - otherwise they may share the counter.
+  a_wpt_mpu_cnt_share:
+  assert property (@(posedge clk) disable iff (!rst_n)
+                  ((state_q == WPT_MATCH_WAIT) || (mpu_state == MPU_RE_ERR_WAIT) || (mpu_state == MPU_WR_ERR_WAIT))
+                  |->
+                  (state_q == WPT_MATCH_WAIT) != ((mpu_state == MPU_RE_ERR_WAIT) || (mpu_state == MPU_WR_ERR_WAIT)))
+    else `uvm_error("load_store_unit", "WPT and MPU both wait for responses")
+endmodule
+


### PR DESCRIPTION
Refactored watchpoint trigger behavior.

- Instead of gating valid_0_i in the LSU, there is a new module cv32e40x_wpt that sits between the 'aligner' and the MPU in the LSU. This module will let un-triggered accesses through and 'consume' those with watchpoint triggers.
- WPT will return the trigger match with WB timing, as the MPU returns mpu status today.
- Controller was updated to handle the new timing of the trigger match/abort_op signals. 