### PR TITLE
Fixed rvfi wmask issue for tselect, tinfo and tdata3

### DIFF
--- a/bhv/cv32e40x_rvfi.sv
+++ b/bhv/cv32e40x_rvfi.sv
@@ -1315,7 +1315,7 @@ module cv32e40x_rvfi
   // Trigger
   assign rvfi_csr_rdata_d.tselect            = csr_tselect_q_i;
   assign rvfi_csr_wdata_d.tselect            = csr_tselect_n_i;
-  assign rvfi_csr_wmask_d.tselect            = csr_tselect_we_i;
+  assign rvfi_csr_wmask_d.tselect            = csr_tselect_we_i ? '1 : '0;
 
   assign rvfi_csr_rdata_d.tdata[0]           = 'Z;
   assign rvfi_csr_wdata_d.tdata[0]           = 'Z; // Does not exist
@@ -1331,11 +1331,11 @@ module cv32e40x_rvfi
 
   assign rvfi_csr_rdata_d.tdata[3]           = csr_tdata3_q_i;
   assign rvfi_csr_wdata_d.tdata[3]           = csr_tdata3_n_i;
-  assign rvfi_csr_wmask_d.tdata[3]           = csr_tdata3_we_i;
+  assign rvfi_csr_wmask_d.tdata[3]           = csr_tdata3_we_i ? '1 : '0;
 
   assign rvfi_csr_rdata_d.tinfo              = csr_tinfo_q_i;
   assign rvfi_csr_wdata_d.tinfo              = csr_tinfo_n_i;
-  assign rvfi_csr_wmask_d.tinfo              = csr_tinfo_we_i;
+  assign rvfi_csr_wmask_d.tinfo              = csr_tinfo_we_i ? '1 : '0;
 
   assign rvfi_csr_rdata_d.tcontrol           = csr_tcontrol_q_i;
   assign rvfi_csr_wdata_d.tcontrol           = csr_tcontrol_n_i;


### PR DESCRIPTION
Fixed issue with rvfi write masks for tselect, tinfo and tdata3 (https://github.com/openhwgroup/cv32e40s/issues/417).