### PR TITLE
User manual updates for mnxti and debug_req_i descriptions

### DIFF
--- a/docs/user_manual/source/control_status_registers.rst
+++ b/docs/user_manual/source/control_status_registers.rst
@@ -1289,8 +1289,9 @@ This register can be used by the software to service the next interrupt when it 
 without incurring the full cost of an interrupt pipeline flush and context save/restore.
 
 .. note::
-  Use of ``mnxti`` with non-zero ``uimm`` values for bits 0, 2, and 4 are reserved for future use.
-  |corev| will treat such instructions as illegal instructions.
+  The ``mnxti`` CSR is only designed to be used with the CSRR (CSRRS rd,csr,x0), CSRRSI, and CSRRCI instructions.
+  Accessing the ``mnxti`` CSR using any other CSR instruction form is reserved and |corev| will treat such instruction as illegal instructions.
+  In addition, use of ``mnxti`` with CSRRSI with non-zero uimm values for bits 0, 2, and 4 are reserved for future use and will also be treated as illegal instructions.
 
 .. _csr-mintthresh:
 

--- a/docs/user_manual/source/debug.rst
+++ b/docs/user_manual/source/debug.rst
@@ -48,7 +48,7 @@ halfword load/store for address ``A`` uses ``A`` and ``A+1`` as compare values; 
 A trigger match will cause debug entry if ``tdata1.ACTION`` is 1.
 
 .. note::
-  Hardware triggers and breakpoints are not supported for the table fetch used in table jump instructions and CLIC hardware vectored interrupts. 
+  Hardware triggers and breakpoints are not supported for the table fetch used in table jump instructions and CLIC hardware vectored interrupts.
 
 The |corev| will not support the optional debug features 10, 11, & 12 listed in Section 4.1 of [RISC-V-DEBUG]_. Specifically, a control transfer instruction's destination location being in or out of the Program Buffer and instructions depending on PC value shall **not** cause an illegal instruction.
 
@@ -81,7 +81,8 @@ Interface
   | ``dm_exception_addr_i[31:0]`` | input     | Address for debugger exception entry       |
   +-------------------------------+-----------+--------------------------------------------+
 
-``debug_req_i`` is the "debug interrupt", issued by the debug module when the core should enter Debug Mode. The ``debug_req_i`` is synchronous to ``clk_i`` and requires a minimum assertion of one clock period to enter Debug Mode. The instruction being decoded during the same cycle that ``debug_req_i`` is first asserted shall not be executed before entering Debug Mode.
+``debug_req_i`` is the "debug interrupt", issued by the debug module when the core should enter Debug Mode. The ``debug_req_i`` is synchronous to ``clk_i``, level sensitive and requires a minimum assertion of one clock period to enter Debug Mode.
+It is not guaranteed that a short pulse on ``debug_req_i`` will cause |corev| to enter debug mode if |corev| is in a state where debug mode cannot be entered while ``debug_req_i`` is high.
 
 ``debug_havereset_o``, ``debug_running_o``, and ``debug_mode_o`` signals provide the operational status of the core to the debug module. The assertion of these
 signals is mutually exclusive.

--- a/docs/user_manual/source/debug.rst
+++ b/docs/user_manual/source/debug.rst
@@ -81,8 +81,8 @@ Interface
   | ``dm_exception_addr_i[31:0]`` | input     | Address for debugger exception entry       |
   +-------------------------------+-----------+--------------------------------------------+
 
-``debug_req_i`` is the "debug interrupt", issued by the debug module when the core should enter Debug Mode. The ``debug_req_i`` is synchronous to ``clk_i``, level sensitive and requires a minimum assertion of one clock period to enter Debug Mode.
-It is not guaranteed that a short pulse on ``debug_req_i`` will cause |corev| to enter debug mode if |corev| is in a state where debug mode cannot be entered while ``debug_req_i`` is high.
+``debug_req_i`` is the "debug interrupt", issued by the debug module when the core should enter Debug Mode. The ``debug_req_i`` signal is synchronous to ``clk_i`` and it is level sensitive.
+It is not guaranteed that a short pulse on ``debug_req_i`` will cause |corev| to enter debug mode.
 
 ``debug_havereset_o``, ``debug_running_o``, and ``debug_mode_o`` signals provide the operational status of the core to the debug module. The assertion of these
 signals is mutually exclusive.


### PR DESCRIPTION
Updated description of the debug_req_i signal.
Updated description of legal CSR instruction for accessing the mnxti CSR.

Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>