### PR TITLE
Added note in user manual about setting tdata1 to disabled trigger if…

### DIFF
--- a/docs/user_manual/source/control_status_registers.rst
+++ b/docs/user_manual/source/control_status_registers.rst
@@ -1439,8 +1439,8 @@ Reset Value: 0x2800_1000
    0xF800_0000, which is the only supported value for a disabled trigger.
    The WARL behavior of ``tdata1.DATA`` depends on the value of ``tdata1.TYPE`` as described in
    :ref:`csr-mcontrol`, :ref:`csr-mcontrol6`, :ref:`csr-etrigger` and :ref:`csr-tdata1_disabled`.
-   ``tdata1`` will also be set to 0xF800_0000 if ``tdata1`` is attempted written with type 0x5 (etrigger) while at the same time ``tdata2``
-   contains an illegal value for exception triggers.
+   ``tdata1`` will also be set to 0xF800_0000 if ``tdata1`` is attempted to be written with type 0x5 (``etrigger``) while at the same time ``tdata2``
+   contains a value that is illegal for exception triggers.
 
 .. _csr-mcontrol:
 

--- a/docs/user_manual/source/control_status_registers.rst
+++ b/docs/user_manual/source/control_status_registers.rst
@@ -1439,6 +1439,8 @@ Reset Value: 0x2800_1000
    0xF800_0000, which is the only supported value for a disabled trigger.
    The WARL behavior of ``tdata1.DATA`` depends on the value of ``tdata1.TYPE`` as described in
    :ref:`csr-mcontrol`, :ref:`csr-mcontrol6`, :ref:`csr-etrigger` and :ref:`csr-tdata1_disabled`.
+   ``tdata1`` will also be set to 0xF800_0000 if ``tdata1`` is attempted written with type 0x5 (etrigger) while at the same time ``tdata2``
+   contains an illegal value for exception triggers.
 
 .. _csr-mcontrol:
 


### PR DESCRIPTION
… an etrigger is attempted written while there are illegal etrigger bits set in tdata2.