### PR TITLE
Updated aliasing of mpp and mpie between mcause and mstatus.

### DIFF
--- a/rtl/cv32e40x_cs_registers.sv
+++ b/rtl/cv32e40x_cs_registers.sv
@@ -258,6 +258,15 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
   logic                         csr_wr_in_wb;
   logic                         jvt_wr_in_wb;
 
+  // Special we signal for aliased writes between mstatus and mcause.
+  // Only used for explicit writes to either mcause or mstatus, to signal that
+  // mpp and mpie of the aliased CSR should be written.
+  // All implicit writes (upon taking exceptions etc) handle the aliasing by also
+  // writing mcause.mpp/mpie to mstatus and vice versa.
+  logic                         mcause_alias_we;
+  logic                         mstatus_alias_we;
+
+
   // Performance Counter Signals
   logic [31:0] [63:0]           mhpmcounter_q;                                  // Performance counters
   logic [31:0] [63:0]           mhpmcounter_n;                                  // Performance counters next value
@@ -681,6 +690,7 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
 
     mstatush_n    = mstatush_rdata; // Read only
     mstatush_we   = 1'b0;
+    mstatus_alias_we = 1'b0;
 
     misa_n        = misa_rdata; // Read only
     misa_we       = 1'b0;
@@ -725,11 +735,14 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
       mcause_n                 = '{
                                     irq:            csr_wdata_int[31],
                                     minhv:          csr_wdata_int[30],
+                                    mpp:            mstatus_mpp_resolve(mstatus_rdata.mpp, csr_wdata_int[MCAUSE_MPP_BIT_HIGH:MCAUSE_MPP_BIT_LOW]),
+                                    mpie:           csr_wdata_int[MCAUSE_MPIE_BIT],
                                     mpil:           csr_wdata_int[23:16],
                                     exception_code: csr_wdata_int[10:0],
                                     default:        'b0
                                   };
       mcause_we                = 1'b0;
+      mcause_alias_we          = 1'b0;
     end else begin // !SMCLIC
       mtvec_n.mode             = csr_mtvec_init_i ? mtvec_rdata.mode : mtvec_mode_clint_resolve(mtvec_rdata.mode, csr_wdata_int[MTVEC_MODE_BIT_HIGH:MTVEC_MODE_BIT_LOW]);
 
@@ -765,6 +778,7 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
                                     default:        'b0
                                   };
       mcause_we                = 1'b0;
+      mcause_alias_we          = 1'b0;
     end
 
     mtval_n         = mtval_rdata;                // Read-only
@@ -799,6 +813,12 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
         // mstatus
         CSR_MSTATUS: begin
           mstatus_we = 1'b1;
+          // CLIC mode is assumed when SMCLIC = 1
+          // For CLIC, a write to mstatus.mpp or mstatus.mpie will write to the
+          // corresponding bits in mstatus as well.
+          if (SMCLIC) begin
+            mcause_alias_we = 1'b1;
+          end
         end
 
         CSR_MISA: begin
@@ -843,7 +863,7 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
           // For CLIC, a write to mcause.mpp or mcause.mpie will write to the
           // corresponding bits in mstatus as well.
           if (SMCLIC) begin
-            mstatus_we = 1'b1;
+            mstatus_alias_we = 1'b1;
           end
         end
 
@@ -862,6 +882,7 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
 
             // Writes to mnxti also writes to mstatus
             mstatus_we = 1'b1;
+            mcause_we  = 1'b1;
 
             // Writes to mintstatus.mil and mcause depend on the current state of
             // clic interrupts AND the type of CSR instruction used.
@@ -869,7 +890,6 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
             // This is already coded into the csr_we_int/mnxti_we
             if (mnxti_irq_pending_i) begin
               mintstatus_we = 1'b1;
-              mcause_we     = 1'b1;
             end
           end
         end
@@ -963,30 +983,44 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
     end
 
     // CSR side effects from other CSRs
-    // All write enables are already calculated at this point
 
     // CLIC mode is assumed when SMCLIC = 1
     if (SMCLIC) begin
       if (mnxti_we) begin
+        // Mstatus is written as part of an mnxti access
+        // Make sure we alias the mpp/mpie to mcause
+        mcause_n = mcause_rdata;
+        mcause_n.mpie = mstatus_n.mpie;
+        mcause_n.mpp = mstatus_n.mpp;
+
         // mintstatus and mcause are updated if an actual mstatus write happens and
         // a higher level non-shv interrupt is pending.
         // This is already decoded into the respective _we signals below.
         if (mintstatus_we) begin
           mintstatus_n.mil = mnxti_irq_level_i;
         end
-        if (mcause_we) begin
-          mcause_n = mcause_rdata;
+        if (mnxti_irq_pending_i) begin
           mcause_n.irq = 1'b1;
           mcause_n.exception_code = {1'b0, 10'(mnxti_irq_id_i)};
         end
