### PR TITLE
Updated priority of actions after waking from SLEEP.

### DIFF
--- a/rtl/cv32e40x_controller_fsm.sv
+++ b/rtl/cv32e40x_controller_fsm.sv
@@ -1348,8 +1348,10 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
       woke_to_debug_q <= 1'b0;
       woke_to_interrupt_q <= 1'b0;
     end else begin
-      woke_to_debug_q     <= (ctrl_fsm_cs == SLEEP) && debug_req_i;
-      woke_to_interrupt_q <= (ctrl_fsm_cs == SLEEP) && irq_wu_ctrl_i;
+      // Woke up to debug if no nmi was pending
+      woke_to_debug_q     <= (ctrl_fsm_cs == SLEEP) && debug_req_i && !(pending_nmi);
+      // Woke up to interrupts if no NMI or debug was pending
+      woke_to_interrupt_q <= (ctrl_fsm_cs == SLEEP) && irq_wu_ctrl_i && !(pending_nmi || debug_req_i);
     end
   end
 


### PR DESCRIPTION
Updated assertions (made them more strict).

When waking up from SLEEP, the core could prioritize debug over NMI if an NMI and debug request happened at the same time will in SLEEP. The same could happen for debug_req_i and interrupts. This PR fixes that issue.

Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>