### PR TITLE
Added exception codes 0x4 and 0x6 misaligned atomics.

### DIFF
--- a/bhv/include/cv32e40x_rvfi_pkg.sv
+++ b/bhv/include/cv32e40x_rvfi_pkg.sv
@@ -30,10 +30,9 @@ package cv32e40x_rvfi_pkg;
   parameter NMEM = 128;   // Maximum number of memory transactions per instruction is currently 13 when ZC_EXT=1
 
   typedef enum logic [1:0] { // Memory error types
-    MEM_ERR_MISALIGNED_ATOMIC = 2'h0,
-    MEM_ERR_IO_ALIGN          = 2'h1,
-    MEM_ERR_ATOMIC            = 2'h2,
-    MEM_ERR_PMP               = 2'h3
+    MEM_ERR_IO_ALIGN          = 2'h0,
+    MEM_ERR_ATOMIC            = 2'h1,
+    MEM_ERR_PMP               = 2'h2
   } mem_err_t;
 
   typedef struct packed { // Autonomously updated CSRs

--- a/rtl/cv32e40x_controller_fsm.sv
+++ b/rtl/cv32e40x_controller_fsm.sv
@@ -346,14 +346,16 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
   assign ctrl_fsm_o.exception_in_wb = exception_in_wb;
 
   // Set exception cause
-  assign exception_cause_wb = (ex_wb_pipe_i.instr.mpu_status != MPU_OK)                                                      ? EXC_CAUSE_INSTR_FAULT     :
-                              ex_wb_pipe_i.instr.bus_resp.err                                                                ? EXC_CAUSE_INSTR_BUS_FAULT :
-                              ex_wb_pipe_i.illegal_insn                                                                      ? EXC_CAUSE_ILLEGAL_INSN    :
-                              (ex_wb_pipe_i.sys_en && ex_wb_pipe_i.sys_ecall_insn)                                           ? EXC_CAUSE_ECALL_MMODE     :
+  assign exception_cause_wb = (ex_wb_pipe_i.instr.mpu_status != MPU_OK)                                                      ? EXC_CAUSE_INSTR_FAULT      :
+                              ex_wb_pipe_i.instr.bus_resp.err                                                                ? EXC_CAUSE_INSTR_BUS_FAULT  :
+                              ex_wb_pipe_i.illegal_insn                                                                      ? EXC_CAUSE_ILLEGAL_INSN     :
+                              (ex_wb_pipe_i.sys_en && ex_wb_pipe_i.sys_ecall_insn)                                           ? EXC_CAUSE_ECALL_MMODE      :
                               (ex_wb_pipe_i.sys_en && ex_wb_pipe_i.sys_ebrk_insn && (ex_wb_pipe_i.priv_lvl == PRIV_LVL_M) &&
-                                !dcsr_i.ebreakm && !debug_mode_q)                                                            ? EXC_CAUSE_BREAKPOINT      :
-                              (mpu_status_wb_i == MPU_WR_FAULT)                                                              ? EXC_CAUSE_STORE_FAULT     :
-                              EXC_CAUSE_LOAD_FAULT; // (mpu_status_wb_i == MPU_RE_FAULT)
+                                !dcsr_i.ebreakm && !debug_mode_q)                                                            ? EXC_CAUSE_BREAKPOINT       :
+                              (mpu_status_wb_i == MPU_WR_FAULT)                                                              ? EXC_CAUSE_STORE_FAULT      :
+                              (mpu_status_wb_i == MPU_RE_FAULT)                                                              ? EXC_CAUSE_LOAD_FAULT       :
+                              (mpu_status_wb_i == MPU_WR_MISALIGNED)                                                         ? EXC_CAUSE_STORE_MISALIGNED :
+                                                                                                                               EXC_CAUSE_LOAD_MISALIGNED;
 
   assign ctrl_fsm_o.exception_cause_wb = exception_cause_wb;
 

--- a/rtl/cv32e40x_mpu.sv
+++ b/rtl/cv32e40x_mpu.sv
@@ -119,13 +119,13 @@ module cv32e40x_mpu import cv32e40x_pkg::*;
           if (core_mpu_err_wait_i) begin
             if(core_trans_we) begin
               // MPU error on write