-      end else if (mcause_we) begin
+      end else if (mstatus_alias_we) begin
         // In CLIC mode, writes to mcause.mpp/mpie is aliased to mstatus.mpp/mpie
         // All other mstatus bits are preserved
         mstatus_n      = mstatus_rdata; // Preserve all fields
 
         // Write mpie and mpp as aliased through mcause
-        mstatus_n.mpie = csr_wdata_int[MCAUSE_MPIE_BIT];
-        mstatus_n.mpp  = mstatus_mpp_resolve(mstatus_rdata.mpp, csr_wdata_int[MCAUSE_MPP_BIT_HIGH:MCAUSE_MPP_BIT_LOW]);
+        mstatus_n.mpie = mcause_n.mpie;
+        mstatus_n.mpp  = mcause_n.mpp;
+
+        mstatus_we = 1'b1;
+      end else if (mcause_alias_we) begin
+        // In CLIC mode, writes to mstatus.mpp/mpie is aliased to mcause.mpp/mpie
+        // All other mcause bits are preserved
+        mcause_n = mcause_rdata;
+        mcause_n.mpie = mstatus_n.mpie;
+        mcause_n.mpp = mstatus_n.mpp;
+
+        mcause_we = 1'b1;
       end
       // The CLIC pointer address should always be output for an access to MNXTI,
       // but will only contain a nonzero value if a CLIC interrupt is actually pending
@@ -1037,7 +1071,15 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
           mepc_n         = ctrl_fsm_i.pipe_pc;
           mepc_we        = 1'b1;
 
-          mcause_n       = ctrl_fsm_i.csr_cause;
+          // Save relevant fields from controller to mcause
+          mcause_n.irq            = ctrl_fsm_i.csr_cause.irq;
+          mcause_n.exception_code = ctrl_fsm_i.csr_cause.exception_code;
+          mcause_n.minhv          = ctrl_fsm_i.csr_cause.minhv;
+          // Save aliased values for mpp and mpie
+          mcause_n.mpp            = mstatus_n.mpp;
+          mcause_n.mpie           = mstatus_n.mpie;
+
+          mcause_we = 1'b1;
 
 
           if (SMCLIC) begin
@@ -1059,8 +1101,6 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
           end else begin
             mcause_n.mpil = '0;
           end
-          mcause_we = 1'b1;
-
         end
       end //ctrl_fsm_i.csr_save_cause
 
@@ -1079,11 +1119,15 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
           mintstatus_n.mil = mcause_rdata.mpil;
           mintstatus_we = 1'b1;
 
+          // Save aliased values for mpp and mpie
+          mcause_n = mcause_rdata;
+          mcause_n.mpp = mstatus_n.mpp;
+          mcause_n.mpie = mstatus_n.mpie;
+          mcause_we = 1'b1;
+
           if (ctrl_fsm_i.csr_restore_mret_ptr) begin
             // Clear mcause.minhv if the mret also caused a successful CLIC pointer fetch
-            mcause_n = mcause_rdata;
             mcause_n.minhv = 1'b0;
-            mcause_we = 1'b1;
           end
         end
       end //ctrl_fsm_i.csr_restore_mret
@@ -1098,6 +1142,10 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
         mstatus_n.mprv = (privlvl_t'(dcsr_rdata.prv) == PRIV_LVL_M) ? mstatus_rdata.mprv : 1'b0;
         mstatus_we     = 1'b1;
 
+        // Not really needed, but allows for asserting mstatus_we == mcause_we to check aliasing formally
+        mcause_n       = mcause_rdata;
+        mcause_we      = 1'b1;
+
       end //ctrl_fsm_i.csr_restore_dret
 
       // Clear mcause.minhv on successful CLIC pointer fetches
@@ -1110,6 +1158,10 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
           mcause_n = mcause_rdata;
           mcause_n.minhv = 1'b0;
           mcause_we = 1'b1;
+
+          // Not really needed, but allows for asserting mstatus_we == mcause_we to check aliasing formally
+          mstatus_n  = mstatus_rdata;
+          mstatus_we = 1'b1;
         end
       end
       default:;
@@ -1260,23 +1312,25 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
     .rd_data_o          ( mstatus_q             )
   );
 
-  cv32e40x_csr
-  #(
-    .WIDTH      (32),
-    .RESETVALUE (32'd0)
-  )
-  mcause_csr_i (
-    .clk                ( clk                   ),
-    .rst_n              ( rst_n                 ),
-    .wr_data_i          ( mcause_n              ),
-    .wr_en_i            ( mcause_we             ),
-    .rd_data_o          ( mcause_q              )
-  );
+
 
   generate
     if (SMCLIC) begin : smclic_csrs
 
       assign mie_q = 32'h0;                                                     // CLIC mode is assumed when SMCLIC = 1
+
+      cv32e40x_csr
+      #(
+        .WIDTH      (32),
+        .RESETVALUE (MCAUSE_RESET_VAL)
+      )
+      mcause_csr_i (
+        .clk                ( clk                   ),
+        .rst_n              ( rst_n                 ),
+        .wr_data_i          ( mcause_n              ),
+        .wr_en_i            ( mcause_we             ),
+        .rd_data_o          ( mcause_q              )
+      );
 
       cv32e40x_csr
       #(
