### PR TITLE
Partial fix for issue #766

### DIFF
--- a/rtl/cv32e40x_cs_registers.sv
+++ b/rtl/cv32e40x_cs_registers.sv
@@ -659,30 +659,31 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
   always_comb
   begin
 
-    jvt_n         = csr_wdata_int & CSR_JVT_MASK;
+    jvt_n         = csr_next_value(csr_wdata_int, CSR_JVT_MASK, JVT_RESET_VAL);
     jvt_we        = 1'b0;
 
-    mscratch_n    = csr_wdata_int;
+    mscratch_n    = csr_next_value(csr_wdata_int, CSR_MSCRATCH_MASK, MSCRATCH_RESET_VAL);
     mscratch_we   = 1'b0;
 
-    mepc_n        = csr_wdata_int & CSR_MEPC_MASK;
+    mepc_n        = csr_next_value(csr_wdata_int, CSR_MEPC_MASK, MEPC_RESET_VAL);
     mepc_we       = 1'b0;
 
-    dpc_n         = csr_wdata_int & CSR_DPC_MASK;
+    dpc_n         = csr_next_value(csr_wdata_int, CSR_DPC_MASK, DPC_RESET_VAL);
     dpc_we        = 1'b0;
 
-    dcsr_n        = '{
-                      xdebugver : dcsr_rdata.xdebugver,
-                      ebreakm   : csr_wdata_int[15],
-                      ebreaku   : dcsr_ebreaku_resolve(dcsr_rdata.ebreaku, csr_wdata_int[DCSR_EBREAKU_BIT]),
-                      stepie    : csr_wdata_int[11],
-                      stopcount : csr_wdata_int[10],
-                      mprven    : dcsr_rdata.mprven,
-                      step      : csr_wdata_int[2],
-                      prv       : dcsr_prv_resolve(dcsr_rdata.prv, csr_wdata_int[DCSR_PRV_BIT_HIGH:DCSR_PRV_BIT_LOW]),
-                      cause     : dcsr_rdata.cause,
-                      default   : 'd0
-                     };
+    dcsr_n        = csr_next_value(dcsr_t'{
+                                            xdebugver : dcsr_rdata.xdebugver,
+                                            ebreakm   : csr_wdata_int[15],
+                                            ebreaku   : dcsr_ebreaku_resolve(dcsr_rdata.ebreaku, csr_wdata_int[DCSR_EBREAKU_BIT]),
+                                            stepie    : csr_wdata_int[11],
+                                            stopcount : csr_wdata_int[10],
+                                            mprven    : dcsr_rdata.mprven,
+                                            step      : csr_wdata_int[2],
+                                            prv       : dcsr_prv_resolve(dcsr_rdata.prv, csr_wdata_int[DCSR_PRV_BIT_HIGH:DCSR_PRV_BIT_LOW]),
+                                            cause     : dcsr_rdata.cause,
+                                            default   : 'd0
+                                          },
+                                    CSR_DCSR_MASK, DCSR_RESET_VAL);
     dcsr_we       = 1'b0;
 
     dscratch0_n   = csr_wdata_int;
@@ -1224,8 +1225,9 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
 
   cv32e40x_csr
   #(
-    .WIDTH      (32),
-    .RESETVALUE (32'd0)
+    .WIDTH      (32            ),
+    .MASK       (CSR_JVT_MASK  ),
+    .RESETVALUE (JVT_RESET_VAL )
   )
   jvt_csr_i
   (
@@ -1268,7 +1270,8 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
 
       cv32e40x_csr
       #(
-        .WIDTH      (32),
+        .WIDTH      (32            ),
+        .MASK       (CSR_DCSR_MASK ),
         .RESETVALUE (DCSR_RESET_VAL)
       )
       dcsr_csr_i
@@ -1282,8 +1285,9 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
 
       cv32e40x_csr
       #(
