### PR TITLE
Added set/clear assertions for trigger CSRs.

### DIFF
--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -36,6 +36,7 @@
   `include "cv32e40x_clic_int_controller_sva.sv"
   `include "cv32e40x_register_file_sva.sv"
   `include "cv32e40x_wpt_sva.sv"
+  `include "cv32e40x_debug_triggers_sva.sv"
 `endif
 
 `include "cv32e40x_wrapper.vh"
@@ -243,6 +244,7 @@ module cv32e40x_wrapper
                           .ctrl_fsm_cs (core_i.controller_i.controller_fsm_i.ctrl_fsm_cs),
                           .*);
 
+
   bind cv32e40x_load_store_unit:
     core_i.load_store_unit_i cv32e40x_load_store_unit_sva #(.DEPTH (DEPTH)) load_store_unit_sva (
       // The SVA's monitor modport can't connect to a master modport, so it is connected to the interface instance directly:
@@ -257,12 +259,25 @@ module cv32e40x_wrapper
       .*);
 
   generate
-    if (DBG_NUM_TRIGGERS > 0) begin : wpt_sva
+    if (DBG_NUM_TRIGGERS > 0) begin : debug_sva
       bind cv32e40x_wpt:
         core_i.load_store_unit_i.gen_wpt.wpt_i
           cv32e40x_wpt_sva wpt_sva(
             .mpu_state (core_i.load_store_unit_i.mpu_i.state_q),
             .*);
+
+      bind cv32e40x_debug_triggers:
+        core_i.cs_registers_i.debug_triggers_i
+          cv32e40x_debug_triggers_sva
+            #(.DBG_NUM_TRIGGERS(DBG_NUM_TRIGGERS))
+            debug_triggers_sva (.csr_wdata     (core_i.cs_registers_i.csr_wdata),
+                                .csr_waddr     (core_i.cs_registers_i.csr_waddr),
+                                .csr_op        (core_i.cs_registers_i.csr_op),
+                                .ex_wb_pipe_i  (core_i.ex_wb_pipe),
+                                .tselect_q     (core_i.cs_registers_i.debug_triggers_i.gen_triggers.tselect_q),
+                                .tdata1_q      (core_i.cs_registers_i.debug_triggers_i.gen_triggers.tdata1_q),
+                                .tdata2_q      (core_i.cs_registers_i.debug_triggers_i.gen_triggers.tdata2_q),
+                                .*);
     end
   endgenerate
   bind cv32e40x_prefetch_unit:

--- a/sva/cv32e40x_debug_triggers_sva.sv
+++ b/sva/cv32e40x_debug_triggers_sva.sv
@@ -1,0 +1,86 @@
+// Copyright 2023 Silicon Labs, Inc.
+//
+// This file, and derivatives thereof are licensed under the
+// Solderpad License, Version 2.0 (the "License");
+// Use of this file means you agree to the terms and conditions
+// of the license and are in full compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://solderpad.org/licenses/SHL-2.0/
+//
+// Unless required by applicable law or agreed to in writing, software
+// and hardware implementations thereof
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESSED OR IMPLIED.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+////////////////////////////////////////////////////////////////////////////////
+//                                                                            //
+// Authors:        Oystein Knauserud - oystein.knauserud@silabs.com           //
+//                                                                            //
+// Description:    debug_triggers assertions                                  //
+//                                                                            //
+////////////////////////////////////////////////////////////////////////////////
+
+module cv32e40x_debug_triggers_sva
+  import uvm_pkg::*;
+  import cv32e40x_pkg::*;
+#(
+    parameter int DBG_NUM_TRIGGERS = 1
+  )
+
+  (
+   input logic        clk,
+   input logic        rst_n,
+   input csr_opcode_e csr_op,       // from cs_registers
+   input logic [31:0] csr_wdata,    // from cs_registers
+   input csr_num_e    csr_waddr,    // from cs_registers
+   input ex_wb_pipe_t ex_wb_pipe_i,
+   input ctrl_fsm_t   ctrl_fsm_i,
+   input logic [31:0] tselect_q,
+   input logic [31:0] tdata1_q[DBG_NUM_TRIGGERS],
+   input logic [31:0] tdata2_q[DBG_NUM_TRIGGERS]
+  );
+
+
+
+  /////////////////////////////////////////////////////////////////////////////////////////
+  // Asserts to check that the CSR flops remain unchanged if a set/clear has all_zero rs1
+  /////////////////////////////////////////////////////////////////////////////////////////
+  a_set_clear_tselect_q:
+  assert property (@(posedge clk) disable iff (!rst_n)
+                  (csr_waddr == CSR_TSELECT) &&
+                  ((csr_op == CSR_OP_SET) || (csr_op == CSR_OP_CLEAR)) &&
+                  !(|csr_wdata) &&
+                  ex_wb_pipe_i.csr_en &&
+                  !ctrl_fsm_i.kill_wb
+                  |=>
+                  $stable(tselect_q))
+    else `uvm_error("debug_triggers", "tselect_q changed after set/clear with rs1==0")
+
+  a_set_clear_tdata1_q:
+  assert property (@(posedge clk) disable iff (!rst_n)
+                  (csr_waddr == CSR_TDATA1) &&
+                  ((csr_op == CSR_OP_SET) || (csr_op == CSR_OP_CLEAR)) &&
+                  !(|csr_wdata) &&
+                  ex_wb_pipe_i.csr_en &&
+                  !ctrl_fsm_i.kill_wb
+                  |=>
+                  $stable(tdata1_q)) // Checking stability of ALL tdata1, not just the one selected
+    else `uvm_error("debug_triggers", "tdata1_q changed after set/clear with rs1==0")
+
+  a_set_clear_tdata2_q:
+  assert property (@(posedge clk) disable iff (!rst_n)
+                  (csr_waddr == CSR_TDATA2) &&
+                  ((csr_op == CSR_OP_SET) || (csr_op == CSR_OP_CLEAR)) &&
+                  !(|csr_wdata) &&
+                  ex_wb_pipe_i.csr_en &&
+                  !ctrl_fsm_i.kill_wb
+                  |=>
+                  $stable(tdata2_q)) // Checking stability of ALL tdata2, not just the one selected
+    else `uvm_error("debug_triggers", "tdata2_q changed after set/clear with rs1==0")
+
+
+endmodule
+


### PR DESCRIPTION
Added assertions to instantiated trigger CSRs in debug_triggers. Checking that no bits change on set/clear with all-zero write data.

Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>