@@ -1336,6 +1390,19 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
 
 
     end else begin : basic_mode_csrs
+
+      cv32e40x_csr
+      #(
+        .WIDTH      (32),
+        .RESETVALUE (32'd0)
+      )
+      mcause_csr_i (
+        .clk                ( clk                   ),
+        .rst_n              ( rst_n                 ),
+        .wr_data_i          ( mcause_n              ),
+        .wr_en_i            ( mcause_we             ),
+        .rd_data_o          ( mcause_q              )
+      );
 
       cv32e40x_csr
       #(
@@ -1432,14 +1499,9 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
   // dcsr_rdata factors in the flop outputs and the nmip bit from the controller
   assign dcsr_rdata = {dcsr_q[31:4], ctrl_fsm_i.pending_nmi, dcsr_q[2:0]};
 
-  generate
-    if (SMCLIC) begin : smclic_rdata
-        // mcause.mpp is alias of mstatus.mpp, mcause.mpie is alias of mstatus.mpie
-        assign mcause_rdata = {mcause_q[31:30], mstatus_q.mpp, mstatus_q.mpie, mcause_q[26:0]};
-    end else begin : basic_mode_rdata
-       assign mcause_rdata = mcause_q;
-    end
-  endgenerate
+
+  assign mcause_rdata = mcause_q;
+
 
   assign csr_rdata_o = csr_rdata_int;
 
@@ -1459,7 +1521,7 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
   // Signal when an interrupt may become enabled due to a CSR write
   generate
     if (SMCLIC) begin : smclic_irq_en
-      assign csr_irq_enable_write_o = mstatus_we || priv_lvl_we || mintthresh_we || mintstatus_we;
+      assign csr_irq_enable_write_o = (mstatus_we && !ctrl_fsm_i.csr_clear_minhv) || priv_lvl_we || mintthresh_we || mintstatus_we;
     end else begin : basic_irq_en
       assign csr_irq_enable_write_o = mie_we || mstatus_we || priv_lvl_we;
     end

--- a/rtl/include/cv32e40x_pkg.sv
+++ b/rtl/include/cv32e40x_pkg.sv
@@ -651,9 +651,12 @@ parameter mstatus_t MSTATUS_RESET_VAL = '{
   zero0   : 'b0,
   default : 'b0};
 
-parameter mcause_t MCAUSE_RESET_VAL = '{
+parameter mcause_t MCAUSE_CLIC_RESET_VAL = '{
   mpp     : PRIV_LVL_M,
   default: 'b0};
+
+parameter mcause_t MCAUSE_BASIC_RESET_VAL = '{
+    default: 'b0};
 
 parameter logic [31:0] TDATA1_RST_VAL = {
   TTYPE_MCONTROL6,       // type    : address/data match
@@ -1364,6 +1367,15 @@ typedef struct packed {
     logic [1:0] next_value
   );
     // mstatus.mpp is WARL(0x3)
+    return PRIV_LVL_M;
+  endfunction
+
+  function automatic logic [1:0] mcause_mpp_resolve
+  (
+    logic [1:0] current_value,
+    logic [1:0] next_value
+  );
+    // mcause.mpp is WARL(0x3)
     return PRIV_LVL_M;
   endfunction
 

--- a/rtl/include/cv32e40x_pkg.sv
+++ b/rtl/include/cv32e40x_pkg.sv
@@ -651,6 +651,10 @@ parameter mstatus_t MSTATUS_RESET_VAL = '{
   zero0   : 'b0,
   default : 'b0};
 
+parameter mcause_t MCAUSE_RESET_VAL = '{
+  mpp     : PRIV_LVL_M,
+  default: 'b0};
+
 parameter logic [31:0] TDATA1_RST_VAL = {
   TTYPE_MCONTROL6,       // type    : address/data match
   1'b1,                  // dmode   : access from D mode only

--- a/sva/cv32e40x_cs_registers_sva.sv
+++ b/sva/cv32e40x_cs_registers_sva.sv
@@ -148,7 +148,7 @@ module cv32e40x_cs_registers_sva
       );
     endproperty;
     a_mstatus_mcause_we: assert property(p_mstatus_mcause_we)
-      else `uvm_error("cs_registers", "Mstatus.mpp and mstatus.mpie not written at the same time")
+      else `uvm_error("cs_registers", "mcause and mstatus not written at the same time")
 
     property p_mcause_mstatus_alias;
       @(posedge clk) disable iff (!rst_n)


### PR DESCRIPTION
RVFI didn't always get the correct write values, and the aliasing was only working from mcause to mstatus and not the other way.

The three bits are now duplicated in both mcause and mstatus, and are always written simultaneously. Assertions are added to check that mcause and mstatus always write at the same time, and that the *_rdata.mpp/mpie fields are always the same.

SEC clean

Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>