### PR TITLE
User manual update for A_EXT.

### DIFF
--- a/docs/user_manual/source/atomics.rst
+++ b/docs/user_manual/source/atomics.rst
@@ -3,12 +3,13 @@
 Atomic instructions
 ===================
 
-|corev| supports exclusive transactions and atomic transactions if ``A_EXT`` = 1.
+|corev| supports exclusive transactions if ``A_EXT`` = ZALRSC or A.
+|corev| supports exclusive transactions and atomic transactions if ``A_EXT`` = A.
 
 Load-Reserved/Store-Conditional Instructions
 --------------------------------------------
 
-The ``lr.w`` and ``sc.w`` instructions are supported if ``A_EXT`` = 1. These instructions perform exclusive transactions via the
+The ``lr.w`` and ``sc.w`` instructions are supported if ``A_EXT`` = ZALRSC or A. These instructions perform exclusive transactions via the
 data OBI interface (i.e. ``data_atop_o[5]`` = 1). The ``data_atop_o`` signal will indicate the type of exclusive transaction
 as specified in [OPENHW-OBI]_.
 
@@ -23,10 +24,13 @@ signal for ``lr.w`` instructions and will therefore **not** detect the failure o
 a region without support for exclusive transactions, then a following ``sc.w`` will fail as well. The PMA's ``atomic`` attribute can be used to detect attempts
 to perform any type of atomic transaction (including ``lr.w`` and ``sc.w``) on regions not supporting atomic transactions.
 
+.. note::
+  An ``mret`` instruction will NOT clear the reservation set, and thus trap handlers must execute a ``sc.w`` if needed before executing ``mret``.
+
 Atomic Memory Operations
 ------------------------
 
-The ``amoswap.w``, ``amoadd.w``, ``amoand.w``, ``amoor.w``, ``amoxor.w``, ``amomax[u].w`` and ``amomin[u].w`` instructions are supported if ``A_EXT`` = 1. These instructions
+The ``amoswap.w``, ``amoadd.w``, ``amoand.w``, ``amoor.w``, ``amoxor.w``, ``amomax[u].w`` and ``amomin[u].w`` instructions are supported if ``A_EXT`` = A. These instructions
 perform atomic memory operations (AMOs).
 
 Atomic memory operation (AMO) instructions perform read-modify-write operations for multiprocessor

--- a/docs/user_manual/source/atomics.rst
+++ b/docs/user_manual/source/atomics.rst
@@ -3,14 +3,14 @@
 Atomic instructions
 ===================
 
-|corev| supports exclusive transactions if ``A_EXT`` = ZALRSC or A.
-|corev| supports exclusive transactions and atomic transactions if ``A_EXT`` = A.
+|corev| supports Load-Reserved/Store-Conditional instructions (i.e. ``lr.w`` and ``sc.w``) if ``A_EXT`` = ZALRSC or A.
+|corev| supports Load-Reserved/Store-Conditional instructions and Atomic Memory Operations (AMOs) if ``A_EXT`` = A.
 
 Load-Reserved/Store-Conditional Instructions
 --------------------------------------------
 
-The ``lr.w`` and ``sc.w`` instructions are supported if ``A_EXT`` = ZALRSC or A. These instructions perform exclusive transactions via the
-data OBI interface (i.e. ``data_atop_o[5]`` = 1). The ``data_atop_o`` signal will indicate the type of exclusive transaction
+The ``lr.w`` and ``sc.w`` instructions are supported if ``A_EXT`` = ZALRSC or ``A_EXT`` = A. These instructions perform exclusive transactions via the
+data OBI interface. The ``data_atop_o`` signal will indicate the type of exclusive transaction
 as specified in [OPENHW-OBI]_.
 
 The definition of the related reservation set as well as registering or invalidating a reservation is outside the scope of |corev|.
@@ -25,7 +25,7 @@ a region without support for exclusive transactions, then a following ``sc.w`` w
 to perform any type of atomic transaction (including ``lr.w`` and ``sc.w``) on regions not supporting atomic transactions.
 
 .. note::
-  An ``mret`` instruction will NOT clear the reservation set, and thus trap handlers must execute a ``sc.w`` if needed before executing ``mret``.
+  An ``mret`` instruction will **not** clear the reservation set, and thus trap handlers must execute a ``sc.w`` if needed before executing ``mret``.
 
 Atomic Memory Operations
 ------------------------

--- a/docs/user_manual/source/control_status_registers.rst
+++ b/docs/user_manual/source/control_status_registers.rst
@@ -559,7 +559,7 @@ Detailed:
 
 All bitfields in the ``misa`` CSR read as 0 except for the following:
 
-* **A** = 1 if ``A_EXT`` == 1
+* **A** = 1 if ``A_EXT`` == A
 * **C** = 1
 * **F** = 1 ``X_EXT`` == 1 and ``X_MISA[5]`` == 1
 * **I** = 1 if ``RV32`` == RV32I

--- a/docs/user_manual/source/integration.rst
+++ b/docs/user_manual/source/integration.rst
@@ -14,7 +14,7 @@ Instantiation Template
   cv32e40x_core #(
       .LIB                        (            0 ),
       .RV32                       (        RV32I ),
