### PR TITLE
RVFI updates for A_EXT

### DIFF
--- a/bhv/cv32e40x_rvfi.sv
+++ b/bhv/cv32e40x_rvfi.sv
@@ -22,9 +22,9 @@ module cv32e40x_rvfi
   import cv32e40x_pkg::*;
   import cv32e40x_rvfi_pkg::*;
   #(
-    parameter bit SMCLIC = 0,
-    parameter int DEBUG  = 1,
-    parameter bit A_EXT  = 0
+    parameter bit     SMCLIC = 0,
+    parameter int     DEBUG  = 1,
+    parameter a_ext_e A_EXT  = A_NONE
   )
   (
    input logic                                clk_i,
@@ -81,6 +81,7 @@ module cv32e40x_rvfi
    input logic                                lsu_pmp_err_ex_i,
    input logic                                lsu_pma_err_ex_i,
    input logic                                lsu_pma_atomic_ex_i,
+   input logic                                lsu_misaligned_ex_i,
    input obi_data_req_t                       buffer_trans,
    input logic                                lsu_split_q_ex_i,
 
@@ -709,7 +710,9 @@ module cv32e40x_rvfi
 
   assign        mret_ptr_wb = mret_ptr_wb_i;
 
-  assign lsu_pma_err_atomic_ex = lsu_pma_err_ex_i && lsu_pma_atomic_ex_i;
+  // PMA error due to atomic not within an atomic region
+  // Error due to misaligned atomics shall get cause_type==0 and is excluded here.
+  assign lsu_pma_err_atomic_ex = lsu_pma_err_ex_i && lsu_pma_atomic_ex_i && !lsu_misaligned_ex_i;
 
   assign insn_opcode = rvfi_insn[6:0];
   assign insn_rd     = rvfi_insn[11:7];

--- a/bhv/cv32e40x_rvfi.sv
+++ b/bhv/cv32e40x_rvfi.sv
@@ -23,7 +23,8 @@ module cv32e40x_rvfi
   import cv32e40x_rvfi_pkg::*;
   #(
     parameter bit SMCLIC = 0,
-    parameter int DEBUG  = 1
+    parameter int DEBUG  = 1,
+    parameter bit A_EXT  = 0
   )
   (
    input logic                                clk_i,
@@ -78,7 +79,8 @@ module cv32e40x_rvfi
    input logic                                dret_in_ex_i,
    input logic                                lsu_en_ex_i,
    input logic                                lsu_pmp_err_ex_i,
-   input logic                                lsu_pma_err_atomic_ex_i,
+   input logic                                lsu_pma_err_ex_i,
+   input logic                                lsu_pma_atomic_ex_i,
    input obi_data_req_t                       buffer_trans,
    input logic                                lsu_split_q_ex_i,
 
@@ -702,7 +704,12 @@ module cv32e40x_rvfi
   // Detect mret initiated CLIC pointer in WB
   logic         mret_ptr_wb;
 
+  // Detect a PMA error due to atomics
+  logic         lsu_pma_err_atomic_ex;
+
   assign        mret_ptr_wb = mret_ptr_wb_i;
+
+  assign lsu_pma_err_atomic_ex = lsu_pma_err_ex_i && lsu_pma_atomic_ex_i;
 
   assign insn_opcode = rvfi_insn[6:0];
   assign insn_rd     = rvfi_insn[11:7];
@@ -1088,7 +1095,7 @@ module cv32e40x_rvfi
         end
 
         mem_err   [STAGE_WB]  <= lsu_pmp_err_ex_i        ? MEM_ERR_PMP :
-                                 lsu_pma_err_atomic_ex_i ? MEM_ERR_ATOMIC :
+                                 lsu_pma_err_atomic_ex   ? MEM_ERR_ATOMIC :
                                                            MEM_ERR_IO_ALIGN;
 
         // Read autonomuos CSRs from EX perspective

--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -282,7 +282,8 @@ module cv32e40x_wrapper
       bind cv32e40x_debug_triggers:
         core_i.cs_registers_i.debug_triggers_i
           cv32e40x_debug_triggers_sva
-            #(.DBG_NUM_TRIGGERS(DBG_NUM_TRIGGERS))
+            #(.DBG_NUM_TRIGGERS(DBG_NUM_TRIGGERS),
+              .A_EXT           (A_EXT))
             debug_triggers_sva (.csr_wdata     (core_i.cs_registers_i.csr_wdata),
                                 .csr_waddr     (core_i.cs_registers_i.csr_waddr),
                                 .csr_op        (core_i.cs_registers_i.csr_op),
@@ -484,6 +485,7 @@ endgenerate
                .obi_instr_rptr_q(rvfi_i.rvfi_instr_obi_i.rptr_q),
                .lsu_atomic_wb_i (core_i.lsu_atomic_wb),
                .lsu_en_wb_i     (core_i.ex_wb_pipe.lsu_en),
+               .lsu_split_q_wb_i (core_i.load_store_unit_i.split_q),
                .*);
 
 `endif //  `ifndef COREV_ASSERT_OFF
