### PR TITLE
Updated exception cause for instruction bus faults to be 24 instead o…

### DIFF
--- a/rtl/include/cv32e40x_pkg.sv
+++ b/rtl/include/cv32e40x_pkg.sv
@@ -885,7 +885,7 @@ parameter EXC_CAUSE_BREAKPOINT      = 11'h03;
 parameter EXC_CAUSE_LOAD_FAULT      = 11'h05;
 parameter EXC_CAUSE_STORE_FAULT     = 11'h07;
 parameter EXC_CAUSE_ECALL_MMODE     = 11'h0B;
-parameter EXC_CAUSE_INSTR_BUS_FAULT = 11'h30;
+parameter EXC_CAUSE_INSTR_BUS_FAULT = 11'h18;
 
 parameter logic [31:0] ETRIGGER_TDATA2_MASK = (1 << EXC_CAUSE_INSTR_BUS_FAULT) | (1 << EXC_CAUSE_ECALL_MMODE) | (1 << EXC_CAUSE_STORE_FAULT) |
                                               (1 << EXC_CAUSE_LOAD_FAULT) | (1 << EXC_CAUSE_BREAKPOINT) | (1 << EXC_CAUSE_ILLEGAL_INSN) | (1 << EXC_CAUSE_INSTR_FAULT);


### PR DESCRIPTION
…f 48 to align with user manual.

Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>