### PR TITLE
Update to Zc v1.0.1

### DIFF
--- a/rtl/cv32e40x_compressed_decoder.sv
+++ b/rtl/cv32e40x_compressed_decoder.sv
@@ -71,26 +71,6 @@ module cv32e40x_compressed_decoder import cv32e40x_pkg::*;
               end
             end
 
-            3'b001: begin
-              if (ZC_EXT) begin
-                if (instr[12]) begin
-                  // cm.lh -> lh rd', imm(rs1')
-                  instr_o.bus_resp.rdata = {7'b0, instr[11:10], instr[6:5], 1'b0, 2'b01, instr[9:7], 3'b001, 2'b01, instr[4:2], OPCODE_LOAD};
-
-                  // uimm < 4 is designated for custom use, flagging as illegal
-                  if ({instr[11:10], instr[6]} == 3'b000) begin
-                    illegal_instr_o = 1'b1;
-                  end
-                end else begin
-                  // cm.lb -> lb rd', imm(rs1')
-                  instr_o.bus_resp.rdata = {8'b0, instr[10], instr[6:5], instr[11], 2'b01, instr[9:7], 3'b000, 2'b01, instr[4:2], OPCODE_LOAD};
-                end
-              end else begin
-                illegal_instr_o = 1'b1;
-                instr_o.bus_resp.rdata = {5'b0, instr[5], instr[12:10], instr[6], 2'b00, 2'b01, instr[9:7], 3'b010, 2'b01, instr[4:2], OPCODE_LOAD};
-              end
-            end
-
             3'b010: begin
               // c.lw -> lw rd', imm(rs1')
               instr_o.bus_resp.rdata = {5'b0, instr[5], instr[12:10], instr[6], 2'b00, 2'b01, instr[9:7], 3'b010, 2'b01, instr[4:2], OPCODE_LOAD};
@@ -138,34 +118,9 @@ module cv32e40x_compressed_decoder import cv32e40x_pkg::*;
               end
             end
 
-            3'b101: begin
-              if (ZC_EXT) begin
-                if (instr[12]) begin
-                  // cm.sh -> sh rs2', imm(rs1')
-                  instr_o.bus_resp.rdata = {7'b0, 2'b01, instr[4:2], 2'b01, instr[9:7], 3'b001, instr[11:10], instr[6:5], 1'b0, OPCODE_STORE};
-
-                  // uimm < 4 is designated for custom use, flagging as illegal
-                  if ({instr[11:10], instr[6]} == 3'b000) begin
-                    illegal_instr_o = 1'b1;
-                  end
-                end else begin
-                  // cm.sb -> sb rs2', imm(rs1')
-                  instr_o.bus_resp.rdata = {7'b0, 2'b01, instr[4:2], 2'b01, instr[9:7], 3'b000, 1'b0, instr[10], instr[6:5], instr[11], OPCODE_STORE};
-
-                  // uimm < 4 is designated for custom use, flagging as illegal
-                  if ({instr[10], instr[6]} == 2'b00) begin
-                    illegal_instr_o = 1'b1;
-                  end
-                end
-              end else begin
-                illegal_instr_o = 1'b1;
-                // todo: likely change to commented line, but that is not SEC clean due to load stalls differences.
-                //instr_o.bus_resp.rdata = {7'b0, 2'b01, instr[4:2], 2'b01, instr[9:7], 3'b001, instr[11:10], instr[6:5], 1'b0, OPCODE_STORE};
-                instr_o.bus_resp.rdata = {5'b0, instr[5], instr[12:10], instr[6], 2'b00, 2'b01, instr[9:7], 3'b010, 2'b01, instr[4:2], OPCODE_LOAD};
-              end
-            end
-
+            3'b001,
             3'b011,       // c.flw -> flw rd', imm(rs1')
+            3'b101,
             3'b111: begin // c.fsw -> fsw rs2', imm(rs1')
               illegal_instr_o = 1'b1;
               instr_o.bus_resp.rdata = {5'b0, instr[5], instr[12:10], instr[6], 2'b00, 2'b01, instr[9:7], 3'b010, 2'b01, instr[4:2], OPCODE_LOAD};
@@ -368,28 +323,7 @@ module cv32e40x_compressed_decoder import cv32e40x_pkg::*;
               end
             end
 
-            3'b001: begin
-              if (ZC_EXT) begin
-                if (instr[12]) begin
-                  // cm.lhu rd', uimm(rs1') -> lhu rd', uimm(rs1')
-                  instr_o.bus_resp.rdata = {7'b0000000, instr[11:10], instr[6:5], 1'b0, 2'b01, instr[9:7], 3'b101, 2'b01, instr[4:2], OPCODE_LOAD};
 
-                  if ({instr[11:10], instr[6]} == 3'b000) begin
-                    illegal_instr_o = 1'b1;
-                  end
-                end else begin
-                  // cm.lbu rd', uimm(rs1') -> lbu rd', uimm(rs1')
-                  instr_o.bus_resp.rdata = {8'h00, instr[10], instr[6:5], instr[11], 2'b01, instr[9:7], 3'b100, 2'b01, instr[4:2], OPCODE_LOAD};
-
-                  if ({instr[10], instr[6]} == 2'b00) begin
-                    illegal_instr_o = 1'b1;
-                  end
-                end
-              end else begin
-                instr_o.bus_resp.rdata = {4'b0, instr[3:2], instr[12], instr[6:4], 2'b00, 5'h02, 3'b010, instr[11:7], OPCODE_LOAD};
-                illegal_instr_o = 1'b1;
-              end
-            end
             3'b010: begin
               // c.lwsp -> lw rd, imm(x2)
               instr_o.bus_resp.rdata = {4'b0, instr[3:2], instr[12], instr[6:4], 2'b00, 5'h02, 3'b010, instr[11:7], OPCODE_LOAD};
@@ -444,6 +378,7 @@ module cv32e40x_compressed_decoder import cv32e40x_pkg::*;
               instr_o.bus_resp.rdata = {4'b0, instr[8:7], instr[12], instr[6:2], 5'h02, 3'b010, instr[11:9], 2'b00, OPCODE_STORE};
             end
 
+            3'b001,
             3'b011,
             3'b101,
             3'b111: begin  // c.fswsp -> fsw rs2, imm(x2)

--- a/rtl/cv32e40x_core.sv
+++ b/rtl/cv32e40x_core.sv
@@ -217,6 +217,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
 
   // JVT
   logic [JVT_ADDR_WIDTH-1:0]  jvt_addr;
+  logic [5:0]                 jvt_mode;
 
   logic [MTVT_ADDR_WIDTH-1:0] mtvt_addr;
 
@@ -451,6 +452,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .mepc_i              ( mepc                     ), // Exception PC (restore upon return from exception/interrupt)
     .mtvec_addr_i        ( mtvec_addr               ), // Exception/interrupt address (MSBs only)
     .mtvt_addr_i         ( mtvt_addr                ), // CLIC vector base
+    .jvt_mode_i          ( jvt_mode                 ),
 
     .m_c_obi_instr_if    ( m_c_obi_instr_if         ), // Instruction bus interface
 
@@ -772,6 +774,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .dcsr_o                     ( dcsr                   ),
     .dpc_o                      ( dpc                    ),
     .jvt_addr_o                 ( jvt_addr               ),
+    .jvt_mode_o                 ( jvt_mode               ),
     .mcause_o                   ( mcause                 ),
     .mcycle_o                   ( mcycle_o               ),
     .mepc_o                     ( mepc                   ),

--- a/rtl/cv32e40x_cs_registers.sv
+++ b/rtl/cv32e40x_cs_registers.sv
@@ -58,6 +58,7 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
   output dcsr_t                         dcsr_o,
   output logic [31:0]                   dpc_o,
   output logic [JVT_ADDR_WIDTH-1:0]     jvt_addr_o,
+  output logic [5:0]                    jvt_mode_o,
   output mcause_t                       mcause_o,
   output logic [63:0]                   mcycle_o,
   output logic [31:0]                   mepc_o,
@@ -1547,6 +1548,7 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
   assign dcsr_o        = dcsr_rdata;
   assign dpc_o         = dpc_rdata;
   assign jvt_addr_o    = jvt_rdata.base[31:32-JVT_ADDR_WIDTH];
+  assign jvt_mode_o    = jvt_rdata.mode;
   assign mcause_o      = mcause_rdata;
   assign mcycle_o      = mhpmcounter_rdata[0];
   assign mepc_o        = mepc_rdata;

--- a/rtl/cv32e40x_if_stage.sv
+++ b/rtl/cv32e40x_if_stage.sv
@@ -54,6 +54,7 @@ module cv32e40x_if_stage import cv32e40x_pkg::*;
   input  logic [31:0]   jump_target_id_i,       // Jump target address
   input  logic [31:0]   mepc_i,                 // Exception PC (restore upon return from exception/interrupt)
   input  logic [24:0]   mtvec_addr_i,           // Exception/interrupt address (MSBs)
+  input  logic [5:0]    jvt_mode_i,
 
   input  logic [MTVT_ADDR_WIDTH-1:0]   mtvt_addr_i,            // Base address for CLIC vectoring
 
@@ -446,6 +447,8 @@ module cv32e40x_if_stage import cv32e40x_pkg::*;
       (
         .clk                  ( clk                     ),
         .rst_n                ( rst_n                   ),
+
+        .jvt_mode_i           ( jvt_mode_i              ),
 
         .instr_i              ( prefetch_instr          ),
         .instr_is_clic_ptr_i  ( prefetch_is_clic_ptr    ),

--- a/rtl/cv32e40x_sequencer.sv
+++ b/rtl/cv32e40x_sequencer.sv
@@ -39,6 +39,7 @@ module cv32e40x_sequencer import cv32e40x_pkg::*;
     input  logic       clk,
     input  logic       rst_n,
 
+    input  logic [5:0] jvt_mode_i,
     input  inst_resp_t instr_i,               // Instruction from prefetch unit
     input  logic       instr_is_clic_ptr_i,   // CLIC pointer flag, instr_i does not contain an instruction
     input  logic       instr_is_mret_ptr_i,   // mret pointer flag, instr_i does not contain an instruction
@@ -149,8 +150,10 @@ module cv32e40x_sequencer import cv32e40x_pkg::*;
         if (instr[15:13] == 3'b101) begin
           unique case (instr[12:10])
             3'b000: begin
-              seq_tbljmp_o = 1'b1;
-              seq_instr = TBLJMP;
+              if (!(|jvt_mode_i)) begin
+                seq_tbljmp_o = 1'b1;
+                seq_instr = TBLJMP;
+              end
             end
 
             3'b011: begin
@@ -301,7 +304,7 @@ module cv32e40x_sequencer import cv32e40x_pkg::*;
           instr_o.bus_resp.rdata = {12'h000, 5'd10, 3'b000, sn_to_regnum(5'(instr[9:7])), OPCODE_OPIMM};
           seq_state_n = S_DMOVE;
         end else if (seq_tbljmp_o) begin
-          if (instr[9:8] == 2'b00) begin
+          if (instr[9:7] == 3'b000) begin
             // cm.jt -> JAL x0, index
             instr_o.bus_resp.rdata = {15'b000000000000000, instr[6:2], 5'b00000, OPCODE_JAL};
           end else begin

--- a/rtl/cv32e40x_sequencer.sv
+++ b/rtl/cv32e40x_sequencer.sv
@@ -303,10 +303,10 @@ module cv32e40x_sequencer import cv32e40x_pkg::*;
         end else if (seq_tbljmp_o) begin
           if (instr[9:8] == 2'b00) begin
             // cm.jt -> JAL x0, index
-            instr_o.bus_resp.rdata = {13'b0000000000000, instr[7:2], 5'b00000, OPCODE_JAL};
+            instr_o.bus_resp.rdata = {15'b000000000000000, instr[6:2], 5'b00000, OPCODE_JAL};
           end else begin
             // cm.jalt -> JAL, x1, index
-            instr_o.bus_resp.rdata = {11'b00000000000, instr[9:2], 5'b00001, OPCODE_JAL};
+            instr_o.bus_resp.rdata = {12'b000000000000, instr[9:2], 5'b00001, OPCODE_JAL};
           end
           // The second half of tablejumps (pointer) will not use the FSM (the jump will kill the sequencer anyway).
           // Signalling ready here will acknowledge the prefetcher.


### PR DESCRIPTION
Removed Zcmb
Adjusted split between cm.jt (32 indices) and cm.jalt (224 indices)
Added check for jvt.mode when decoding cm.jt and cm.jalt. (This change is SEC clean)