### PR TITLE
DEBUG parameter

### DIFF
--- a/bhv/cv32e40x_rvfi.sv
+++ b/bhv/cv32e40x_rvfi.sv
@@ -22,7 +22,8 @@ module cv32e40x_rvfi
   import cv32e40x_pkg::*;
   import cv32e40x_rvfi_pkg::*;
   #(
-    parameter bit SMCLIC = 0
+    parameter bit SMCLIC = 0,
+    parameter int DEBUG  = 1
   )
   (
    input logic                                clk_i,

--- a/rtl/cv32e40x_controller.sv
+++ b/rtl/cv32e40x_controller.sv
@@ -35,7 +35,8 @@ module cv32e40x_controller import cv32e40x_pkg::*;
   parameter bit          A_EXT                  = 0,
   parameter int unsigned REGFILE_NUM_READ_PORTS = 2,
   parameter bit          SMCLIC                 = 0,
-  parameter int          SMCLIC_ID_WIDTH        = 5
+  parameter int          SMCLIC_ID_WIDTH        = 5,
+  parameter int          DEBUG                  = 1
 )
 (
   input  logic        clk,                        // Gated clock
@@ -147,7 +148,8 @@ module cv32e40x_controller import cv32e40x_pkg::*;
   #(
     .X_EXT                       ( X_EXT                    ),
     .SMCLIC                      ( SMCLIC                   ),
-    .SMCLIC_ID_WIDTH             ( SMCLIC_ID_WIDTH          )
+    .SMCLIC_ID_WIDTH             ( SMCLIC_ID_WIDTH          ),
+    .DEBUG                       ( DEBUG                    )
   )
   controller_fsm_i
   (

--- a/rtl/cv32e40x_controller_fsm.sv
+++ b/rtl/cv32e40x_controller_fsm.sv
@@ -32,6 +32,7 @@
 module cv32e40x_controller_fsm import cv32e40x_pkg::*;
 #(
   parameter bit       X_EXT           = 0,
+  parameter int       DEBUG           = 1,
   parameter bit       SMCLIC          = 0,
   parameter int       SMCLIC_ID_WIDTH = 5
 )

--- a/rtl/cv32e40x_if_stage.sv
+++ b/rtl/cv32e40x_if_stage.sv
@@ -40,6 +40,7 @@ module cv32e40x_if_stage import cv32e40x_pkg::*;
   parameter int          SMCLIC_ID_WIDTH = 5,
   parameter bit          ZC_EXT          = 0,
   parameter m_ext_e      M_EXT           = M_NONE,
+  parameter int          DEBUG           = 1,
   parameter logic [31:0] DM_REGION_START = 32'hF0000000,
   parameter logic [31:0] DM_REGION_END   = 32'hF0003FFF
 )
@@ -236,6 +237,7 @@ module cv32e40x_if_stage import cv32e40x_pkg::*;
     .BUS_RESP_TYPE        ( obi_inst_resp_t             ),
     .PMA_NUM_REGIONS      ( PMA_NUM_REGIONS             ),
     .PMA_CFG              ( PMA_CFG                     ),
+    .DEBUG                ( DEBUG                       ),
     .DM_REGION_START      ( DM_REGION_START             ),
     .DM_REGION_END        ( DM_REGION_END               )
   )

--- a/rtl/cv32e40x_load_store_unit.sv
+++ b/rtl/cv32e40x_load_store_unit.sv
@@ -33,6 +33,7 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
   parameter int          PMA_NUM_REGIONS = 0,
   parameter pma_cfg_t    PMA_CFG[PMA_NUM_REGIONS-1:0] = '{default:PMA_R_DEFAULT},
   parameter int          DBG_NUM_TRIGGERS = 1,
+  parameter int          DEBUG           = 1,
   parameter logic [31:0] DM_REGION_START = 32'hF0000000,
   parameter logic [31:0] DM_REGION_END   = 32'hF0003FFF
 )
@@ -767,6 +768,7 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
     .CORE_REQ_TYPE      ( obi_data_req_t       ),
     .PMA_NUM_REGIONS    ( PMA_NUM_REGIONS      ),
     .PMA_CFG            ( PMA_CFG              ),
+    .DEBUG              ( DEBUG                ),
     .DM_REGION_START    ( DM_REGION_START      ),
     .DM_REGION_END      ( DM_REGION_END        )
   )

