### PR TITLE
Single step and debug cause cleanup

### DIFF
--- a/bhv/cv32e40x_rvfi.sv
+++ b/bhv/cv32e40x_rvfi.sv
@@ -110,6 +110,7 @@ module cv32e40x_rvfi
    input logic                                nmi_pending_i,          // regular NMI pending
    input logic                                nmi_is_store_i,         // regular NMI type
    input logic                                debug_mode_q_i,
+   input logic [2:0]                          debug_cause_n_i,
 
    // Interrupt Controller probes
    input logic [31:0]                         irq_i,
@@ -792,7 +793,9 @@ module cv32e40x_rvfi
 
     end
 
-    if(pending_single_step_i && single_step_allowed_i) begin
+    // Check for single step debug entry, need to include the actual debug_cause_n, as single step has the lowest priority
+    // to enter debug and any higher priority cause could be active at the same time.
+    if((pending_single_step_i && single_step_allowed_i) && (debug_cause_n_i == DBG_CAUSE_STEP)) begin
       // The timing of the single step debug entry does not allow using pc_mux for detection
       rvfi_trap_next.debug       = 1'b1;
       rvfi_trap_next.debug_cause = DBG_CAUSE_STEP;

--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -519,6 +519,7 @@ endgenerate
          .nmi_pending_i            ( core_i.controller_i.controller_fsm_i.nmi_pending_q                   ),
          .nmi_is_store_i           ( core_i.controller_i.controller_fsm_i.nmi_is_store_q                  ),
          .debug_mode_q_i           ( core_i.controller_i.controller_fsm_i.debug_mode_q                    ),
+         .debug_cause_n_i          ( core_i.controller_i.controller_fsm_i.debug_cause_n                   ),
          .irq_i                    ( core_i.irq_i & IRQ_MASK                                              ),
          .irq_wu_ctrl_i            ( core_i.irq_wu_ctrl                                                   ),
          .irq_id_ctrl_i            ( core_i.irq_id_ctrl                                                   ),


### PR DESCRIPTION
Removed dependency on other pending debug causes when setting 'pending_single_step.

Updated setting of debug_cause_n, all possible causes are now in the priority (0.13.2, will be updated for 1.0.0). When all casues are set, some code cleanup faning into kill_wb from the DEBUG_TAKEN state was possible.

Updaed RVFI to account for the possibility of have pending_single_step active at the same time as there can be pending async or sync debug reasons.

Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>