### PR TITLE
Bugfix for wpt/mpu backpressure from WB

### DIFF
--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -188,6 +188,7 @@ module cv32e40x_wrapper
   bind cv32e40x_wb_stage:
     core_i.wb_stage_i cv32e40x_wb_stage_sva wb_stage_sva
     (
+      .lsu_filter_resp_valid_i (core_i.load_store_unit_i.filter_resp_valid),
       .*
     );
 

--- a/rtl/cv32e40x_load_store_unit.sv
+++ b/rtl/cv32e40x_load_store_unit.sv
@@ -690,7 +690,7 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
       assign wpt_resp_ready = ready_0_i;
 
       assign resp_valid = wpt_resp_valid;
-      assign resp_ready = ready_0_i;
+      assign resp_ready = wpt_resp_ready;
       assign resp_rdata = wpt_resp_rdata;
       assign resp       = wpt_resp;
 

--- a/rtl/cv32e40x_load_store_unit.sv
+++ b/rtl/cv32e40x_load_store_unit.sv
@@ -107,6 +107,7 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
 
   // Transaction response
   logic           resp_valid;
+  logic           resp_ready;  // Used to not decrement outstanding counter for WPT/MPU responses if WB is not ready
   logic [31:0]    resp_rdata;
   data_resp_t     resp;
 
@@ -554,7 +555,7 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
   //////////////////////////////////////////////////////////////////////////////
 
   assign count_up = trans_valid && trans_ready;         // Increment upon accepted transfer request
-  assign count_down = resp_valid;                       // Decrement upon accepted transfer response
+  assign count_down = resp_valid && resp_ready;         // Decrement upon accepted transfer response
 
   always_comb begin
     case ({count_up, count_down})
@@ -661,6 +662,7 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
         .mpu_trans_o         ( mpu_trans         ),
 
         .mpu_resp_valid_i    ( mpu_resp_valid    ),
+        .mpu_resp_ready_o    ( mpu_resp_ready    ),
         .mpu_resp_i          ( mpu_resp          ),
 
         // Interface towards core
@@ -688,6 +690,7 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
       assign wpt_resp_ready = ready_0_i;
 
       assign resp_valid = wpt_resp_valid;
+      assign resp_ready = ready_0_i;
       assign resp_rdata = wpt_resp_rdata;
       assign resp       = wpt_resp;
 
@@ -699,12 +702,15 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
       assign mpu_trans         = wpt_trans;
       assign wpt_trans_ready   = mpu_trans_ready;
       assign wpt_resp_valid    = mpu_resp_valid;
+      assign mpu_resp_ready    = wpt_resp_ready;
+      assign wpt_resp_ready    = ready_0_i;
       assign wpt_resp          = mpu_resp;
       assign xif_wpt_match     = 1'b0;
 
       assign wpt_resp_rdata = wpt_resp.bus_resp.rdata;
 
       assign resp_valid = wpt_resp_valid;
+      assign resp_ready = wpt_resp_ready;
       assign resp_rdata = wpt_resp_rdata;
       assign resp       = wpt_resp;
     end

--- a/rtl/cv32e40x_wpt.sv
+++ b/rtl/cv32e40x_wpt.sv
@@ -42,6 +42,7 @@ module cv32e40x_wpt import cv32e40x_pkg::*;
    output obi_data_req_t  mpu_trans_o,
 
    input  logic           mpu_resp_valid_i,
+   output logic           mpu_resp_ready_o,
    input  data_resp_t     mpu_resp_i,
 
    // Interface towards core
@@ -160,6 +161,9 @@ module cv32e40x_wpt import cv32e40x_pkg::*;
 
   // Signal ready towards core
   assign core_trans_ready_o     = (mpu_trans_ready_i && !wpt_block_core) || wpt_trans_ready;
+
+  // Send resp_ready through wpt
+  assign mpu_resp_ready_o = core_resp_ready_i;
 
 
 

--- a/sva/cv32e40x_controller_fsm_sva.sv
+++ b/sva/cv32e40x_controller_fsm_sva.sv
@@ -873,10 +873,13 @@ end
     else `uvm_error("controller", "LSU in WB halted without watchpoint trigger match")
 
 
-  // Check that debug is always taken when a watchpoint trigger is arrives in WB
+  // Check that debug is always taken when a watchpoint trigger is arrives in WB during FUNCTIONAL state
+  // Since WB is halted when ctrl_fsm_ns == DEBUG_TAKEN, the watchpoint is also valid during DEBUG_TAKEN, thus
+  // only checking while in FUNCTIONAL.
   a_wpt_debug_entry:
   assert property (@(posedge clk) disable iff (!rst_n)
-                  (ex_wb_pipe_i.instr_valid && lsu_wpt_match_wb_i)
+                  (ex_wb_pipe_i.instr_valid && lsu_wpt_match_wb_i) &&
+                  (ctrl_fsm_cs == FUNCTIONAL)
                   |->
                   (abort_op_wb_i && (ctrl_fsm_ns == DEBUG_TAKEN)))
     else `uvm_error("controller", "Debug not entered on a WPT match")

--- a/sva/cv32e40x_load_store_unit_sva.sv
+++ b/sva/cv32e40x_load_store_unit_sva.sv
@@ -129,20 +129,11 @@ module cv32e40x_load_store_unit_sva
     else `uvm_error("load_store_unit", "Second half of split transaction was killed")
 
   // cnt_q == 2'b00 shall be the same as !(ex_wb_pipe.lsu_en && ex_wb_pipe_i.instr_valid)
-  // With a watchpoint match, the LSU counter may clear while WB is halted for synchronous debug entry, leaving cnt=0 while lsu_en in WB is true.
   a_cnt_zero:
   assert property (@(posedge clk) disable iff (!rst_n)
-                    (cnt_q == 2'b00) && !(ctrl_fsm_cs == DEBUG_TAKEN) |-> !(ex_wb_pipe_i.lsu_en && ex_wb_pipe_i.instr_valid))
+                    (cnt_q == 2'b00) |-> !(ex_wb_pipe_i.lsu_en && ex_wb_pipe_i.instr_valid))
       else `uvm_error("load_store_unit", "cnt_q is zero when WB contains a valid LSU instruction")
 
-  // The only cause of (cnt_q==0) with a valid LSU instruction in WB is a watchpoint trigger.
-  // Assertions checks that this is the case and that a debug entry is taking place.
-  a_lsu_cnt_nonzero_wpt:
-  assert property (@(posedge clk) disable iff (!rst_n)
-                  (cnt_q == 2'b00) && (ex_wb_pipe_i.lsu_en && ex_wb_pipe_i.instr_valid)
-                  |->
-                  $past(lsu_wpt_match_1_o) && (ctrl_fsm_cs == DEBUG_TAKEN))
-      else `uvm_error("load_store_unit", "Illegal cause of cnt_q=0 while a valid LSU instruction is in WB")
 
   // Check that no XIF request or result are produced if X_EXT is disabled
   a_lsu_no_xif_req_if_xext_disabled:


### PR DESCRIPTION
Bugfix for wpt/mpu backpressure from WB:
    
- resp_valid could be high for several cycles if WB was halted (debug entry or XIF). This would cause the LSU outstanding counter to underflow.
- Fixed by introducing 'resp_ready' in the LSU, which is connected to wb_ready via ready_0_i. This causes the outstanding counter to only decrement when there is a valid response _and_ WB is ready. 
- Added assertion to check that WB must be ready when a LSU response arrives from the bus.
