### PR TITLE
WARL resolution functions

### DIFF
--- a/rtl/cv32e40x_controller_fsm.sv
+++ b/rtl/cv32e40x_controller_fsm.sv
@@ -475,7 +475,7 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
 
   // Debug pending for any other synchronous reason than single step
   assign pending_sync_debug = (trigger_match_in_wb) ||
-                              (ebreak_in_wb && dcsr_i.ebreakm && !debug_mode_q) || // Ebreak with dcsr.ebreakm==1
+                              (ebreak_in_wb && dcsr_i.ebreakm && !debug_mode_q) || // Ebreak with dcsr.ebreakm==1 // todo: add check for WB stage priv level
                               (ebreak_in_wb && debug_mode_q); // Ebreak during debug_mode restarts execution from dm_halt_addr, as a regular debug entry without CSR updates.
 
   // Debug pending for external debug request, only if not already in debug mode

--- a/rtl/cv32e40x_cs_registers.sv
+++ b/rtl/cv32e40x_cs_registers.sv
@@ -639,11 +639,12 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
     dcsr_n        = '{
                       xdebugver : dcsr_rdata.xdebugver,
                       ebreakm   : csr_wdata_int[15],
+                      ebreaku   : dcsr_ebreaku_resolve(dcsr_rdata.ebreaku, csr_wdata_int[DCSR_EBREAKU_BIT]),
                       stepie    : csr_wdata_int[11],
                       stopcount : csr_wdata_int[10],
                       mprven    : dcsr_rdata.mprven,
                       step      : csr_wdata_int[2],
-                      prv       : dcsr_prv_resolve(dcsr_rdata.prv, csr_wdata_int[1:0]),
+                      prv       : dcsr_prv_resolve(dcsr_rdata.prv, csr_wdata_int[DCSR_PRV_BIT_HIGH:DCSR_PRV_BIT_LOW]),
                       cause     : dcsr_rdata.cause,
                       default   : 'd0
                      };
@@ -670,7 +671,7 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
     // TODO: add support for SD/XS/FS/VS
     mstatus_n     = '{
                                   tw:   1'b0,
-                                  mprv: 1'b0,
+                                  mprv: mstatus_mprv_resolve(mstatus_rdata.mprv, csr_wdata_int[MSTATUS_MPRV_BIT]),
                                   mpp:  mstatus_mpp_resolve(mstatus_rdata.mpp, csr_wdata_int[MSTATUS_MPP_BIT_HIGH:MSTATUS_MPP_BIT_LOW]),
                                   mpie: csr_wdata_int[MSTATUS_MPIE_BIT],
                                   mie:  csr_wdata_int[MSTATUS_MIE_BIT],
@@ -693,7 +694,7 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
     mtvec_we        = csr_mtvec_init_i;
 
     if (SMCLIC) begin
