### PR TITLE
Misaligned pointer update.

### DIFF
--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -418,6 +418,7 @@ endgenerate
              .write_buffer_valid_o              ('0),
              .write_buffer_txn_bufferable       ('0),
              .write_buffer_txn_cacheable        ('0),
+             .obi_if_state                      (core_i.if_stage_i.instruction_obi_i.state_q),
              .*);
 
   bind cv32e40x_mpu:
@@ -444,6 +445,7 @@ endgenerate
              .write_buffer_valid_o              (core_i.load_store_unit_i.write_buffer_i.valid_o),
              .write_buffer_txn_bufferable       (core_i.load_store_unit_i.write_buffer_i.trans_o.memtype[0]),
              .write_buffer_txn_cacheable        (core_i.load_store_unit_i.write_buffer_i.trans_o.memtype[1]),
+             .obi_if_state                      (cv32e40x_pkg::TRANSPARENT),
              .*);
 
   bind cv32e40x_lsu_response_filter :

--- a/rtl/cv32e40x_align_check.sv
+++ b/rtl/cv32e40x_align_check.sv
@@ -41,7 +41,6 @@ module cv32e40x_align_check import cv32e40x_pkg::*;
    // Interface towards bus interface
    input  logic           bus_trans_ready_i,
    output logic           bus_trans_valid_o,
-   output logic           bus_trans_pushpop_o,
    output CORE_REQ_TYPE   bus_trans_o,
 
    input  logic           bus_resp_valid_i,
@@ -50,7 +49,6 @@ module cv32e40x_align_check import cv32e40x_pkg::*;
    // Interface towards core (MPU)
    input  logic           core_trans_valid_i,
    output logic           core_trans_ready_o,
-   input  logic           core_trans_pushpop_i,
    input  CORE_REQ_TYPE   core_trans_i,
 
    output logic           core_resp_valid_o,
@@ -156,7 +154,6 @@ module cv32e40x_align_check import cv32e40x_pkg::*;
   // Forward transaction request towards MPU
   assign bus_trans_valid_o   = core_trans_valid_i && !align_block_bus;
   assign bus_trans_o         = core_trans_i;
-  assign bus_trans_pushpop_o = core_trans_pushpop_i;
 
 
   // Forward transaction response towards core

--- a/rtl/cv32e40x_alignment_buffer.sv
+++ b/rtl/cv32e40x_alignment_buffer.sv
@@ -562,6 +562,11 @@ module cv32e40x_alignment_buffer import cv32e40x_pkg::*;
         if(instr_valid_o && instr_ready_i) begin
           addr_q <= addr_n;
           rptr   <= rptr_n;
+
+          // Clear pointer flags when pointers are consumed.
+          is_clic_ptr_q     <= 1'b0;
+          is_mret_ptr_q     <= 1'b0;
+          is_tbljmp_ptr_q   <= 1'b0;
         end
       end
 

--- a/rtl/cv32e40x_alignment_buffer.sv
+++ b/rtl/cv32e40x_alignment_buffer.sv
@@ -199,7 +199,7 @@ module cv32e40x_alignment_buffer import cv32e40x_pkg::*;
           mpu_status_unaligned = MPU_RE_FAULT;
         end
 
-        if((resp_q[rptr2].align_status != MPU_OK) || (resp_q[rptr].align_status != MPU_OK)) begin
+        if((resp_q[rptr2].align_status != ALIGN_OK) || (resp_q[rptr].align_status != ALIGN_OK)) begin
           align_status_unaligned = ALIGN_RE_ERR;
         end
 
@@ -224,7 +224,7 @@ module cv32e40x_alignment_buffer import cv32e40x_pkg::*;
             mpu_status_unaligned = MPU_RE_FAULT;
           end
 
-          if((resp_q[rptr].align_status != MPU_OK) || (resp_i.align_status != MPU_OK)) begin
+          if((resp_q[rptr].align_status != ALIGN_OK) || (resp_i.align_status != ALIGN_OK)) begin
             align_status_unaligned = ALIGN_RE_ERR;
           end
 

--- a/rtl/cv32e40x_alignment_buffer.sv
+++ b/rtl/cv32e40x_alignment_buffer.sv
@@ -270,14 +270,19 @@ module cv32e40x_alignment_buffer import cv32e40x_pkg::*;
       instr_instr_o.bus_resp.err   = bus_err_unaligned;
       instr_instr_o.mpu_status     = mpu_status_unaligned;
       instr_instr_o.align_status   = align_status_unaligned;
-      // No instruction valid
+
       if (!valid) begin
+        // No instruction valid
         instr_valid_o = 1'b0;
-      // Unaligned instruction is compressed, we only need 16 upper bits from index 0
+      end else if (instr_is_clic_ptr_o || instr_is_mret_ptr_o || instr_is_tbljmp_ptr_o) begin
+        // currently outputting a pointer, valid whenever the response arrives or we have
+        // the pointer within index 0 of the buffer.
+        instr_valid_o = valid;
       end else if (unaligned_is_compressed) begin
+        // Unaligned instruction is compressed, we only need 16 upper bits from index 0
         instr_valid_o = valid;
       end else begin
-      // Unaligned is not compressed, we need data from either index 0 and 1, or 0 and input
+        // Unaligned is not compressed, we need data from either index 0 and 1, or 0 and input
         instr_valid_o = valid_unaligned_uncompressed;
       end
     end else begin

--- a/rtl/cv32e40x_controller_bypass.sv
+++ b/rtl/cv32e40x_controller_bypass.sv
@@ -194,7 +194,7 @@ module cv32e40x_controller_bypass import cv32e40x_pkg::*;
     // Also deassert for trigger match, as with dcsr.timing==0 we do not execute before entering debug mode
     // CLIC pointer fetches go through the pipeline, but no write enables should be active.
     if (if_id_pipe_i.instr.bus_resp.err || !(if_id_pipe_i.instr.mpu_status == MPU_OK) || if_id_pipe_i.trigger_match ||
-        if_id_pipe_i.instr_meta.clic_ptr || if_id_pipe_i.instr_meta.mret_ptr) begin
+        if_id_pipe_i.instr_meta.clic_ptr || if_id_pipe_i.instr_meta.mret_ptr || !(if_id_pipe_i.instr.align_status == ALIGN_OK)) begin
       ctrl_byp_o.deassert_we = 1'b1;
     end
 

