### PR TITLE
Updated targets for NMI.

### DIFF
--- a/rtl/cv32e40x_controller_fsm.sv
+++ b/rtl/cv32e40x_controller_fsm.sv
@@ -271,6 +271,11 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
   // index for table jumps taken from instruction word in ID stage.
   assign ctrl_fsm_o.jvt_pc_mux = if_id_pipe_i.instr.bus_resp.rdata[19:12];
 
+  // Set which mtvec index to jump to when an NMI is taken
+  // index 0 for non-vectored CLINT mode and CLIC mode, 0xF for vectored CLINT mode
+  assign ctrl_fsm_o.nmi_mtvec_index = (mtvec_mode_i == 2'b01) ? 5'hF : 5'h0;
+
+
 
   ////////////////////////////////////////////////////////////////////
   // ID stage

--- a/rtl/cv32e40x_if_stage.sv
+++ b/rtl/cv32e40x_if_stage.sv
@@ -163,7 +163,7 @@ module cv32e40x_if_stage import cv32e40x_pkg::*;
       PC_TRAP_IRQ:   branch_addr_n = {mtvec_addr_i, ctrl_fsm_i.mtvec_pc_mux, 2'b00};     // interrupts are vectored
       PC_TRAP_DBD:   branch_addr_n = {dm_halt_addr_i[31:2], 2'b0};
       PC_TRAP_DBE:   branch_addr_n = {dm_exception_addr_i[31:2], 2'b0};
-      PC_TRAP_NMI:   branch_addr_n = {mtvec_addr_i, NMI_MTVEC_INDEX, 2'b00};
+      PC_TRAP_NMI:   branch_addr_n = {mtvec_addr_i, ctrl_fsm_i.nmi_mtvec_index, 2'b00};
       PC_TRAP_CLICV: branch_addr_n = {mtvt_addr_i, ctrl_fsm_i.mtvt_pc_mux[SMCLIC_ID_WIDTH-1:0], 2'b00};
       // CLIC and Zc* spec requires to clear bit 0. This clearing is done in the alignment buffer.
       PC_POINTER :   branch_addr_n = if_id_pipe_o.ptr;

--- a/rtl/include/cv32e40x_pkg.sv
+++ b/rtl/include/cv32e40x_pkg.sv
@@ -1269,13 +1269,15 @@ typedef struct packed {
   logic        pc_set_clicv;          // Signal pc_set it for CLIC vectoring pointer load
   logic        pc_set_tbljmp;         // Signal pc_set is for Zc* cm.jt / cm.jalt pointer load
   pc_mux_e     pc_mux;                // Selector in the Fetch stage to select the rigth PC (normal, jump ...)
-
-  // To WB stage
-  logic        block_data_addr;       // To LSU to prevent data_addr_wb_i updates between error and taken NMI
   logic [4:0]  mtvec_pc_mux;          // Id of taken basic mode irq (to IF, EXC_PC_MUX, zeroed if mtvec_mode==0)
   logic [9:0]  mtvt_pc_mux;           // Id of taken CLIC irq (to IF, EXC_PC_MUX, zeroed if not shv)
                                       // Setting to 11 bits (max), unused bits will be tied off
   logic [7:0]  jvt_pc_mux;            // Index for table jumps
+  logic [4:0]  nmi_mtvec_index;       // Offset into mtvec when taking an NMI
+
+  // To WB stage
+  logic        block_data_addr;       // To LSU to prevent data_addr_wb_i updates between error and taken NMI
+
 
   logic        irq_ack;               // Irq has been taken
   logic [9:0]  irq_id;                // Id of taken irq. Max width (1024 interrupts), unused bits will be tied off

--- a/sva/cv32e40x_rvfi_sva.sv
+++ b/sva/cv32e40x_rvfi_sva.sv
@@ -205,7 +205,7 @@ module cv32e40x_rvfi_sva
     assert property (@(posedge clk_i) disable iff (!rst_ni)
                      (no_debug && $stable(mtvec_addr_i)) throughout s_goto_next_rvfi_valid(rvfi_csr_dcsr_rdata[3]) |->
                      rvfi_intr.intr &&
-                     (rvfi_pc_rdata == {mtvec_addr_i, NMI_MTVEC_INDEX, 2'b00}) &&
+                     (rvfi_pc_rdata == {mtvec_addr_i, ctrl_fsm_i.nmi_mtvec_index, 2'b00}) &&
                      ((rvfi_csr_mcause_rdata[10:0] == INT_CAUSE_LSU_LOAD_FAULT) || (rvfi_csr_mcause_rdata[10:0] == INT_CAUSE_LSU_STORE_FAULT)))
       else `uvm_error("rvfi", "dcsr.nmip not followed by rvfi_intr and NMI handler")
 
@@ -213,7 +213,7 @@ module cv32e40x_rvfi_sva
   /* TODO: Add back in.
      Currently, the alignment buffer can interpret pointers as compressed instructions and pass on two "instructions" from the IF stage.
      cv32e40x_rvfi_instr_obi will not be in sync with the alignment buffer until this is fixed. See https://github.com/openhwgroup/cv32e40x/issues/704
-   
+
   // Check that cv32e40x_rvfi_instr_obi tracks alignment buffer
   a_rvfi_instr_obi_addr:
     assert property (@(posedge clk_i) disable iff (!rst_ni)
@@ -254,7 +254,7 @@ module cv32e40x_rvfi_sva
                      obi_instr_fifo_q[obi_instr_rptr_q].req_payload.prot == obi_instr_fifo_q[obi_instr_rptr_q_inc].req_payload.prot)
       else `uvm_error("rvfi", "rvfi_instr_obi prot not the same for split transfers")
   */
-   
+
 endmodule
 
 


### PR DESCRIPTION
CLINT vectored: mtvec offset 15
CLINT non-vectored: mtvec offset 0
CLIC mtvec offset 0

Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>