-      mtvec_n.mode             = mtvec_rdata.mode; // mode is WARL 0x3 when using CLIC
+      mtvec_n.mode             = mtvec_mode_clic_resolve(mtvec_rdata.mode, csr_wdata_int[MTVEC_MODE_BIT_HIGH:MTVEC_MODE_BIT_LOW]); // mode is WARL 0x3 when using CLIC
 
       mtvt_n                   = {csr_wdata_int[31:(32-MTVT_ADDR_WIDTH)], {(32-MTVT_ADDR_WIDTH){1'b0}}};
       mtvt_we                  = 1'b0;
@@ -730,7 +731,7 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
                                   };
       mcause_we                = 1'b0;
     end else begin // !SMCLIC
-      mtvec_n.mode             = csr_mtvec_init_i ? mtvec_rdata.mode : {1'b0, csr_wdata_int[0]};
+      mtvec_n.mode             = csr_mtvec_init_i ? mtvec_rdata.mode : mtvec_mode_clint_resolve(mtvec_rdata.mode, csr_wdata_int[MTVEC_MODE_BIT_HIGH:MTVEC_MODE_BIT_LOW]);;
 
       mtvt_n                   = '0;
       mtvt_we                  = 1'b0;
@@ -1007,6 +1008,7 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
           dcsr_n         = '{
             xdebugver : dcsr_rdata.xdebugver,
             ebreakm   : dcsr_rdata.ebreakm,
+            ebreaku   : dcsr_rdata.ebreaku,
             stepie    : dcsr_rdata.stepie,
             stopcount : dcsr_rdata.stopcount,
             mprven    : dcsr_rdata.mprven,

--- a/rtl/cv32e40x_cs_registers.sv
+++ b/rtl/cv32e40x_cs_registers.sv
@@ -731,7 +731,7 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
                                   };
       mcause_we                = 1'b0;
     end else begin // !SMCLIC
-      mtvec_n.mode             = csr_mtvec_init_i ? mtvec_rdata.mode : mtvec_mode_clint_resolve(mtvec_rdata.mode, csr_wdata_int[MTVEC_MODE_BIT_HIGH:MTVEC_MODE_BIT_LOW]);;
+      mtvec_n.mode             = csr_mtvec_init_i ? mtvec_rdata.mode : mtvec_mode_clint_resolve(mtvec_rdata.mode, csr_wdata_int[MTVEC_MODE_BIT_HIGH:MTVEC_MODE_BIT_LOW]);
 
       mtvt_n                   = '0;
       mtvt_we                  = 1'b0;

--- a/rtl/cv32e40x_debug_triggers.sv
+++ b/rtl/cv32e40x_debug_triggers.sv
@@ -160,7 +160,7 @@ import cv32e40x_pkg::*;
                         csr_wdata_i[6],        // M  6
                         1'b0,                  // zero 5
                         1'b0,                  // zero, S 4
-                        1'b0,                  // zero, U 3
+                        mcontrol6_u_resolve(csr_wdata_i[MCONTROL6_U]),     // zero, U 3
                         csr_wdata_i[2],        // EXECUTE 2
                         csr_wdata_i[1],        // STORE 1
                         csr_wdata_i[0]         // LOAD 0
@@ -185,7 +185,7 @@ import cv32e40x_pkg::*;
                           csr_wdata_i[9],        // m     : Match in machine mode 9
                           1'b0,                  // zero  : tied to zero 8
                           1'b0,                  // s     : WARL(0) 7
-                          1'b0,                  // u     : Match in user mode 7
+                          etrigger_u_resolve(csr_wdata_i[ETRIGGER_U]), // u     : Match in user mode 6
                           6'b000001              // action : WARL(1), enter debug on match
               };
             end

--- a/rtl/cv32e40x_i_decoder.sv
+++ b/rtl/cv32e40x_i_decoder.sv
@@ -392,7 +392,7 @@ module cv32e40x_i_decoder import cv32e40x_pkg::*;
                 if (instr_rdata_i[19:15] != 5'b0) begin
                   decoder_ctrl_o = DECODER_CTRL_ILLEGAL_INSN;
                 end
-              end else if (instr_rdata_i[14:12] == 2'b110) begin // CSRRSI
+              end else if (instr_rdata_i[14:12] == 3'b110) begin // CSRRSI
                 // Only legal if immediate 0,2 and 4 is zero
                 if (instr_rdata_i[19] || instr_rdata_i[17] || instr_rdata_i[15]) begin
                   decoder_ctrl_o = DECODER_CTRL_ILLEGAL_INSN;

--- a/rtl/include/cv32e40x_pkg.sv
+++ b/rtl/include/cv32e40x_pkg.sv
@@ -477,10 +477,19 @@ parameter MSTATUS_MIE_BIT      = 3;
 parameter MSTATUS_MPIE_BIT     = 7;
 parameter MSTATUS_MPP_BIT_LOW  = 11;
 parameter MSTATUS_MPP_BIT_HIGH = 12;
+parameter MSTATUS_MPRV_BIT     = 17;
 
 parameter MCAUSE_MPIE_BIT      = 27;
 parameter MCAUSE_MPP_BIT_LOW   = 28;
 parameter MCAUSE_MPP_BIT_HIGH  = 29;
+
+parameter MTVEC_MODE_BIT_HIGH  = 1;
+parameter MTVEC_MODE_BIT_LOW   = 0;
+
+parameter DCSR_EBREAKU_BIT     = 12;
+parameter DCSR_PRV_BIT_HIGH    = 1;
+parameter DCSR_PRV_BIT_LOW     = 0;
+
 
 // misa
 parameter logic [1:0] MXL = 2'd1; // M-XLEN: XLEN in M-Mode for RV32
@@ -1322,6 +1331,7 @@ typedef struct packed {
   ////////////////////////////////////////
   // Resolution functions
 
+
   function automatic privlvl_t dcsr_prv_resolve
   (
     privlvl_t   current_value,
@@ -1329,6 +1339,15 @@ typedef struct packed {
   );
     // dcsr.prv is WARL(0x3)
     return PRIV_LVL_M;
+  endfunction
+
+  function automatic logic dcsr_ebreaku_resolve
+  (
+    logic       current_value,
+    logic       next_value
+  );
+    // dcsr.ebreaku is WARL(0x0)
+    return 1'b0;
   endfunction
 
   function automatic logic [1:0] mstatus_mpp_resolve
@@ -1340,11 +1359,54 @@ typedef struct packed {
     return PRIV_LVL_M;
   endfunction
 
+  function automatic logic mstatus_mprv_resolve
+  (
+    logic current_value,
+    logic next_value
+  );
+    // mstatus.mprv is WARL(0x0)
+    return 1'b0;
+  endfunction
+
   function automatic logic [3:0] mcontrol6_match_resolve
   (
     logic [3:0] next_value
   );
     return ((next_value != 4'h0) && (next_value != 4'h2) && (next_value != 4'h3)) ? 4'h0 : next_value;
+  endfunction
+
+  function automatic logic mcontrol6_u_resolve
+  (
+    logic next_value
+  );
+    // mcontrol6.u is WARL(0x0)
+    return 1'b0;
+  endfunction
+
+  function automatic logic etrigger_u_resolve
+  (
+    logic next_value
+  );
+    // etrigger.u is WARL(0x0)
+    return 1'b0;
+  endfunction
+
+  function automatic logic[1:0] mtvec_mode_clint_resolve
+  (
+    logic [1:0] current_value,
+    logic [1:0] next_value
+  );
+    // mtvec.mode is WARL(0,1) in CLINT mode
+    return ((next_value != 2'b00) && (next_value != 1'b01)) ? current_value : next_value;
+  endfunction
+
+  function automatic logic[1:0] mtvec_mode_clic_resolve
+  (
+    logic current_value,
+    logic next_value
+  );
+    // mtvec.mode is WARL(0x3) in CLIC mode
+    return 2'b11;
   endfunction
   ///////////////////////////
   //                       //


### PR DESCRIPTION
Added WARL resolution functions for the following CSR fields:
- mstatus.mprv
- mtvec.mode (CLIC mode)
- mtvec.mode (CLINT mode)
- mcontrol6.u
- etrigger.u
- dcsr.ebreaku

SEC clean when SMCLIC=1
NOT SEC clean when SMCLIC=0 due due to a known bug in mtvec.mode WARL handling.

Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>