--- a/rtl/cv32e40x_mpu.sv
+++ b/rtl/cv32e40x_mpu.sv
@@ -31,6 +31,7 @@ module cv32e40x_mpu import cv32e40x_pkg::*;
       parameter type         BUS_RESP_TYPE                = obi_inst_resp_t,
       parameter int          PMA_NUM_REGIONS              = 0,
       parameter pma_cfg_t    PMA_CFG[PMA_NUM_REGIONS-1:0] = '{default:PMA_R_DEFAULT},
+      parameter int          DEBUG                        = 1,
       parameter logic [31:0] DM_REGION_START              = 32'hF0000000,
       parameter logic [31:0] DM_REGION_END                = 32'hF0003FFF)
   (

--- a/rtl/cv32e40x_wb_stage.sv
+++ b/rtl/cv32e40x_wb_stage.sv
@@ -35,6 +35,9 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 module cv32e40x_wb_stage import cv32e40x_pkg::*;
+#(
+    parameter int DEBUG = 1
+)
 (
   input  logic          clk,            // Not used in RTL; only used by assertions
   input  logic          rst_n,          // Not used in RTL; only used by assertions

--- a/sva/cv32e40x_rvfi_sva.sv
+++ b/sva/cv32e40x_rvfi_sva.sv
@@ -28,7 +28,8 @@ module cv32e40x_rvfi_sva
   import cv32e40x_pkg::*;
   import cv32e40x_rvfi_pkg::*;
 #(
-    parameter bit SMCLIC = 0
+    parameter bit SMCLIC = 0,
+    parameter int DEBUG  = 1
 )
 (
    input logic             clk_i,
@@ -97,6 +98,42 @@ module cv32e40x_rvfi_sva
       $sformatf("Every irq_ack should be followed by the corresponding rvfi_intr"));
 
 
+  // Sequence used to locate rvfi_valid following rvfi_valid with prereq set
+  sequence s_goto_next_rvfi_valid(prereq);
+    (prereq && rvfi_valid) ##1 rvfi_valid[->1];
+  endsequence
+
+  logic no_debug;
+
+  // Indicate debug mode, or single stepping
+  assign no_debug = !(rvfi_csr_dcsr_rdata[2] || ctrl_fsm_i.debug_mode);
+
+  // rvfi_trap should always be followed by rvfi_intr (as long as we're not in debug mode)
+  a_rvfi_trap_intr :
+    assert property (@(posedge clk_i) disable iff (!rst_ni)
+                     no_debug throughout s_goto_next_rvfi_valid(|rvfi_trap) |->
+                     rvfi_intr.intr)
+      else `uvm_error("rvfi", "rvfi_trap not followed by rvfi_intr")
+
+  // Exception code in rvfi_trap.exception_cause should align with mcause exception cause in the following retired instruction
+  // This is exempt if we have an NMI, because NMI will result in mcause being updated in between retired instructions.
+  // Also, in debug mode, mcause is not updated.
+  a_rvfi_trap_mcause_align:
+    assert property (@(posedge clk_i) disable iff (!rst_ni)
+                    (no_debug && !ctrl_fsm_i.pending_nmi) throughout s_goto_next_rvfi_valid(|rvfi_trap) |->
+                     rvfi_intr.intr && (rvfi_csr_mcause_rdata[5:0] == $past(rvfi_trap.exception_cause)))
+      else `uvm_error("rvfi", "rvfi_trap.exception_cause not consistent with mcause[5:0] in following retired instruction")
+
+
+  // Check that the trap is always signalled on the instruction before single step debug entry (unless killed by interrupt)
+  a_rvfi_single_step_no_trap_no_dbg_entry:
+    assert property (@(posedge clk_i) disable iff (!rst_ni)
+                     s_goto_next_rvfi_valid(rvfi_trap.debug_cause != DBG_CAUSE_STEP) |-> ((rvfi_dbg != DBG_CAUSE_STEP) || rvfi_intr.intr))
+     else `uvm_error("rvfi", "Single step debug entry without correct rvfi_trap first")
+
+
+
+if (DEBUG) begin
   // Helper signal, indicating debug cause
   // Special case for debug entry from debug mode caused by EBREAK as it is not captured by debug_cause_i
   logic [2:0] debug_cause_int;
@@ -136,79 +173,46 @@ module cv32e40x_rvfi_sva
                      (rvfi_dbg_ack |-> (dbg_ack_cnt != 0)))
       else `uvm_error("rvfi", "rvfi_dbg not preceeded by dbg_ack")
 
