### PR TITLE
Updated CLIC version to Version 0.9-draft, 3/14/2023 and clarified th…

### DIFF
--- a/docs/user_manual/source/exceptions_interrupts.rst
+++ b/docs/user_manual/source/exceptions_interrupts.rst
@@ -75,11 +75,13 @@ Similarly an instruction fetch with a failing PMA check only leads to an instruc
 Non Maskable Interrupts
 -----------------------
 
-Non Maskable Interrupts (NMIs) update ``mepc``, ``mcause`` and ``mstatus`` similar to regular interrupts. However, as the faults that result in NMIs are imprecise, the contents of ``mepc`` is not guaranteed to point to the instruction after the faulted load or store.
+Non Maskable Interrupts (NMIs) update ``mepc``, ``mcause`` and ``mstatus`` similar to regular interrupts.
+However, as the faults that result in NMIs are imprecise, the contents of ``mepc`` is not guaranteed to point to the instruction after the faulted load or store.
+The ``minsttatus`` CSR (which exists only if ``CLIC`` == 1) is not impacted by NMIs.
 
 .. note::
 
-   (Unrecoverable) NMIs and regular interrupts have identical effects on the ``mstatus`` CSR". Specifically ``mstatus.mie`` will get cleared
+   (Unrecoverable) NMIs and regular interrupts have identical effects on the ``mstatus`` CSR. Specifically ``mstatus.mie`` will get cleared
    to 0 when an (unrecoverable) NMI is taken. [RISC-V-PRIV]_ does not specify the behavior of
    ``mstatus`` in response to NMIs, see https://github.com/riscv/riscv-isa-manual/issues/756. If this behavior is
    specified at a future date, then we will reconsider our implementation.

--- a/docs/user_manual/source/intro.rst
+++ b/docs/user_manual/source/intro.rst
@@ -45,8 +45,8 @@ It follows these specifications:
 .. [RISC-V-DEBUG] RISC-V Debug Support, version 1.0-STABLE, 246028cd719426597269b3d717c866802c58bde7,
    https://github.com/riscv/riscv-debug-spec/blob/05252da1575610e9605d882145da3f4e7f4f3cb1/riscv-debug-stable.pdf 
 
-.. [RISC-V-CLIC] Core-Local Interrupt Controller (CLIC) RISC-V Privileged Architecture Extensions, version 0.9-draft, 2/14/2023,
-   https://github.com/riscv/riscv-fast-interrupt/blob/a371ddda849a055932fa49fe58d1fee6d9063a3c/clic.pdf 
+.. [RISC-V-CLIC] Core-Local Interrupt Controller (CLIC) RISC-V Privileged Architecture Extensions, version 0.9-draft, 3/14/2023,
+   https://github.com/riscv/riscv-fast-interrupt/blob/550771f42b579776a37345894b9ca7e01e645555/clic.pdf 
 
 .. [RISC-V-ZBA_ZBB_ZBC_ZBS] RISC-V Bit Manipulation ISA-extensions, Version 1.0.0-38-g865e7a7, 2021-06-28,
    https://github.com/riscv/riscv-bitmanip/releases/download/1.0.0/bitmanip-1.0.0-38-g865e7a7.pdf


### PR DESCRIPTION
…at NMIs do not impact mintstatus.

Note that an mret instruction that lowers the privilege mode shall clear mintthresh to 0 now.