-      .A_EXT                      (            0 ),
+      .A_EXT                      (       A_NONE ),
       .B_EXT                      (       B_NONE ),
       .M_EXT                      (            M ),
       .X_EXT                      (            0 ),
@@ -135,7 +135,10 @@ Parameters
   |                                |                |               | ``RV32`` = RV32I: RV32I Base Integer Instruction Set.              |
   |                                |                |               | ``RV32`` = RV32E: RV32E Base Integer Instruction Set.              |
   +--------------------------------+----------------+---------------+--------------------------------------------------------------------+
-  | ``A_EXT``                      | bit            | 0             | Enable Atomic Instruction (A) support  (**not implemented yet**)   |
+  | ``A_EXT``                      | a_ext_e        | A_NONE        | Enable Atomic Instruction (A) support.                             |
+  |                                |                |               | ``A_EXT`` = A_NONE: No Atomic instructions supported.              |
+  |                                |                |               | ``A_EXT`` = ZALRSC: Only LR.W and SC.W instructions supported.     |
+  |                                |                |               | ``A_EXT`` = A: Full A extension supported.                         |
   +--------------------------------+----------------+---------------+--------------------------------------------------------------------+
   | ``B_EXT``                      | b_ext_e        | B_NONE        | Enable Bit Manipulation support. ``B_EXT`` = B_NONE: No Bit        |
   |                                |                |               | Manipulation instructions are supported. ``B_EXT`` = ZBA_ZBB:      |

--- a/docs/user_manual/source/load_store_unit.rst
+++ b/docs/user_manual/source/load_store_unit.rst
@@ -160,5 +160,5 @@ Transactions in the write buffer must be completed before the |corev| is able to
 Atomics
 -------
 
-|corev| supports exclusive transactions if ``A_EXT`` = ZALRSC or A, and atomic transactions if ``A_EXT`` = A. For atomic transactions |corev| does however **not** provide a full implementation of the ``A`` extension as it is assumed
+|corev| supports exclusive transactions if ``A_EXT`` = ZALRSC or ``A_EXT`` = A, and atomic transactions if ``A_EXT`` = A. For atomic transactions |corev| does however **not** provide a full implementation of the ``A`` extension as it is assumed
 that |corev| is used in combination with an external adapter that transforms the OBI transactions (see [OPENHW-OBI]_) into the required *read-modify-write* sequences. For more information about Atomic instructions, see :ref:`atomics`.

--- a/docs/user_manual/source/load_store_unit.rst
+++ b/docs/user_manual/source/load_store_unit.rst
@@ -61,7 +61,7 @@ is therefore performed as two bus transactions for the following scenarios:
 
 In both cases the transfer corresponding to the lowest address is performed first. All other scenarios can be handled with a single bus transaction.
 
-Misaligned transactions are not supported in I/O regions and will result in an exception trap when attempted, see :ref:`exceptions-interrupts`. 
+Misaligned transactions are not supported in I/O regions and will result in an exception trap when attempted, see :ref:`exceptions-interrupts`.
 
 Protocol
 --------
@@ -88,7 +88,7 @@ granting a request, the memory answers with a ``data_rvalid_i`` set high
 if ``data_rdata_i`` is valid. This may happen one or more cycles after the
 request has been granted. Note that ``data_rvalid_i`` must also be set high
 to signal the end of the response phase for a write transaction (although
-the ``data_rdata_i`` has no meaning in that case). When multiple granted requests 
+the ``data_rdata_i`` has no meaning in that case). When multiple granted requests
 are outstanding, it is assumed that the memory requests will be kept in-order and
 one ``data_rvalid_i`` will be signalled for each of them, in the order they were issued.
 
@@ -149,10 +149,10 @@ The write buffer (when not full) allows |corev| to proceed executing instruction
 .. note::
 
    On the OBI interface ``data_gnt_i`` = 1 and ``data_rvalid_i`` = 1 still need to be signaled for every transfer (as specified in [OPENHW-OBI]_), also for bufferable transfers.
- 
+
 Bus transfers will occur in program order, no matter if transfers are bufferable and non-bufferable.
 Transactions in the write buffer must be completed before the |corev| is able to:
- 
+
  * Retire a ``fence`` instruction
  * Retire a ``fence.i`` instruction
  * Enter SLEEP mode
@@ -160,5 +160,5 @@ Transactions in the write buffer must be completed before the |corev| is able to
 Atomics
 -------
 
-|corev| supports exclusive transactions and atomic transactions if ``A_EXT`` = 1. For atomic transactions |corev| does however **not** provide a full implementation of the ``A`` extension as it is assumed
-that |corev| is used in combination with an external adapter that transforms the OBI transactions (see [OPENHW-OBI]_) into the required *read-modify-write* sequences. For more information about Atomic instructions, see :ref:`atomics`. 
+|corev| supports exclusive transactions if ``A_EXT`` = ZALRSC or A, and atomic transactions if ``A_EXT`` = A. For atomic transactions |corev| does however **not** provide a full implementation of the ``A`` extension as it is assumed
+that |corev| is used in combination with an external adapter that transforms the OBI transactions (see [OPENHW-OBI]_) into the required *read-modify-write* sequences. For more information about Atomic instructions, see :ref:`atomics`.


### PR DESCRIPTION
Updated user manual to describe the updated A_EXT parameter, and added a note about mret instructions not clearing reservation sets.