-
-  // Sequence used to locate rvfi_valid following rvfi_valid with prereq set
-  sequence s_goto_next_rvfi_valid(prereq);
-    (prereq && rvfi_valid) ##1 rvfi_valid[->1];
-  endsequence
-
-  logic no_debug;
-
-  // Indicate debug mode, or single stepping
-  assign no_debug = !(rvfi_csr_dcsr_rdata[2] || ctrl_fsm_i.debug_mode);
-
-  // rvfi_trap should always be followed by rvfi_intr (as long as we're not in debug mode)
-  a_rvfi_trap_intr :
-    assert property (@(posedge clk_i) disable iff (!rst_ni)
-                     no_debug throughout s_goto_next_rvfi_valid(|rvfi_trap) |->
-                     rvfi_intr.intr)
-      else `uvm_error("rvfi", "rvfi_trap not followed by rvfi_intr")
-
   // rvfi_trap[2] should always be followed by rvfi_dbg
   a_rvfi_trap_dbg :
-    assert property (@(posedge clk_i) disable iff (!rst_ni)
-                     s_goto_next_rvfi_valid(rvfi_trap.debug) |->
-                     rvfi_dbg != '0)
-      else `uvm_error("rvfi", "rvfi_trap.debug not followed by rvfi_dbg")
-
-  // Exception code in rvfi_trap.exception_cause should align with mcause exception cause in the following retired instruction
-  // This is exempt if we have an NMI, because NMI will result in mcause being updated in between retired instructions.
-  // Also, in debug mode, mcause is not updated.
-  a_rvfi_trap_mcause_align:
-    assert property (@(posedge clk_i) disable iff (!rst_ni)
-                    (no_debug && !ctrl_fsm_i.pending_nmi) throughout s_goto_next_rvfi_valid(|rvfi_trap) |->
-                     rvfi_intr.intr && (rvfi_csr_mcause_rdata[5:0] == $past(rvfi_trap.exception_cause)))
-      else `uvm_error("rvfi", "rvfi_trap.exception_cause not consistent with mcause[5:0] in following retired instruction")
+  assert property (@(posedge clk_i) disable iff (!rst_ni)
+                    s_goto_next_rvfi_valid(rvfi_trap.debug) |->
+                    rvfi_dbg != '0)
+    else `uvm_error("rvfi", "rvfi_trap.debug not followed by rvfi_dbg")
 
   // Exception code in rvfi_trap[11:9] should align with rvfi_dbg the following retired instruction
   a_rvfi_trap_rvfi_dbg_align:
-    assert property (@(posedge clk_i) disable iff (!rst_ni)
-                     s_goto_next_rvfi_valid(rvfi_trap.debug) |->
-                     rvfi_dbg == $past(rvfi_trap.debug_cause))
-     else `uvm_error("rvfi", "rvfi_trap.debug_cause not consistent with rvfi_dbg in following retired instruction")
+  assert property (@(posedge clk_i) disable iff (!rst_ni)
+                    s_goto_next_rvfi_valid(rvfi_trap.debug) |->
+                    rvfi_dbg == $past(rvfi_trap.debug_cause))
+    else `uvm_error("rvfi", "rvfi_trap.debug_cause not consistent with rvfi_dbg in following retired instruction")
 
   // Check that rvfi_trap always indicate single step if rvfi_trap[2:1] == 2'b11
   a_rvfi_single_step_trap:
