### PR TITLE
Fix for issue #410

### DIFF
--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -231,6 +231,8 @@ module cv32e40x_wrapper
                               .lsu_trans_valid_i            (core_i.load_store_unit_i.trans_valid),
                               .csr_en_id_i                  (core_i.id_stage_i.csr_en),
                               .ptr_in_if_i                  (core_i.if_stage_i.ptr_in_if_o),
+                              .instr_req_o                  (core_i.instr_req_o),
+                              .instr_dbg_o                  (core_i.instr_dbg_o),
                               .*);
   bind cv32e40x_cs_registers:
     core_i.cs_registers_i
@@ -266,7 +268,10 @@ module cv32e40x_wrapper
     core_i.if_stage_i.prefetch_unit_i
       cv32e40x_prefetch_unit_sva
       #(.SMCLIC(SMCLIC))
-      prefetch_unit_sva (.*);
+      prefetch_unit_sva (
+                          .ctrl_fsm_cs     (core_i.controller_i.controller_fsm_i.ctrl_fsm_cs),
+                          .debug_req_i     (core_i.debug_req_i),
+                          .*);
 
   generate
     if(M_EXT == M) begin: div_sva

--- a/rtl/include/cv32e40x_pkg.sv
+++ b/rtl/include/cv32e40x_pkg.sv
@@ -169,7 +169,7 @@ typedef enum logic [DIV_OP_WIDTH-1:0]
  } div_opcode_e;
 
 // FSM state encoding
-typedef enum logic [2:0] { RESET, FUNCTIONAL, SLEEP, DEBUG_TAKEN} ctrl_state_e;
+typedef enum logic [1:0] { RESET, FUNCTIONAL, SLEEP, DEBUG_TAKEN} ctrl_state_e;
 
 // Debug FSM state encoding
 // State encoding done one-hot to ensure that debug_havereset_o, debug_running_o, debug_halted_o

--- a/rtl/include/cv32e40x_pkg.sv
+++ b/rtl/include/cv32e40x_pkg.sv
@@ -169,7 +169,7 @@ typedef enum logic [DIV_OP_WIDTH-1:0]
  } div_opcode_e;
 
 // FSM state encoding
-typedef enum logic [2:0] { RESET, BOOT_SET, FUNCTIONAL, SLEEP, DEBUG_TAKEN} ctrl_state_e;
+typedef enum logic [2:0] { RESET, FUNCTIONAL, SLEEP, DEBUG_TAKEN} ctrl_state_e;
 
 // Debug FSM state encoding
 // State encoding done one-hot to ensure that debug_havereset_o, debug_running_o, debug_halted_o

--- a/sva/cv32e40x_alignment_buffer_sva.sv
+++ b/sva/cv32e40x_alignment_buffer_sva.sv
@@ -186,16 +186,6 @@ module cv32e40x_alignment_buffer_sva
         `uvm_error("Alignment buffer SVA",
                   $sformatf("Wrong PC after branch"))
 
-  // Check that a taken branch can only occur if fetching is requested
-  property p_branch_implies_req;
-    @(posedge clk) disable iff (!rst_n) (ctrl_fsm_i.pc_set) |-> (ctrl_fsm_i.instr_req);
-  endproperty
-
-   a_branch_implies_req:
-     assert property(p_branch_implies_req)
-     else
-       `uvm_error("Alignment buffer SVA",
-                  $sformatf("Taken branch occurs while fetching is not requested"))
 
   // Check that we never exceed two outstanding transactions
   property p_max_outstanding;

--- a/sva/cv32e40x_controller_fsm_sva.sv
+++ b/sva/cv32e40x_controller_fsm_sva.sv
@@ -108,7 +108,11 @@ module cv32e40x_controller_fsm_sva
   input pipe_pc_mux_e   pipe_pc_mux_ctrl,
   input logic           ptr_in_if_i,
   input logic           etrigger_in_wb,
-  input logic           lsu_wpt_match_wb_i
+  input logic           lsu_wpt_match_wb_i,
+  input logic           debug_req_i,
+  input logic           fetch_enable_i,
+  input logic           instr_req_o,
+  input logic           instr_dbg_o
 );
 
 
@@ -198,11 +202,11 @@ module cv32e40x_controller_fsm_sva
                     (ctrl_fsm_o.kill_wb) |-> (!csr_we_i) )
     else `uvm_error("controller", "csr written while kill_wb is asserted")
 
-  // Check that no stages have valid instructions using RESET or BOOT_SET
+  // Check that no stages have valid instructions using RESET
   a_reset_if_csr :
     assert property (@(posedge clk) disable iff (!rst_n)
-            ((ctrl_fsm_cs == RESET) || (ctrl_fsm_cs == BOOT_SET)) |-> (!if_valid_i && !if_id_pipe_i.instr_valid && !id_ex_pipe_i.instr_valid && !ex_wb_pipe_i.instr_valid) )
-      else `uvm_error("controller", "Instruction valid during RESET or BOOT_SET")
+            ((ctrl_fsm_cs == RESET)) |-> (!if_valid_i && !if_id_pipe_i.instr_valid && !id_ex_pipe_i.instr_valid && !ex_wb_pipe_i.instr_valid) )
+      else `uvm_error("controller", "Instruction valid during RESET")
 
   // Check that no LSU insn can be in EX when there is a WFI or WFE in WB
   a_wfi_wfe_lsu_csr :
@@ -870,5 +874,9 @@ end
                   |->
                   (abort_op_wb_i && (ctrl_fsm_ns == DEBUG_TAKEN)))
     else `uvm_error("controller", "Debug not entered on a WPT match")
+
+
+
+
 endmodule
 


### PR DESCRIPTION
Removed BOOT_SET state from controller_fsm.
Checking for debug_req_i in RESET state to enable going directly to debug mode from RESET without fetching any instructions.

Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>