@@ -558,6 +560,7 @@ endgenerate
          .lsu_pmp_err_ex_i         ( 1'b0                          /* PMP not implemented in cv32e40x */  ),
          .lsu_pma_err_ex_i         ( core_i.load_store_unit_i.mpu_i.pma_i.pma_err_o                       ),
          .lsu_pma_atomic_ex_i      ( core_i.load_store_unit_i.mpu_i.pma_i.atomic_access_i                 ),
+         .lsu_misaligned_ex_i      ( core_i.load_store_unit_i.misaligned_access                           ),
          .buffer_trans             ( core_i.load_store_unit_i.buffer_trans                                ),
          .lsu_split_q_ex_i         ( core_i.load_store_unit_i.split_q                                     ),
 

--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -473,7 +473,8 @@ endgenerate
     rvfi_i
     cv32e40x_rvfi_sva
       #(.SMCLIC(SMCLIC),
-        .DEBUG (DEBUG))
+        .DEBUG (DEBUG),
+        .A_EXT (A_EXT))
       rvfi_sva(.irq_ack(core_i.irq_ack),
                .dbg_ack(core_i.dbg_ack),
                .ebreak_in_wb_i(core_i.controller_i.controller_fsm_i.ebreak_in_wb),
@@ -481,6 +482,8 @@ endgenerate
                .obi_instr_fifo_q(rvfi_i.rvfi_instr_obi_i.fifo_q),
                .obi_instr_rptr_q_inc(rvfi_i.rvfi_instr_obi_i.rptr_q_inc),
                .obi_instr_rptr_q(rvfi_i.rvfi_instr_obi_i.rptr_q),
+               .lsu_atomic_wb_i (core_i.lsu_atomic_wb),
+               .lsu_en_wb_i     (core_i.ex_wb_pipe.lsu_en),
                .*);
 
 `endif //  `ifndef COREV_ASSERT_OFF
@@ -499,7 +502,8 @@ endgenerate
 
     cv32e40x_rvfi
       #(.SMCLIC(SMCLIC),