-    assert property (@(posedge clk_i) disable iff (!rst_ni)
-                     rvfi_trap.exception && rvfi_trap.debug |-> rvfi_trap.debug_cause == DBG_CAUSE_STEP)
-     else `uvm_error("rvfi", "rvfi_trap[2:1] == 2'b11, but debug cause bits do not indicate single stepping")
-
-  // Check that the trap is always signalled on the instruction before single step debug entry (unless killed by interrupt)
-  a_rvfi_single_step_no_trap_no_dbg_entry:
-    assert property (@(posedge clk_i) disable iff (!rst_ni)
-                     s_goto_next_rvfi_valid(rvfi_trap.debug_cause != DBG_CAUSE_STEP) |-> ((rvfi_dbg != DBG_CAUSE_STEP) || rvfi_intr.intr))
-     else `uvm_error("rvfi", "Single step debug entry without correct rvfi_trap first")
+  assert property (@(posedge clk_i) disable iff (!rst_ni)
+                    rvfi_trap.exception && rvfi_trap.debug |-> rvfi_trap.debug_cause == DBG_CAUSE_STEP)
+    else `uvm_error("rvfi", "rvfi_trap[2:1] == 2'b11, but debug cause bits do not indicate single stepping")
 
   // Check that dcsr.cause and mcause exception align with rvfi_trap when rvfi_trap[2:1] == 2'b11
   // rvfi_intr should also always be set in this case
   a_rvfi_trap_step_exception:
-    assert property (@(posedge clk_i) disable iff (!rst_ni)
-                     s_goto_next_rvfi_valid(rvfi_trap.exception && rvfi_trap.debug) |->
-                     (rvfi_dbg == DBG_CAUSE_STEP) && (rvfi_csr_dcsr_rdata[8:6] == DBG_CAUSE_STEP) &&
-                     (rvfi_csr_mcause_rdata[5:0] == $past(rvfi_trap.exception_cause)) &&
-                     rvfi_intr.intr)
-     else `uvm_error("rvfi", "dcsr.cause, mcause and rvfi_intr not as expected following an exception during single step")
+  assert property (@(posedge clk_i) disable iff (!rst_ni)
+                    s_goto_next_rvfi_valid(rvfi_trap.exception && rvfi_trap.debug) |->
+                    (rvfi_dbg == DBG_CAUSE_STEP) && (rvfi_csr_dcsr_rdata[8:6] == DBG_CAUSE_STEP) &&
+                    (rvfi_csr_mcause_rdata[5:0] == $past(rvfi_trap.exception_cause)) &&
+                    rvfi_intr.intr)
+    else `uvm_error("rvfi", "dcsr.cause, mcause and rvfi_intr not as expected following an exception during single step")
 
   // When dcsr.nmip is set, the next retired instruction should be the NMI handler (except in debug mode).
   // rvfi_intr should also be set.
   a_rvfi_nmip_nmi_handler:
-    assert property (@(posedge clk_i) disable iff (!rst_ni)
-                     (no_debug && $stable(mtvec_addr_i)) throughout s_goto_next_rvfi_valid(rvfi_csr_dcsr_rdata[3]) |->
-                     rvfi_intr.intr &&
-                     (rvfi_pc_rdata == {mtvec_addr_i, ctrl_fsm_i.nmi_mtvec_index, 2'b00}) &&
-                     ((rvfi_csr_mcause_rdata[10:0] == INT_CAUSE_LSU_LOAD_FAULT) || (rvfi_csr_mcause_rdata[10:0] == INT_CAUSE_LSU_STORE_FAULT)))
-      else `uvm_error("rvfi", "dcsr.nmip not followed by rvfi_intr and NMI handler")
-
+  assert property (@(posedge clk_i) disable iff (!rst_ni)
+                    (no_debug && $stable(mtvec_addr_i)) throughout s_goto_next_rvfi_valid(rvfi_csr_dcsr_rdata[3]) |->
+                    rvfi_intr.intr &&
+                    (rvfi_pc_rdata == {mtvec_addr_i, ctrl_fsm_i.nmi_mtvec_index, 2'b00}) &&
+                    ((rvfi_csr_mcause_rdata[10:0] == INT_CAUSE_LSU_LOAD_FAULT) || (rvfi_csr_mcause_rdata[10:0] == INT_CAUSE_LSU_STORE_FAULT)))
+    else `uvm_error("rvfi", "dcsr.nmip not followed by rvfi_intr and NMI handler")
+end
 
   /* TODO: Add back in.
      Currently, the alignment buffer can interpret pointers as compressed instructions and pass on two "instructions" from the IF stage.


### PR DESCRIPTION
Introduced 'DEBUG' parameter. When not enabled, no debug CSRs will be implemented and the external debug_req_i will be ignored.

Restructured lots of sva-file to accomodate the new parameter.

Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>