-        .WIDTH      (32),
-        .RESETVALUE (32'd0)
+        .WIDTH      (32           ),
+        .MASK       (CSR_DPC_MASK ),
+        .RESETVALUE (DPC_RESET_VAL)
       )
       dpc_csr_i
       (
@@ -1303,8 +1307,9 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
 
   cv32e40x_csr
   #(
-    .WIDTH      (32),
-    .RESETVALUE (32'd0)
+    .WIDTH      (32            ),
+    .MASK       (CSR_MEPC_MASK ),
+    .RESETVALUE (MEPC_RESET_VAL)
   )
   mepc_csr_i
   (
@@ -1317,8 +1322,9 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
 
   cv32e40x_csr
   #(
-    .WIDTH      (32),
-    .RESETVALUE (32'd0)
+    .WIDTH      (32                ),
+    .MASK       (CSR_MSCRATCH_MASK ),
+    .RESETVALUE (MSCRATCH_RESET_VAL)
   )
   mscratch_csr_i
   (

--- a/rtl/cv32e40x_csr.sv
+++ b/rtl/cv32e40x_csr.sv
@@ -9,7 +9,8 @@
 
 module cv32e40x_csr #(
     parameter int unsigned    WIDTH      = 32,
-    parameter bit [WIDTH-1:0] RESETVALUE = '0
+    parameter bit [WIDTH-1:0] RESETVALUE = '0,
+    parameter bit [WIDTH-1:0] MASK       = '1
  ) (
     input  logic             clk,
     input  logic             rst_n,
@@ -21,14 +22,26 @@ module cv32e40x_csr #(
 
   logic [WIDTH-1:0] rdata_q;
 
-  always_ff @(posedge clk or negedge rst_n) begin
-    if (!rst_n) begin
-      rdata_q <= RESETVALUE;
-    end else if (wr_en_i) begin
-      rdata_q <= wr_data_i;
-    end
-  end
+  generate
+    for (genvar i = 0; i < WIDTH; i++) begin : gen_csr
+      if (MASK[i]) begin : gen_unmasked
+        // Bits with mask set are actual flipflops
+        always_ff @(posedge clk or negedge rst_n) begin
+          if (!rst_n) begin
+            rdata_q[i] <= RESETVALUE[i];
+          end else if (wr_en_i) begin
+            rdata_q[i] <= wr_data_i[i];
+          end
+        end
+      end else begin : gen_masked
+        // Bits with mask cleared are tied off to the reset value
+        assign rdata_q[i] = RESETVALUE[i];
+      end
+    end // for
+  endgenerate
 
   assign rd_data_o = rdata_q;
+
+
 
 endmodule

--- a/rtl/include/cv32e40x_pkg.sv
+++ b/rtl/include/cv32e40x_pkg.sv
@@ -428,11 +428,12 @@ typedef enum logic[11:0] {
 } csr_num_e;
 
 // CSR Bit Implementation Masks
+// A mask bit of '1' means a flipflop is implemented.
 parameter CSR_JVT_MASK          = 32'hFFFFFFC0;
 parameter CSR_MEPC_MASK         = 32'hFFFFFFFE;
 parameter CSR_DPC_MASK          = 32'hFFFFFFFE;
 parameter CSR_MSCRATCH_MASK     = 32'hFFFFFFFF;
-parameter CSR_DCSR_MASK         = 32'b1111_0000_0000_0000_1000_1101_1100_0111; // NMI bit taken from ctrl_fsm
+parameter CSR_DCSR_MASK         = 32'b0000_0000_0000_0000_1000_1101_1100_0100; // NMI bit taken from ctrl_fsm
 
 // CSR operations
 

--- a/rtl/include/cv32e40x_pkg.sv
+++ b/rtl/include/cv32e40x_pkg.sv
@@ -432,7 +432,7 @@ parameter CSR_JVT_MASK          = 32'hFFFFFFC0;
 parameter CSR_MEPC_MASK         = 32'hFFFFFFFE;
 parameter CSR_DPC_MASK          = 32'hFFFFFFFE;
 parameter CSR_MSCRATCH_MASK     = 32'hFFFFFFFF;
-parameter CSR_DCSR_MASK         = 32'b1111_0000_0000_0000_1001_1101_1100_0111; // NMI bit taken from ctrl_fsm
+parameter CSR_DCSR_MASK         = 32'b1111_0000_0000_0000_1000_1101_1100_0111; // NMI bit taken from ctrl_fsm
 
 // CSR operations
 

--- a/rtl/include/cv32e40x_pkg.sv
+++ b/rtl/include/cv32e40x_pkg.sv
@@ -431,6 +431,8 @@ typedef enum logic[11:0] {
 parameter CSR_JVT_MASK          = 32'hFFFFFFC0;
 parameter CSR_MEPC_MASK         = 32'hFFFFFFFE;
 parameter CSR_DPC_MASK          = 32'hFFFFFFFE;
+parameter CSR_MSCRATCH_MASK     = 32'hFFFFFFFF;
+parameter CSR_DCSR_MASK         = 32'b1111_0000_0000_0000_1001_1101_1100_0111; // NMI bit taken from ctrl_fsm
 
 // CSR operations
 
@@ -659,6 +661,11 @@ parameter mcause_t MCAUSE_CLIC_RESET_VAL = '{
 
 parameter mcause_t MCAUSE_BASIC_RESET_VAL = '{
     default: 'b0};
+
+parameter JVT_RESET_VAL      = 32'd0;
+parameter MSCRATCH_RESET_VAL = 32'd0;
+parameter MEPC_RESET_VAL     = 32'd0;
+parameter DPC_RESET_VAL      = 32'd0;
 
 parameter logic [31:0] TDATA1_RST_VAL = {
   TTYPE_MCONTROL,        // type    : address/data match
@@ -1460,6 +1467,17 @@ typedef struct packed {
   );
     // mtvec.mode is WARL(0x3) in CLIC mode
     return 2'b11;
+  endfunction
+
+  // Function for setting next-value for CSRs
+  // Uses a mask and reset value to allow nom-implemented (no flipflop) bits to be either 0 or 1.
+  function automatic logic [31:0] csr_next_value
+  (
+      logic [31:0] wdata,
+      logic [31:0] mask,
+      logic [31:0] reset_value
+  );
+      return (wdata & mask) | (reset_value & ~mask);
   endfunction
   ///////////////////////////
   //                       //


### PR DESCRIPTION
- Changes CSR implementation to be identical to the unhardened version on cv32e40s
- Introduces MASK and RESET_VAL for all CSRs
- Use a function to compute next value for all next-value assignments

This should align X and S better, and allow for unimplemented bits in CSRs to be either 0 or 1.

Once this PR is approved, similar changes will be done for the remaining CSRs.

SEC clean.