### PR TITLE
Updated CLIC to version 0.9-draft, 2/14/2023. Changed mintstatus CSR …

### DIFF
--- a/docs/user_manual/source/integration.rst
+++ b/docs/user_manual/source/integration.rst
@@ -32,9 +32,9 @@ Instantiation Template
       .NUM_MHPMCOUNTERS           (            1 ),
       .PMA_NUM_REGIONS            (            1 ),
       .PMA_CFG                    (    PMA_CFG[] ),
-      .SMCLIC                     (            0 ),
-      .SMCLIC_ID_WIDTH            (            5 ),
-      .SMCLIC_INTTHRESHBITS       (            8 )
+      .CLIC                       (            0 ),
+      .CLIC_ID_WIDTH              (            5 ),
+      .CLIC_INTTHRESHBITS         (            8 )
   ) u_core (
       // Clock and reset
       .clk_i                    (),
@@ -189,14 +189,14 @@ Parameters
   | ``PMA_CFG[]``                  | pma_cfg_t      | PMA_R_DEFAULT | PMA configuration.                                                 |
   |                                |                |               | Array of pma_cfg_t with PMA_NUM_REGIONS entries, see :ref:`pma`    |
   +--------------------------------+----------------+---------------+--------------------------------------------------------------------+
-  | ``SMCLIC``                     | int (0..1)     | 0             | Is Smclic supported?                                               |
+  | ``CLIC``                       | int (0..1)     | 0             | Are Smclic, Smclicshv and Smclicconfig supported?                  |
   +--------------------------------+----------------+---------------+--------------------------------------------------------------------+
-  | ``SMCLIC_ID_WIDTH``            | int (1..10)    | 5             | Width of ``clic_irq_id_i`` and ``clic_irq_id_o``. The maximum      |
+  | ``CLIC_ID_WIDTH``              | int (1..10)    | 5             | Width of ``clic_irq_id_i`` and ``clic_irq_id_o``. The maximum      |
   |                                |                |               | number of supported interrupts in CLIC mode is                     |
-  |                                |                |               | ``2^SMCLIC_ID_WIDTH``. Trap vector table alignment is restricted   |
+  |                                |                |               | ``2^CLIC_ID_WIDTH``. Trap vector table alignment is restricted     |
   |                                |                |               | as described in :ref:`csr-mtvt`.                                   |
   +--------------------------------+----------------+---------------+--------------------------------------------------------------------+
-  | ``SMCLIC_INTTHRESHBITS``       | int (1..8)     | 8             | Number of bits actually implemented in ``mintthresh.th`` field.    |
+  | ``CLIC_INTTHRESHBITS``         | int (1..8)     | 8             | Number of bits actually implemented in ``mintthresh.th`` field.    |
   +--------------------------------+----------------+---------------+--------------------------------------------------------------------+
 
 Interfaces

--- a/docs/user_manual/source/intro.rst
+++ b/docs/user_manual/source/intro.rst
@@ -45,8 +45,8 @@ It follows these specifications:
 .. [RISC-V-DEBUG] RISC-V Debug Support, version 1.0-STABLE, 246028cd719426597269b3d717c866802c58bde7,
    https://github.com/riscv/riscv-debug-spec/blob/05252da1575610e9605d882145da3f4e7f4f3cb1/riscv-debug-stable.pdf 
 
-.. [RISC-V-SMCLIC] "Smclic" Core-Local Interrupt Controller (CLIC) RISC-V Privileged Architecture Extension, version 0.9-draft, 11/08/2022,
-   https://github.com/riscv/riscv-fast-interrupt/blob/15618901f6e38e92919031eac99b980055353df6/clic.pdf
+.. [RISC-V-CLIC] Core-Local Interrupt Controller (CLIC) RISC-V Privileged Architecture Extensions, version 0.9-draft, 2/14/2023,
+   https://github.com/riscv/riscv-fast-interrupt/blob/a371ddda849a055932fa49fe58d1fee6d9063a3c/clic.pdf 
 
 .. [RISC-V-ZBA_ZBB_ZBC_ZBS] RISC-V Bit Manipulation ISA-extensions, Version 1.0.0-38-g865e7a7, 2021-06-28,
    https://github.com/riscv/riscv-bitmanip/releases/download/1.0.0/bitmanip-1.0.0-38-g865e7a7.pdf


### PR DESCRIPTION
…address to 0xFB1. Renamed CLIC related parameters.