-              // PMA errors take presedence over misaligned atomics
+              // PMA errors take precedence over misaligned atomics
               state_n = core_one_txn_pend_n ? (pma_err ? MPU_WR_ERR_RESP : MPU_WR_MISALIGN_RESP) :
                                               (pma_err ? MPU_WR_ERR_WAIT : MPU_WR_MISALIGN_WAIT);
             end
             else begin
               // MPU error on read
-              // PMA errors take presedence over misaligned atomics
+              // PMA errors take precedence over misaligned atomics
               state_n = core_one_txn_pend_n ? (pma_err ? MPU_RE_ERR_RESP : MPU_RE_MISALIGN_RESP) :
                                               (pma_err ? MPU_RE_ERR_WAIT : MPU_RE_MISALIGN_WAIT);
             end

--- a/rtl/cv32e40x_mpu.sv
+++ b/rtl/cv32e40x_mpu.sv
@@ -70,6 +70,7 @@ module cv32e40x_mpu import cv32e40x_pkg::*;
    );
 
   logic        pma_err;
+  logic        pma_misaligned_atomic;
   logic        mpu_err;
   logic        mpu_block_core;
   logic        mpu_block_bus;
@@ -118,27 +119,36 @@ module cv32e40x_mpu import cv32e40x_pkg::*;
           if (core_mpu_err_wait_i) begin
             if(core_trans_we) begin
               // MPU error on write
-              state_n = core_one_txn_pend_n ? MPU_WR_ERR_RESP : MPU_WR_ERR_WAIT;
+              // PMA errors take presedence over misaligned atomics
+              state_n = core_one_txn_pend_n ? (pma_err ? MPU_WR_ERR_RESP : MPU_WR_MISALIGN_RESP) :
+                                              (pma_err ? MPU_WR_ERR_WAIT : MPU_WR_MISALIGN_WAIT);
             end
             else begin
               // MPU error on read
-              state_n = core_one_txn_pend_n ? MPU_RE_ERR_RESP : MPU_RE_ERR_WAIT;
+              // PMA errors take presedence over misaligned atomics
+              state_n = core_one_txn_pend_n ? (pma_err ? MPU_RE_ERR_RESP : MPU_RE_MISALIGN_RESP) :
+                                              (pma_err ? MPU_RE_ERR_WAIT : MPU_RE_MISALIGN_WAIT);
             end
           end
 
         end
       end
-      MPU_RE_ERR_WAIT, MPU_WR_ERR_WAIT: begin
+      MPU_RE_ERR_WAIT, MPU_WR_ERR_WAIT,
+      MPU_RE_MISALIGN_WAIT, MPU_WR_MISALIGN_WAIT: begin
 
         // Block new transfers while waiting for in flight transfers to complete
         mpu_block_bus  = 1'b1;
         mpu_block_core = 1'b1;
 
         if (core_one_txn_pend_n) begin
-          state_n = (state_q == MPU_RE_ERR_WAIT) ? MPU_RE_ERR_RESP : MPU_WR_ERR_RESP;
+          state_n = (state_q == MPU_RE_ERR_WAIT)      ? MPU_RE_ERR_RESP      :
+                    (state_q == MPU_WR_ERR_WAIT)      ? MPU_WR_ERR_RESP      :
+                    (state_q == MPU_RE_MISALIGN_WAIT) ? MPU_RE_MISALIGN_RESP :
+                                                        MPU_WR_MISALIGN_RESP;
         end
       end
-      MPU_RE_ERR_RESP, MPU_WR_ERR_RESP: begin
+      MPU_RE_ERR_RESP, MPU_WR_ERR_RESP,
+      MPU_RE_MISALIGN_RESP, MPU_WR_MISALIGN_RESP: begin
 
         // Keep blocking new transfers
         mpu_block_bus  = 1'b1;
@@ -146,7 +156,10 @@ module cv32e40x_mpu import cv32e40x_pkg::*;
 
         // Set up MPU error response towards the core
         mpu_err_trans_valid = 1'b1;
