### PR TITLE
Trigger type WARL resolution (0xF)

### DIFF
--- a/rtl/cv32e40x_debug_triggers.sv
+++ b/rtl/cv32e40x_debug_triggers.sv
@@ -141,10 +141,7 @@ import cv32e40x_pkg::*;
         tdata2_n  = tdata2_rdata_o;
 
         if (tdata1_we_i) begin
-          if (csr_wdata_i == 32'd0) begin
-            // Writing zero to tdata1 disables the currently selected trigger
-            tdata1_n = {TTYPE_DISABLED, 1'b1, {27{1'b0}}};
-          end else if (csr_wdata_i[TDATA1_TTYPE_HIGH:TDATA1_TTYPE_LOW] == TTYPE_MCONTROL6) begin
+          if (csr_wdata_i[TDATA1_TTYPE_HIGH:TDATA1_TTYPE_LOW] == TTYPE_MCONTROL6) begin
             // Mcontrol6 supports any value in tdata2, no need to check tdata2 before writing tdata1
             tdata1_n = {
                         TTYPE_MCONTROL6,       // type    : address/data match
@@ -193,8 +190,8 @@ import cv32e40x_pkg::*;
             // All tdata2 values are legal for a disabled trigger, no WARL on tdata1.
             tdata1_n = {TTYPE_DISABLED, 1'b1, {27{1'b0}}};
           end else begin
-            // No legal trigger type, keep currently selected value
-            tdata1_n = tdata1_rdata_o;
+            // No legal trigger type, set disabled trigger type 0xF
+            tdata1_n = {TTYPE_DISABLED, 1'b1, {27{1'b0}}};
           end
         end // tdata1_we_i
 


### PR DESCRIPTION
Attempts to write an unsupported trigger will now cause tdata1 to become a disabled trigger (type 0xF) instead of keeping its old value.

Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>