### PR TITLE
Removed todo from controller_fsm.

### DIFF
--- a/rtl/cv32e40x_controller_fsm.sv
+++ b/rtl/cv32e40x_controller_fsm.sv
@@ -315,7 +315,6 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
   assign mret_ptr_in_id = if_id_pipe_i.instr_valid && if_id_pipe_i.instr_meta.mret_ptr;
 
   // Note: RVFI does not use jump_taken_id (which is not in itself an issue); An assertion in id_stage_sva checks that the jump target remains stable;
-  // todo: Do we need a similar stability check for branches?
 
   // EX stage
   // Branch taken for valid branch instructions in EX with valid decision


### PR DESCRIPTION
"  // todo: Do we need a similar stability check for branches?".

Existing assertion "a_bch_target_stable" within cv32e40x_ex_stage_sva checks this.