--- a/rtl/cv32e40x_controller_fsm.sv
+++ b/rtl/cv32e40x_controller_fsm.sv
@@ -1025,7 +1025,7 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
             end
           end else if (clic_ptr_in_id || mret_ptr_in_id) begin
             // todo e40s: Factor in integrity related errors
-            if (!(if_id_pipe_i.instr.bus_resp.err || (if_id_pipe_i.instr.mpu_status != MPU_OK))) begin // todo: add check for alignment check in IF (mret pointer)
+            if (!(if_id_pipe_i.instr.bus_resp.err || (if_id_pipe_i.instr.mpu_status != MPU_OK) || (if_id_pipe_i.instr.align_status != ALIGN_OK))) begin
               if (!branch_taken_q) begin
                 ctrl_fsm_o.pc_set = 1'b1;
                 ctrl_fsm_o.pc_mux = PC_POINTER;

--- a/rtl/cv32e40x_controller_fsm.sv
+++ b/rtl/cv32e40x_controller_fsm.sv
@@ -338,6 +338,7 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
   //   M      |   1     |      1     | Debug entry (restart from dm_halt_addr_i)
   //
   assign exception_in_wb = ((ex_wb_pipe_i.instr.mpu_status != MPU_OK)                                                      ||
+                            (ex_wb_pipe_i.instr.align_status != ALIGN_OK)                                                  ||
                              ex_wb_pipe_i.instr.bus_resp.err                                                               ||
                              ex_wb_pipe_i.illegal_insn                                                                     ||
                             (ex_wb_pipe_i.sys_en && ex_wb_pipe_i.sys_ecall_insn)                                           ||
@@ -349,7 +350,8 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
   assign ctrl_fsm_o.exception_in_wb = exception_in_wb;
 
   // Set exception cause
-  assign exception_cause_wb = (ex_wb_pipe_i.instr.mpu_status != MPU_OK)                                                      ? EXC_CAUSE_INSTR_FAULT      : // todo: add code from align_check in IF
+  assign exception_cause_wb = (ex_wb_pipe_i.instr.mpu_status != MPU_OK)                                                      ? EXC_CAUSE_INSTR_FAULT      :
+                              (ex_wb_pipe_i.instr.align_status != ALIGN_OK)                                                  ? EXC_CAUSE_INSTR_MISALIGNED :
                               ex_wb_pipe_i.instr.bus_resp.err                                                                ? EXC_CAUSE_INSTR_BUS_FAULT  :
                               ex_wb_pipe_i.illegal_insn                                                                      ? EXC_CAUSE_ILLEGAL_INSN     :
                               (ex_wb_pipe_i.sys_en && ex_wb_pipe_i.sys_ecall_insn)                                           ? EXC_CAUSE_ECALL_MMODE      :

--- a/rtl/cv32e40x_ex_stage.sv
+++ b/rtl/cv32e40x_ex_stage.sv
@@ -147,10 +147,11 @@ module cv32e40x_ex_stage import cv32e40x_pkg::*;
 
   // Exception happened during IF or ID, or trigger match in ID (converted to NOP).
   // signal needed for ex_valid to go high in such cases
-  assign previous_exception = (id_ex_pipe_i.illegal_insn                 ||
-                               id_ex_pipe_i.instr.bus_resp.err           ||
-                               (id_ex_pipe_i.instr.mpu_status != MPU_OK) ||
-                               id_ex_pipe_i.trigger_match)               &&
+  assign previous_exception = (id_ex_pipe_i.illegal_insn                     ||
+                               id_ex_pipe_i.instr.bus_resp.err               ||
+                               (id_ex_pipe_i.instr.mpu_status != MPU_OK)     ||
+                               (id_ex_pipe_i.instr.align_status != ALIGN_OK) ||
+                               id_ex_pipe_i.trigger_match)                   &&
                               id_ex_pipe_i.instr_valid;
 
   // ALU write port mux

--- a/rtl/cv32e40x_id_stage.sv
+++ b/rtl/cv32e40x_id_stage.sv
@@ -666,6 +666,7 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
           id_ex_pipe_o.instr.bus_resp.rdata <= {16'h0, if_id_pipe_i.compressed_instr};
           id_ex_pipe_o.instr.bus_resp.err   <= if_id_pipe_i.instr.bus_resp.err;
           id_ex_pipe_o.instr.mpu_status     <= if_id_pipe_i.instr.mpu_status;
+          id_ex_pipe_o.instr.align_status   <= if_id_pipe_i.instr.align_status;
         end else begin
           id_ex_pipe_o.instr                <= if_id_pipe_i.instr;
         end

--- a/rtl/cv32e40x_prefetch_unit.sv
+++ b/rtl/cv32e40x_prefetch_unit.sv
@@ -53,6 +53,7 @@ module cv32e40x_prefetch_unit import cv32e40x_pkg::*;
   output logic        trans_valid_o,
   input  logic        trans_ready_i,
   output logic [31:0] trans_addr_o,
+  output logic        trans_ptr_o,
 
   input  logic        resp_valid_i,
   input  inst_resp_t  resp_i,
@@ -99,7 +100,8 @@ module cv32e40x_prefetch_unit import cv32e40x_pkg::*;
     .fetch_priv_lvl_access_o  ( fetch_priv_lvl_resp  ),
     .trans_valid_o            ( trans_valid_o        ),
     .trans_ready_i            ( trans_ready_i        ),
-    .trans_addr_o             ( trans_addr_o         )
+    .trans_addr_o             ( trans_addr_o         ),
+    .trans_ptr_o              ( trans_ptr_o          )
   );
 
 

--- a/rtl/cv32e40x_prefetcher.sv
+++ b/rtl/cv32e40x_prefetcher.sv
@@ -58,9 +58,8 @@ module cv32e40x_prefetcher import cv32e40x_pkg::*;
   // Transaction request interface
   output logic                     trans_valid_o,           // Transaction request valid (to bus interface adapter)
   input  logic                     trans_ready_i,           // Transaction request ready (transaction gets accepted when trans_valid_o and trans_ready_i are both 1)
-  output logic [31:0]              trans_addr_o             // Transaction address (only valid when trans_valid_o = 1). No stability requirements.
-
-
+  output logic [31:0]              trans_addr_o,            // Transaction address (only valid when trans_valid_o = 1). No stability requirements.
+  output logic                     trans_ptr_o              // Transaction is fetching a pointer
 );
 
 