-        mpu_status = (state_q == MPU_RE_ERR_RESP) ? MPU_RE_FAULT : MPU_WR_FAULT;
+        mpu_status = (state_q == MPU_RE_ERR_RESP)      ? MPU_RE_FAULT      :
+                     (state_q == MPU_WR_ERR_RESP)      ? MPU_WR_FAULT      :
+                     (state_q == MPU_RE_MISALIGN_RESP) ? MPU_RE_MISALIGNED :
+                                                         MPU_WR_MISALIGNED;
 
         // Go back to IDLE uncoditionally.
         // The core is expected to always be ready for the response
@@ -203,11 +216,12 @@ module cv32e40x_mpu import cv32e40x_pkg::*;
     .misaligned_access_i        ( misaligned_access_i     ),
     .load_access_i              ( load_access             ),
     .pma_err_o                  ( pma_err                 ),
+    .pma_misaligned_atomic_o    ( pma_misaligned_atomic   ),
     .pma_bufferable_o           ( bus_trans_bufferable    ),
     .pma_cacheable_o            ( bus_trans_cacheable     )
   );
 
-  assign mpu_err = pma_err;
+  assign mpu_err = pma_err || pma_misaligned_atomic;
 
   // Writes are only supported on the data interface
   // Tie to 1'b0 if this MPU is instantiatied in the IF stage

--- a/rtl/cv32e40x_pma.sv
+++ b/rtl/cv32e40x_pma.sv
@@ -38,6 +38,7 @@ module cv32e40x_pma import cv32e40x_pkg::*;
   input  logic        misaligned_access_i,  // Indicate that ongoing access is part of a misaligned access
   input  logic        load_access_i,        // Indicate that ongoing access is a load
   output logic        pma_err_o,
+  output logic        pma_misaligned_atomic_o, // Atomic instruction is misaligned
   output logic        pma_bufferable_o,
   output logic        pma_cacheable_o
 );
@@ -102,9 +103,15 @@ module cv32e40x_pma import cv32e40x_pkg::*;
   generate
     if (A_EXT) begin: pma_atomic
       assign pma_cfg_atomic = pma_cfg.atomic;
+
+      // Check if atomic access is misaligned.
+      // If not otherwise blocked by the PMA, this will results in exception codes
+      // 4 or 6 indicating misaligned load/store atomics.
+      assign pma_misaligned_atomic_o = atomic_access_i && misaligned_access_i;
     end
     else begin: pma_no_atomic
       assign pma_cfg_atomic = 1'b0;
+      assign pma_misaligned_atomic_o = 1'b0;
     end
   endgenerate
 
@@ -115,14 +122,6 @@ module cv32e40x_pma import cv32e40x_pkg::*;
 
     // Check for atomic access
     if (atomic_access_i && !pma_cfg_atomic) begin
-      pma_err_o = 1'b1;
-    end
-
-    // Check that atomic accesses are not misaligned
-    // Not strictly a part of the PMA, but reusing the PMA logic for flagging errors
-    // and consume transactions rather than making separate logic in the LSU. Uses the same exception
-    // codes as PMA errors.
-    if (atomic_access_i && misaligned_access_i) begin
       pma_err_o = 1'b1;
     end
 