-        .DEBUG (DEBUG))
+        .DEBUG (DEBUG),
+        .A_EXT (A_EXT))
       rvfi_i
         (.clk_i                    ( clk_i                                                                ),
          .rst_ni                   ( rst_ni                                                               ),
@@ -552,8 +556,8 @@ endgenerate
          .dret_in_ex_i             ( core_i.ex_stage_i.id_ex_pipe_i.sys_dret_insn                         ),
          .lsu_en_ex_i              ( core_i.ex_stage_i.id_ex_pipe_i.lsu_en                                ),
          .lsu_pmp_err_ex_i         ( 1'b0                          /* PMP not implemented in cv32e40x */  ),
-         .lsu_pma_err_atomic_ex_i  ( core_i.load_store_unit_i.mpu_i.pma_i.atomic_access_i && // Todo: Consider making this a signal in the pma (no expressions allowed in module hookup)
-                                    !core_i.load_store_unit_i.mpu_i.pma_i.pma_cfg_atomic                 ),
+         .lsu_pma_err_ex_i         ( core_i.load_store_unit_i.mpu_i.pma_i.pma_err_o                       ),
+         .lsu_pma_atomic_ex_i      ( core_i.load_store_unit_i.mpu_i.pma_i.atomic_access_i                 ),
          .buffer_trans             ( core_i.load_store_unit_i.buffer_trans                                ),
          .lsu_split_q_ex_i         ( core_i.load_store_unit_i.split_q                                     ),
 

--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -560,6 +560,7 @@ endgenerate
          .lsu_pmp_err_ex_i         ( 1'b0                          /* PMP not implemented in cv32e40x */  ),
          .lsu_pma_err_ex_i         ( core_i.load_store_unit_i.mpu_i.pma_i.pma_err_o                       ),
          .lsu_pma_atomic_ex_i      ( core_i.load_store_unit_i.mpu_i.pma_i.atomic_access_i                 ),
+         .lsu_pma_cfg_ex_i         ( core_i.load_store_unit_i.mpu_i.pma_i.pma_cfg                         ),
          .lsu_misaligned_ex_i      ( core_i.load_store_unit_i.misaligned_access                           ),
          .buffer_trans             ( core_i.load_store_unit_i.buffer_trans                                ),
          .lsu_split_q_ex_i         ( core_i.load_store_unit_i.split_q                                     ),

--- a/bhv/include/cv32e40x_rvfi_pkg.sv
+++ b/bhv/include/cv32e40x_rvfi_pkg.sv
@@ -30,9 +30,10 @@ package cv32e40x_rvfi_pkg;
   parameter NMEM = 128;   // Maximum number of memory transactions per instruction is currently 13 when ZC_EXT=1
 
   typedef enum logic [1:0] { // Memory error types
-    MEM_ERR_PMP      = 2'h2,
-    MEM_ERR_ATOMIC   = 2'h1,
-    MEM_ERR_IO_ALIGN = 2'h0
+    MEM_ERR_MISALIGNED_ATOMIC = 2'h0,
+    MEM_ERR_IO_ALIGN          = 2'h1,
+    MEM_ERR_ATOMIC            = 2'h2,
+    MEM_ERR_PMP               = 2'h3
   } mem_err_t;
 
   typedef struct packed { // Autonomously updated CSRs

--- a/rtl/cv32e40x_cs_registers.sv
+++ b/rtl/cv32e40x_cs_registers.sv
@@ -1586,7 +1586,8 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
   // When DEBUG==0, DBG_NUM_TRIGGERS is assumed to be 0 as well.
   cv32e40x_debug_triggers
     #(
-        .DBG_NUM_TRIGGERS (DBG_NUM_TRIGGERS)
+        .DBG_NUM_TRIGGERS (DBG_NUM_TRIGGERS),
+        .A_EXT            (A_EXT)
     )
     debug_triggers_i
     (

--- a/rtl/cv32e40x_debug_triggers.sv
+++ b/rtl/cv32e40x_debug_triggers.sv
@@ -32,7 +32,8 @@
 module cv32e40x_debug_triggers
 import cv32e40x_pkg::*;
 #(
-  parameter int DBG_NUM_TRIGGERS = 1
+  parameter int     DBG_NUM_TRIGGERS = 1,
+  parameter a_ext_e A_EXT = A_NONE
 )
 (
   input  logic       clk,

--- a/sva/cv32e40x_rvfi_sva.sv
+++ b/sva/cv32e40x_rvfi_sva.sv
@@ -239,7 +239,7 @@ if ((A_EXT == A) || (A_EXT == ZALRSC)) begin
                   lsu_split_q_wb_i
                   |=>
                   rvfi_valid &&
-                  (rvfi_trap.cause_type == MEM_ERR_IO_ALIGN) &&
+                  (rvfi_trap.cause_type == MEM_ERR_MISALIGNED_ATOMIC) &&
                   (rvfi_trap.exception_cause == EXC_CAUSE_LOAD_FAULT))
     else `uvm_error("rvfi", "Exception on misaligned LR.W atomic instruction did not set correct cause_type in rvfi_trap")
 
@@ -259,9 +259,9 @@ if ((A_EXT == A) || (A_EXT == ZALRSC)) begin
                   lsu_split_q_wb_i
                   |=>
                   rvfi_valid &&
-                  (rvfi_trap.cause_type == MEM_ERR_IO_ALIGN) &&
+                  (rvfi_trap.cause_type == MEM_ERR_MISALIGNED_ATOMIC) &&
                   (rvfi_trap.exception_cause == EXC_CAUSE_STORE_FAULT))
-    else `uvm_error("rvfi", "Exception on aligned SC.W atomic instruction did not set correct cause_type in rvfi_trap")
+    else `uvm_error("rvfi", "Exception on misaligned SC.W atomic instruction did not set correct cause_type in rvfi_trap")
 end
 
 if (A_EXT == A) begin
@@ -281,9 +281,9 @@ if (A_EXT == A) begin
                   lsu_split_q_wb_i
                   |=>
                   rvfi_valid &&
-                  (rvfi_trap.cause_type == MEM_ERR_IO_ALIGN) &&
+                  (rvfi_trap.cause_type == MEM_ERR_MISALIGNED_ATOMIC) &&
                   (rvfi_trap.exception_cause == EXC_CAUSE_STORE_FAULT))
-    else `uvm_error("rvfi", "Exception on aligned AMO* atomic instruction did not set correct cause_type in rvfi_trap")
+    else `uvm_error("rvfi", "Exception on misaligned AMO* atomic instruction did not set correct cause_type in rvfi_trap")
 end
 
   /* TODO: Add back in.

--- a/sva/cv32e40x_rvfi_sva.sv
+++ b/sva/cv32e40x_rvfi_sva.sv
@@ -28,9 +28,9 @@ module cv32e40x_rvfi_sva
   import cv32e40x_pkg::*;
   import cv32e40x_rvfi_pkg::*;
 #(
-    parameter bit SMCLIC = 0,
-    parameter int DEBUG  = 1,
-    parameter bit A_EXT  = 0
+    parameter bit     SMCLIC = 0,
+    parameter int     DEBUG  = 1,
+    parameter a_ext_e A_EXT  = A_NONE
 )
 (
    input logic             clk_i,
@@ -70,6 +70,7 @@ module cv32e40x_rvfi_sva
    input logic [31:0]      instr_rdata_wb_past,
    input lsu_atomic_e      lsu_atomic_wb_i,
    input logic             lsu_en_wb_i,
+   input logic             lsu_split_q_wb_i,
    input logic             pc_mux_exception
 
 );
@@ -219,35 +220,70 @@ if (DEBUG) begin
     else `uvm_error("rvfi", "dcsr.nmip not followed by rvfi_intr and NMI handler")
 end
 
-if (A_EXT) begin
-  a_lr_access_fault_trap:
+if ((A_EXT == A) || (A_EXT == ZALRSC)) begin
+  // A PMA error due to an aligned LR.W accessing a non-atomic region must get cause_type==MEM_ERR_ATOMIC (1)
+  // If a LR.W gets blocked due to misalignment, it must get cause_type==MEM_ERR_IO_ALIGN (0)
+  a_aligned_lr_access_fault_trap:
   assert property (@(posedge clk_i) disable iff (!rst_ni)
-                  pc_mux_exception && (lsu_atomic_wb_i == AT_LR) && lsu_en_wb_i
+                  pc_mux_exception && (lsu_atomic_wb_i == AT_LR) && lsu_en_wb_i &&
+                  !lsu_split_q_wb_i
                   |=>
                   rvfi_valid &&
                   (rvfi_trap.cause_type == MEM_ERR_ATOMIC) &&
                   (rvfi_trap.exception_cause == EXC_CAUSE_LOAD_FAULT))
-    else `uvm_error("rvfi", "Exception on LR.W atomic instruction did not set correct cause_type in rvfi_trap")
+    else `uvm_error("rvfi", "Exception on aligned LR.W atomic instruction did not set correct cause_type in rvfi_trap")
 
-  a_sc_access_fault_trap:
+  a_misaligned_lr_access_fault_trap:
   assert property (@(posedge clk_i) disable iff (!rst_ni)
-                  pc_mux_exception && (lsu_atomic_wb_i == AT_SC) && lsu_en_wb_i
+                  pc_mux_exception && (lsu_atomic_wb_i == AT_LR) && lsu_en_wb_i &&
+                  lsu_split_q_wb_i
+                  |=>
+                  rvfi_valid &&
+                  (rvfi_trap.cause_type == MEM_ERR_IO_ALIGN) &&
+                  (rvfi_trap.exception_cause == EXC_CAUSE_LOAD_FAULT))
+    else `uvm_error("rvfi", "Exception on misaligned LR.W atomic instruction did not set correct cause_type in rvfi_trap")
+
+  a_aligned_sc_access_fault_trap:
+  assert property (@(posedge clk_i) disable iff (!rst_ni)
+                  pc_mux_exception && (lsu_atomic_wb_i == AT_SC) && lsu_en_wb_i &&
+                  !lsu_split_q_wb_i
                   |=>
                   rvfi_valid &&
                   (rvfi_trap.cause_type == MEM_ERR_ATOMIC) &&
                   (rvfi_trap.exception_cause == EXC_CAUSE_STORE_FAULT))
-    else `uvm_error("rvfi", "Exception on SC.W atomic instruction did not set correct cause_type in rvfi_trap")
+    else `uvm_error("rvfi", "Exception on aligned SC.W atomic instruction did not set correct cause_type in rvfi_trap")
 
-  a_amo_access_fault_trap:
+  a_misaligned_sc_access_fault_trap:
   assert property (@(posedge clk_i) disable iff (!rst_ni)
-                  pc_mux_exception && (lsu_atomic_wb_i == AT_AMO) && lsu_en_wb_i
+                  pc_mux_exception && (lsu_atomic_wb_i == AT_SC) && lsu_en_wb_i &&
+                  lsu_split_q_wb_i
+                  |=>
+                  rvfi_valid &&
+                  (rvfi_trap.cause_type == MEM_ERR_IO_ALIGN) &&
+                  (rvfi_trap.exception_cause == EXC_CAUSE_STORE_FAULT))
+    else `uvm_error("rvfi", "Exception on aligned SC.W atomic instruction did not set correct cause_type in rvfi_trap")
+end
+
+if (A_EXT == A) begin
+  a_aligned_amo_access_fault_trap:
+  assert property (@(posedge clk_i) disable iff (!rst_ni)
+                  pc_mux_exception && (lsu_atomic_wb_i == AT_AMO) && lsu_en_wb_i &&
+                  !lsu_split_q_wb_i
                   |=>
                   rvfi_valid &&
                   (rvfi_trap.cause_type == MEM_ERR_ATOMIC) &&
                   (rvfi_trap.exception_cause == EXC_CAUSE_STORE_FAULT))
-    else `uvm_error("rvfi", "Exception on AMO* atomic instruction did not set correct cause_type in rvfi_trap")
+    else `uvm_error("rvfi", "Exception on aligned AMO* atomic instruction did not set correct cause_type in rvfi_trap")
 
-
+  a_misaligned_amo_access_fault_trap:
+  assert property (@(posedge clk_i) disable iff (!rst_ni)
+                  pc_mux_exception && (lsu_atomic_wb_i == AT_AMO) && lsu_en_wb_i &&
+                  lsu_split_q_wb_i
+                  |=>
+                  rvfi_valid &&
+                  (rvfi_trap.cause_type == MEM_ERR_IO_ALIGN) &&
+                  (rvfi_trap.exception_cause == EXC_CAUSE_STORE_FAULT))
+    else `uvm_error("rvfi", "Exception on aligned AMO* atomic instruction did not set correct cause_type in rvfi_trap")
 end
 
   /* TODO: Add back in.


### PR DESCRIPTION
Misaligned atomic instruction will get rvfi_trap.cause_type == 0
Aligned atomic instructions to non-atomic PMA regions will get rvfi_trap.cause_type == 1

Note that AMOs are not properly supported within RVFI  yet. This will be implemented once verification is closer to start looking at AMOs.