@@ -79,6 +78,8 @@ module cv32e40x_prefetcher import cv32e40x_pkg::*;
   // Alignment buffer controls number of outstanding transactions
   // and will always be ready to accept responses.
   assign trans_valid_o = fetch_valid_i;
+
+  assign trans_ptr_o = fetch_ptr_access_o;
 
   assign fetch_ready_o = trans_valid_o && trans_ready_i;
 

--- a/sva/cv32e40x_core_sva.sv
+++ b/sva/cv32e40x_core_sva.sv
@@ -214,7 +214,7 @@ always_ff @(posedge clk , negedge rst_ni)
         expected_ebrk_mepc <= ex_wb_pipe.pc;
       end
 
-      if (!first_instr_err_found && (ex_wb_pipe.instr.mpu_status == MPU_OK) && !irq_ack && !pending_debug &&
+      if (!first_instr_err_found && (ex_wb_pipe.instr.mpu_status == MPU_OK) && (ex_wb_pipe.instr.align_status == ALIGN_OK) && !irq_ack && !pending_debug &&
          !(ctrl_fsm.pc_mux == PC_TRAP_NMI) &&
           ex_wb_pipe.instr_valid && ex_wb_pipe.instr.bus_resp.err && !ctrl_debug_mode_n ) begin
         first_instr_err_found   <= 1'b1;

--- a/sva/cv32e40x_if_stage_sva.sv
+++ b/sva/cv32e40x_if_stage_sva.sv
@@ -148,6 +148,10 @@ module cv32e40x_if_stage_sva
                       (branch_addr_n[1:0] == 2'b00))
           else `uvm_error("if_stage", "Misaligned tablejump pointer")
 
+  // Once a pointer exits IF, there cannot be another pointer following it.
+  // A possible case could be a SHV CLIC pointer following a tablejump pointer, but
+  // such a scenario would contain at least one bubble since acking the interrupt
+  // would kill the pipeline and redirect the prefetcher to the CLIC table.
   a_no_ptr_after_ptr:
     assert property (@(posedge clk) disable iff (!rst_n)
                     (if_valid_o && id_ready_i) &&


### PR DESCRIPTION
Detecting misaligned pointers in the IF stage. Propagating alignment status down the pipeline and flagging exception code 0x0 if not ok.

Added assertions for checking that only mret pointers can cause misaligned instruction address exceptions. Added assertions to check that the alignment buffer only signal one valid for each pointer (currently failing), and that the alignment buffer must signal instr_valid_o if is not currently prefetching and the controller wants us to prefetch (currently failing).

The new and failing assertions will be addressed in a coming PR