### PR TITLE
Fix for issue #414 on cv32e40s.

### DIFF
--- a/bhv/include/cv32e40x_rvfi_pkg.sv
+++ b/bhv/include/cv32e40x_rvfi_pkg.sv
@@ -118,6 +118,7 @@ package cv32e40x_rvfi_pkg;
   } rvfi_intr_t;
 
   typedef struct packed {
+    logic        clicptr;
     logic [1:0]  cause_type;
     logic [2:0]  debug_cause;
     logic [5:0]  exception_cause;


### PR DESCRIPTION
Signaling rvfi_valid + rvfi_trap.cliptr for faulted CLIC pointer fetches.

Fixes issue #414 on cv32e40s.