### PR TITLE
Fix for issue #410 on cv32e40s

### DIFF
--- a/bhv/cv32e40x_rvfi.sv
+++ b/bhv/cv32e40x_rvfi.sv
@@ -83,7 +83,8 @@ module cv32e40x_rvfi
    input logic                                lsu_pma_atomic_ex_i,
    input pma_cfg_t                            lsu_pma_cfg_ex_i,
    input logic                                lsu_misaligned_ex_i,
-   input obi_data_req_t                       buffer_trans,
+   input obi_data_req_t                       buffer_trans_ex_i,
+   input logic                                buffer_trans_valid_ex_i,
    input logic                                lsu_split_q_ex_i,
 
    // WB probes
@@ -702,6 +703,7 @@ module cv32e40x_rvfi
 
   rvfi_obi_instr_t obi_instr_if;
   obi_data_req_t   lsu_data_trans;
+  logic            lsu_data_trans_valid;
 
   // Detect mret initiated CLIC pointer in WB
   logic         mret_ptr_wb;
@@ -751,10 +753,12 @@ module cv32e40x_rvfi
   cv32e40x_rvfi_data_obi
   rvfi_data_obi_i
   (
-    .clk                        ( clk_i          ),
-    .rst_n                      ( rst_ni         ),
-    .buffer_trans               ( buffer_trans   ),
-    .lsu_data_trans             ( lsu_data_trans )
+    .clk                        ( clk_i                   ),
+    .rst_n                      ( rst_ni                  ),
+    .buffer_trans_i             ( buffer_trans_ex_i       ),
+    .buffer_trans_valid_i       ( buffer_trans_valid_ex_i ),
+    .lsu_data_trans_o           ( lsu_data_trans          ),
+    .lsu_data_trans_valid_o     ( lsu_data_trans_valid    )
   );
 
 
@@ -1091,8 +1095,8 @@ module cv32e40x_rvfi
         rs2_addr   [STAGE_WB] <= rs2_addr           [STAGE_EX];
         rs1_rdata  [STAGE_WB] <= rs1_rdata          [STAGE_EX];
         rs2_rdata  [STAGE_WB] <= rs2_rdata          [STAGE_EX];
-        mem_rmask  [STAGE_WB] <= mem_rmask          [STAGE_EX];
-        mem_wmask  [STAGE_WB] <= mem_wmask          [STAGE_EX];
+        mem_rmask  [STAGE_WB] <= lsu_data_trans_valid ? mem_rmask[STAGE_EX] : '0;
+        mem_wmask  [STAGE_WB] <= lsu_data_trans_valid ? mem_wmask[STAGE_EX] : '0;
         in_trap    [STAGE_WB] <= in_trap            [STAGE_EX];
 
         rs1_addr_subop   [STAGE_WB] <= rs1_addr_subop [STAGE_EX];

--- a/bhv/cv32e40x_rvfi_data_obi.sv
+++ b/bhv/cv32e40x_rvfi_data_obi.sv
@@ -27,21 +27,26 @@ module cv32e40x_rvfi_data_obi import cv32e40x_pkg::*; import cv32e40x_rvfi_pkg::
 (
   input logic           clk,
   input logic           rst_n,
-  input obi_data_req_t  buffer_trans,
-  output obi_data_req_t lsu_data_trans
+  input obi_data_req_t  buffer_trans_i,
+  input logic           buffer_trans_valid_i,
+  output obi_data_req_t lsu_data_trans_o,
+  output logic          lsu_data_trans_valid_o
 );
 
   // Intermediate rotate signal, as direct part-select not supported in all tools
   logic [63:0] buffer_trans_wdata_ror;
 
   // Rotate right
-  assign buffer_trans_wdata_ror = {buffer_trans.wdata, buffer_trans.wdata} >> (8*buffer_trans.addr[1:0]);
+  assign buffer_trans_wdata_ror = {buffer_trans_i.wdata, buffer_trans_i.wdata} >> (8*buffer_trans_i.addr[1:0]);
+
+  // Feed valid through
+  assign lsu_data_trans_valid_o = buffer_trans_valid_i;
 
   always_comb begin
-    lsu_data_trans = buffer_trans;
+    lsu_data_trans_o = buffer_trans_i;
 
     // Align Memory write data
-    lsu_data_trans.wdata = buffer_trans_wdata_ror;
+    lsu_data_trans_o.wdata = buffer_trans_wdata_ror;
   end
 
 endmodule

--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -562,7 +562,8 @@ endgenerate
          .lsu_pma_atomic_ex_i      ( core_i.load_store_unit_i.mpu_i.pma_i.atomic_access_i                 ),
          .lsu_pma_cfg_ex_i         ( core_i.load_store_unit_i.mpu_i.pma_i.pma_cfg                         ),
          .lsu_misaligned_ex_i      ( core_i.load_store_unit_i.misaligned_access                           ),
-         .buffer_trans             ( core_i.load_store_unit_i.buffer_trans                                ),
+         .buffer_trans_ex_i        ( core_i.load_store_unit_i.buffer_trans                                ),
+         .buffer_trans_valid_ex_i  ( core_i.load_store_unit_i.buffer_trans_valid                          ),
          .lsu_split_q_ex_i         ( core_i.load_store_unit_i.split_q                                     ),
 
          // WB Probes


### PR DESCRIPTION
Only updating rvfi_mem_rmask and rvfi_mem_wmask if a transaction truly went into the write buffer (not blocked by WPT, MPU or alignment checker).

Fixes issue #410 on cv32e40s.