--- a/rtl/include/cv32e40x_pkg.sv
+++ b/rtl/include/cv32e40x_pkg.sv
@@ -904,7 +904,7 @@ typedef enum logic[3:0] {
 parameter EXC_CAUSE_INSTR_FAULT      = 11'h01;
 parameter EXC_CAUSE_ILLEGAL_INSN     = 11'h02;
 parameter EXC_CAUSE_BREAKPOINT       = 11'h03;
-parameter EXC_CAUSE_LOAD_MISALIGNED  = 22'h04;
+parameter EXC_CAUSE_LOAD_MISALIGNED  = 11'h04;
 parameter EXC_CAUSE_LOAD_FAULT       = 11'h05;
 parameter EXC_CAUSE_STORE_MISALIGNED = 11'h06;
 parameter EXC_CAUSE_STORE_FAULT      = 11'h07;

--- a/rtl/include/cv32e40x_pkg.sv
+++ b/rtl/include/cv32e40x_pkg.sv
@@ -901,16 +901,19 @@ typedef enum logic[3:0] {
 } pc_mux_e;
 
 // Exception Cause
-parameter EXC_CAUSE_INSTR_FAULT     = 11'h01;
-parameter EXC_CAUSE_ILLEGAL_INSN    = 11'h02;
-parameter EXC_CAUSE_BREAKPOINT      = 11'h03;
-parameter EXC_CAUSE_LOAD_FAULT      = 11'h05;
-parameter EXC_CAUSE_STORE_FAULT     = 11'h07;
-parameter EXC_CAUSE_ECALL_MMODE     = 11'h0B;
-parameter EXC_CAUSE_INSTR_BUS_FAULT = 11'h18;
+parameter EXC_CAUSE_INSTR_FAULT      = 11'h01;
+parameter EXC_CAUSE_ILLEGAL_INSN     = 11'h02;
+parameter EXC_CAUSE_BREAKPOINT       = 11'h03;
+parameter EXC_CAUSE_LOAD_MISALIGNED  = 22'h04;
+parameter EXC_CAUSE_LOAD_FAULT       = 11'h05;
+parameter EXC_CAUSE_STORE_MISALIGNED = 11'h06;
+parameter EXC_CAUSE_STORE_FAULT      = 11'h07;
+parameter EXC_CAUSE_ECALL_MMODE      = 11'h0B;
+parameter EXC_CAUSE_INSTR_BUS_FAULT  = 11'h18;
 
 parameter logic [31:0] ETRIGGER_TDATA2_MASK = (1 << EXC_CAUSE_INSTR_BUS_FAULT) | (1 << EXC_CAUSE_ECALL_MMODE) | (1 << EXC_CAUSE_STORE_FAULT) |
-                                              (1 << EXC_CAUSE_LOAD_FAULT) | (1 << EXC_CAUSE_BREAKPOINT) | (1 << EXC_CAUSE_ILLEGAL_INSN) | (1 << EXC_CAUSE_INSTR_FAULT);
+                                              (1 << EXC_CAUSE_LOAD_FAULT) | (1 << EXC_CAUSE_BREAKPOINT) | (1 << EXC_CAUSE_ILLEGAL_INSN) | (1 << EXC_CAUSE_INSTR_FAULT) |
+                                              (1 << EXC_CAUSE_LOAD_MISALIGNED) | (1<<EXC_CAUSE_STORE_MISALIGNED);
 
 parameter INT_CAUSE_LSU_LOAD_FAULT  = 11'h400;
 parameter INT_CAUSE_LSU_STORE_FAULT = 11'h401;
@@ -962,13 +965,16 @@ parameter pma_cfg_t PMA_R_DEFAULT = '{word_addr_low   : 0,
                                       atomic          : 1'b0};
 
 // MPU status. Used for PMA
-typedef enum logic [1:0] {
-                          MPU_OK       = 2'h0,
-                          MPU_RE_FAULT = 2'h1,
-                          MPU_WR_FAULT = 2'h2
+typedef enum logic [2:0] {
+                          MPU_OK            = 3'h0,
+                          MPU_RE_FAULT      = 3'h1,
+                          MPU_WR_FAULT      = 3'h2,
+                          MPU_RE_MISALIGNED = 3'h3,
+                          MPU_WR_MISALIGNED = 3'h4
                           } mpu_status_e;
 
-typedef enum logic [2:0] {MPU_IDLE, MPU_RE_ERR_RESP, MPU_RE_ERR_WAIT, MPU_WR_ERR_RESP, MPU_WR_ERR_WAIT} mpu_state_e;
+typedef enum logic [3:0] {MPU_IDLE, MPU_RE_ERR_RESP, MPU_RE_ERR_WAIT, MPU_RE_MISALIGN_RESP, MPU_RE_MISALIGN_WAIT,
+                          MPU_WR_ERR_RESP, MPU_WR_ERR_WAIT, MPU_WR_MISALIGN_RESP, MPU_WR_MISALIGN_WAIT} mpu_state_e;
 
 // WPT state machine
 typedef enum logic [1:0] {WPT_IDLE, WPT_MATCH_WAIT, WPT_MATCH_RESP} wpt_state_e;

--- a/sva/cv32e40x_mpu_sva.sv
+++ b/sva/cv32e40x_mpu_sva.sv
@@ -82,7 +82,8 @@ module cv32e40x_mpu_sva import cv32e40x_pkg::*; import uvm_pkg::*;
    input logic        mpu_block_bus,
    input              mpu_state_e state_q,
    input logic        mpu_err,
-   input logic        load_access
+   input logic        load_access,
+   input logic        pma_misaligned_atomic
    );
 
   // PMA assertions helper signals
@@ -225,6 +226,7 @@ module cv32e40x_mpu_sva import cv32e40x_pkg::*; import uvm_pkg::*;
   // RTL vs SVA expectations
   pma_cfg_t    pma_expected_cfg;
   logic        pma_expected_err;
+  logic        pma_expected_misaligned_err;
   always_comb begin
     pma_expected_cfg = NO_PMA_R_DEFAULT;
     if (PMA_NUM_REGIONS) begin
@@ -236,8 +238,10 @@ module cv32e40x_mpu_sva import cv32e40x_pkg::*; import uvm_pkg::*;
   assign pma_expected_err = (instr_fetch_access && !pma_expected_cfg.main)  ||
                             (misaligned_access_i && !pma_expected_cfg.main) ||
                             (atomic_access_i && !pma_expected_cfg.atomic)   ||
-                            (misaligned_access_i && atomic_access_i)        ||
                             (core_trans_pushpop_i && !pma_expected_cfg.main);
+
+  assign pma_expected_misaligned_err = (misaligned_access_i && atomic_access_i);
+
   a_pma_expect_cfg :
     assert property (@(posedge clk) disable iff (!rst_n) pma_cfg == pma_expected_cfg)
       else `uvm_error("mpu", "RTL cfg don't match SVA expectations")
@@ -257,10 +261,14 @@ module cv32e40x_mpu_sva import cv32e40x_pkg::*; import uvm_pkg::*;
   a_pma_expect_cacheable :
     assert property (@(posedge clk) disable iff (!rst_n) bus_trans_cacheable == pma_expected_cfg.cacheable)
       else `uvm_error("mpu", "expected different cacheable flag")
+
   a_pma_expect_err :
     assert property (@(posedge clk) disable iff (!rst_n) pma_err == pma_expected_err)
       else `uvm_error("mpu", "expected different err flag")
 
+  a_pma_expect_misaligned_err :
+    assert property (@(posedge clk) disable iff (!rst_n) pma_misaligned_atomic == pma_expected_misaligned_err)
+      else `uvm_error("mpu", "expected different err flag for misaligned atomics")
   // Bufferable
   generate
     if (bufferable_in_config() && !IS_INSTR_SIDE) begin
@@ -436,7 +444,7 @@ if (A_EXT != A_NONE) begin
   assert property (@(posedge clk) disable iff (!rst_n)
                   core_trans_valid_i &&
                   atomic_access_i &&
-                  !pma_err
+                  !pma_misaligned_atomic
                   |->
                   (core_trans_i.addr[1:0] == 2'b00))
         else `uvm_error("mpu", "Misaligned atomic instruction not flagged with error")

--- a/sva/cv32e40x_rvfi_sva.sv
+++ b/sva/cv32e40x_rvfi_sva.sv
@@ -299,8 +299,14 @@ if (A_EXT == A) begin
                   lsu_split_q_wb_i
                   |=>
                   rvfi_valid &&
-                  (rvfi_trap.cause_type == MEM_ERR_IO_ALIGN) &&
+                  ((rvfi_trap.cause_type == MEM_ERR_IO_ALIGN) &&
+                  (rvfi_trap.exception_cause == EXC_CAUSE_STORE_MISALIGNED))
+                  or
+                  ((rvfi_trap.cause_type == MEM_ERR_ATOMIC) &&
                   (rvfi_trap.exception_cause == EXC_CAUSE_STORE_FAULT))
+                  or
+                  ((rvfi_trap.cause_type == MEM_ERR_IO_ALIGN) &&
+                  (rvfi_trap.exception_cause == EXC_CAUSE_STORE_FAULT)))
     else `uvm_error("rvfi", "Exception on misaligned AMO* atomic instruction did not set correct cause_type in rvfi_trap")
 end
 

--- a/sva/cv32e40x_rvfi_sva.sv
+++ b/sva/cv32e40x_rvfi_sva.sv
@@ -221,8 +221,14 @@ if (DEBUG) begin
 end
 
 if ((A_EXT == A) || (A_EXT == ZALRSC)) begin
-  // A PMA error due to an aligned LR.W accessing a non-atomic region must get cause_type==MEM_ERR_ATOMIC (1)
-  // If a LR.W gets blocked due to misalignment, it must get cause_type==MEM_ERR_IO_ALIGN (0)
+  // Aligned atomics blocked by the PMA shall use the EXC_CAUSE_LOAD_FAULT or EXC_CAUSE_STORE_FAULT exception codes with
+  // cause_type MEM_ERR_ATOMIC.
+  //
+  // Misaligned atomics to a non-main PMA region shall use EXC_CAUSE_LOAD_FAULT or EXC_CAUSE_STORE_FAULT exception codes with
+  // cause_type MEM_ERR_IO_ALIGN
+  //
+  // Misaligned atomics which are otherwise not blocked by the PMA (cfg is main and atomic) shall use either
+  // EXC_CAUSE_LOAD_MISALIGNED or EXC_CAUSE_STORE_MISALIGNED with cause_type MEM_ERR_IO_ALIGN.
   a_aligned_lr_access_fault_trap:
   assert property (@(posedge clk_i) disable iff (!rst_ni)
                   pc_mux_exception && (lsu_atomic_wb_i == AT_LR) && lsu_en_wb_i &&
@@ -239,8 +245,14 @@ if ((A_EXT == A) || (A_EXT == ZALRSC)) begin
                   lsu_split_q_wb_i
                   |=>
                   rvfi_valid &&
-                  (rvfi_trap.cause_type == MEM_ERR_MISALIGNED_ATOMIC) &&
+                  ((rvfi_trap.cause_type == MEM_ERR_IO_ALIGN) &&
+                  (rvfi_trap.exception_cause == EXC_CAUSE_LOAD_MISALIGNED))
+                  or
+                  ((rvfi_trap.cause_type == MEM_ERR_ATOMIC) &&
                   (rvfi_trap.exception_cause == EXC_CAUSE_LOAD_FAULT))
+                  or
+                  ((rvfi_trap.cause_type == MEM_ERR_IO_ALIGN) &&
+                  (rvfi_trap.exception_cause == EXC_CAUSE_LOAD_FAULT)))
     else `uvm_error("rvfi", "Exception on misaligned LR.W atomic instruction did not set correct cause_type in rvfi_trap")
 
   a_aligned_sc_access_fault_trap:
@@ -259,8 +271,14 @@ if ((A_EXT == A) || (A_EXT == ZALRSC)) begin
                   lsu_split_q_wb_i
                   |=>
                   rvfi_valid &&
-                  (rvfi_trap.cause_type == MEM_ERR_MISALIGNED_ATOMIC) &&
+                  ((rvfi_trap.cause_type == MEM_ERR_IO_ALIGN) &&
+                  (rvfi_trap.exception_cause == EXC_CAUSE_STORE_MISALIGNED))
+                  or
+                  ((rvfi_trap.cause_type == MEM_ERR_ATOMIC) &&
                   (rvfi_trap.exception_cause == EXC_CAUSE_STORE_FAULT))
+                  or
+                  ((rvfi_trap.cause_type == MEM_ERR_IO_ALIGN) &&
+                  (rvfi_trap.exception_cause == EXC_CAUSE_STORE_FAULT)))
     else `uvm_error("rvfi", "Exception on misaligned SC.W atomic instruction did not set correct cause_type in rvfi_trap")
 end
 
@@ -281,7 +299,7 @@ if (A_EXT == A) begin
                   lsu_split_q_wb_i
                   |=>
                   rvfi_valid &&
-                  (rvfi_trap.cause_type == MEM_ERR_MISALIGNED_ATOMIC) &&
+                  (rvfi_trap.cause_type == MEM_ERR_IO_ALIGN) &&
                   (rvfi_trap.exception_cause == EXC_CAUSE_STORE_FAULT))
     else `uvm_error("rvfi", "Exception on misaligned AMO* atomic instruction did not set correct cause_type in rvfi_trap")
 end


### PR DESCRIPTION
These will only be used for misaligned atomics which are not otherwise blocked by the PMA.

SEC clean when A_EXT=A_NONE and the new exception codes are not allowed to cause exception triggers (tdata2_rdata may propagate and lead to counter examples).