### PR TITLE
Update to latest CLIC spec (Version 0.9-draft, 4/11/2023)

### DIFF
--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -174,7 +174,6 @@ module cv32e40x_wrapper
     core_i.if_stage_i cv32e40x_if_stage_sva #(.CLIC(CLIC)) if_stage_sva
     (
       .m_c_obi_instr_if (core_i.m_c_obi_instr_if), // SVA monitor modport cannot connect to a master modport
-      .align_err_i      (core_i.if_stage_i.align_check_i.align_err),
       .*
     );
 

--- a/rtl/cv32e40x_alignment_buffer.sv
+++ b/rtl/cv32e40x_alignment_buffer.sv
@@ -100,7 +100,6 @@ module cv32e40x_alignment_buffer import cv32e40x_pkg::*;
   // Error propagation signals for bus, mpu and alignment checker (pointers)
   logic bus_err_unaligned, bus_err;
   mpu_status_e mpu_status_unaligned, mpu_status;
-  align_status_e align_status_unaligned, align_status;
 
   // resp_valid gated while flushing
   logic resp_valid_gated;
@@ -167,7 +166,6 @@ module cv32e40x_alignment_buffer import cv32e40x_pkg::*;
   assign instr        = (valid_q[rptr]) ? resp_q[rptr].bus_resp.rdata : resp_i.bus_resp.rdata;
   assign bus_err      = (valid_q[rptr]) ? resp_q[rptr].bus_resp.err   : resp_i.bus_resp.err;
   assign mpu_status   = (valid_q[rptr]) ? resp_q[rptr].mpu_status     : resp_i.mpu_status;
-  assign align_status = (valid_q[rptr]) ? resp_q[rptr].align_status   : resp_i.align_status;
 
 
   // Unaligned instructions will either be split across index 0 and 1, or index 0 and incoming data
@@ -190,10 +188,9 @@ module cv32e40x_alignment_buffer import cv32e40x_pkg::*;
                                    !(instr_is_clic_ptr_o || instr_is_mret_ptr_o || instr_is_tbljmp_ptr_o);
 
 
-  // Set mpu_status, align_status and bus error for unaligned instructions
+  // Set mpu_status and bus error for unaligned instructions
   always_comb begin
     mpu_status_unaligned = MPU_OK;
-    align_status_unaligned = ALIGN_OK;
     bus_err_unaligned = 1'b0;
     // There is valid data in q1 (valid q0 is implied)
     if(valid_q[rptr2]) begin
@@ -204,17 +201,11 @@ module cv32e40x_alignment_buffer import cv32e40x_pkg::*;
           mpu_status_unaligned = MPU_RE_FAULT;
         end
 
-        if((resp_q[rptr2].align_status != ALIGN_OK) || (resp_q[rptr].align_status != ALIGN_OK)) begin
-          align_status_unaligned = ALIGN_RE_ERR;
-        end
-
         // Bus error from either entry
         bus_err_unaligned = (resp_q[rptr2].bus_resp.err || resp_q[rptr].bus_resp.err);
       end else begin
         // Compressed, use only mpu_status from q0
         mpu_status_unaligned = resp_q[rptr].mpu_status;
-
-        align_status_unaligned = resp_q[rptr].align_status;
 
         // bus error from q0
         bus_err_unaligned    = resp_q[rptr].bus_resp.err;
@@ -229,16 +220,12 @@ module cv32e40x_alignment_buffer import cv32e40x_pkg::*;
             mpu_status_unaligned = MPU_RE_FAULT;
           end
 
-          if((resp_q[rptr].align_status != ALIGN_OK) || (resp_i.align_status != ALIGN_OK)) begin
-            align_status_unaligned = ALIGN_RE_ERR;
-          end
-
           // Bus error from q0 and resp_i
           bus_err_unaligned = (resp_q[rptr].bus_resp.err || resp_i.bus_resp.err);
         end else begin
           // There is unaligned data in q0 and it is compressed
           mpu_status_unaligned = resp_q[rptr].mpu_status;
-          align_status_unaligned = resp_q[rptr].align_status;
+
           // Bus error from q0
           bus_err_unaligned = resp_q[rptr].bus_resp.err;
         end
@@ -246,7 +233,6 @@ module cv32e40x_alignment_buffer import cv32e40x_pkg::*;
         // There is no data in the buffer, use input
         mpu_status_unaligned   = resp_i.mpu_status;
         bus_err_unaligned      = resp_i.bus_resp.err;
-        align_status_unaligned = resp_i.align_status;
       end
     end
   end
@@ -258,7 +244,6 @@ module cv32e40x_alignment_buffer import cv32e40x_pkg::*;
     instr_instr_o.bus_resp.rdata = instr;
     instr_instr_o.bus_resp.err   = bus_err;
     instr_instr_o.mpu_status     = mpu_status;
-    instr_instr_o.align_status   = align_status;
     instr_valid_o = 1'b0;
 
     // Invalidate output if we get killed
@@ -269,7 +254,6 @@ module cv32e40x_alignment_buffer import cv32e40x_pkg::*;
       instr_instr_o.bus_resp.rdata = instr_unaligned;
       instr_instr_o.bus_resp.err   = bus_err_unaligned;
       instr_instr_o.mpu_status     = mpu_status_unaligned;
-      instr_instr_o.align_status   = align_status_unaligned;
 
       if (!valid) begin
         // No instruction valid

--- a/rtl/cv32e40x_controller_bypass.sv
+++ b/rtl/cv32e40x_controller_bypass.sv
@@ -194,7 +194,7 @@ module cv32e40x_controller_bypass import cv32e40x_pkg::*;
     // Also deassert for trigger match, as with dcsr.timing==0 we do not execute before entering debug mode
     // CLIC pointer fetches go through the pipeline, but no write enables should be active.
     if (if_id_pipe_i.instr.bus_resp.err || !(if_id_pipe_i.instr.mpu_status == MPU_OK) || if_id_pipe_i.trigger_match ||
-        if_id_pipe_i.instr_meta.clic_ptr || if_id_pipe_i.instr_meta.mret_ptr || !(if_id_pipe_i.instr.align_status == ALIGN_OK)) begin
+        if_id_pipe_i.instr_meta.clic_ptr || if_id_pipe_i.instr_meta.mret_ptr) begin
       ctrl_byp_o.deassert_we = 1'b1;
     end
 

--- a/rtl/cv32e40x_controller_fsm.sv
+++ b/rtl/cv32e40x_controller_fsm.sv
@@ -337,7 +337,6 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
   //   M      |   1     |      1     | Debug entry (restart from dm_halt_addr_i)
   //
   assign exception_in_wb = ((ex_wb_pipe_i.instr.mpu_status != MPU_OK)                                                      ||
-                            (ex_wb_pipe_i.instr.align_status != ALIGN_OK)                                                  ||
                              ex_wb_pipe_i.instr.bus_resp.err                                                               ||
                              ex_wb_pipe_i.illegal_insn                                                                     ||
                             (ex_wb_pipe_i.sys_en && ex_wb_pipe_i.sys_ecall_insn)                                           ||
@@ -350,7 +349,6 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
 
   // Set exception cause
   assign exception_cause_wb = (ex_wb_pipe_i.instr.mpu_status != MPU_OK)                                                      ? EXC_CAUSE_INSTR_FAULT      :
-                              (ex_wb_pipe_i.instr.align_status != ALIGN_OK)                                                  ? EXC_CAUSE_INSTR_MISALIGNED :
                               ex_wb_pipe_i.instr.bus_resp.err                                                                ? EXC_CAUSE_INSTR_BUS_FAULT  :
                               ex_wb_pipe_i.illegal_insn                                                                      ? EXC_CAUSE_ILLEGAL_INSN     :
                               (ex_wb_pipe_i.sys_en && ex_wb_pipe_i.sys_ecall_insn)                                           ? EXC_CAUSE_ECALL_MMODE      :
@@ -1029,7 +1027,7 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
               branch_taken_n = 1'b1;
             end
           end else if (clic_ptr_in_id || mret_ptr_in_id) begin
-            if (!(if_id_pipe_i.instr.bus_resp.err || (if_id_pipe_i.instr.mpu_status != MPU_OK) || (if_id_pipe_i.instr.align_status != ALIGN_OK))) begin
+            if (!(if_id_pipe_i.instr.bus_resp.err || (if_id_pipe_i.instr.mpu_status != MPU_OK))) begin
               if (!branch_taken_q) begin
                 ctrl_fsm_o.pc_set = 1'b1;
                 ctrl_fsm_o.pc_mux = PC_POINTER;

--- a/rtl/cv32e40x_cs_registers.sv
+++ b/rtl/cv32e40x_cs_registers.sv
@@ -1148,8 +1148,8 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
 
           // Mret to lower privilege mode clear mintthresh
           if (priv_lvl_n < PRIV_LVL_M) begin
-            mintthresh_n  <= 32'h00000000;
-            mintthresh_we <= 1'b1;
+            mintthresh_n  = 32'h00000000;
+            mintthresh_we = 1'b1;
           end
 
           if (ctrl_fsm_i.csr_restore_mret_ptr) begin
@@ -1176,8 +1176,8 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
 
           // Dret to lower privilege mode clear mintthresh
           if (priv_lvl_n < PRIV_LVL_M) begin
-            mintthresh_n  <= 32'h00000000;
-            mintthresh_we <= 1'b1;
+            mintthresh_n  = 32'h00000000;
+            mintthresh_we = 1'b1;
           end
         end
 

--- a/rtl/cv32e40x_cs_registers.sv
+++ b/rtl/cv32e40x_cs_registers.sv
@@ -1146,6 +1146,12 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
           mcause_n.mpie = mstatus_n.mpie;
           mcause_we = 1'b1;
 
+          // Mret to lower privilege mode clear mintthresh
+          if (priv_lvl_n < PRIV_LVL_M) begin
+            mintthresh_n  <= 32'h00000000;
+            mintthresh_we <= 1'b1;
+          end
+
           if (ctrl_fsm_i.csr_restore_mret_ptr) begin
             // Clear mcause.minhv if the mret also caused a successful CLIC pointer fetch
             mcause_n.minhv = 1'b0;
@@ -1167,6 +1173,12 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
           // Not really needed, but allows for asserting mstatus_we == mcause_we to check aliasing formally
           mcause_n       = mcause_rdata;
           mcause_we      = 1'b1;
+
+          // Dret to lower privilege mode clear mintthresh
+          if (priv_lvl_n < PRIV_LVL_M) begin
+            mintthresh_n  <= 32'h00000000;
+            mintthresh_we <= 1'b1;
+          end
         end
 
       end //ctrl_fsm_i.csr_restore_dret

--- a/rtl/cv32e40x_ex_stage.sv
+++ b/rtl/cv32e40x_ex_stage.sv
@@ -150,7 +150,6 @@ module cv32e40x_ex_stage import cv32e40x_pkg::*;
   assign previous_exception = (id_ex_pipe_i.illegal_insn                     ||
                                id_ex_pipe_i.instr.bus_resp.err               ||
                                (id_ex_pipe_i.instr.mpu_status != MPU_OK)     ||
-                               (id_ex_pipe_i.instr.align_status != ALIGN_OK) ||
                                id_ex_pipe_i.trigger_match)                   &&
                               id_ex_pipe_i.instr_valid;
 

--- a/rtl/cv32e40x_id_stage.sv
+++ b/rtl/cv32e40x_id_stage.sv
@@ -664,7 +664,6 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
           id_ex_pipe_o.instr.bus_resp.rdata <= {16'h0, if_id_pipe_i.compressed_instr};
           id_ex_pipe_o.instr.bus_resp.err   <= if_id_pipe_i.instr.bus_resp.err;
           id_ex_pipe_o.instr.mpu_status     <= if_id_pipe_i.instr.mpu_status;
-          id_ex_pipe_o.instr.align_status   <= if_id_pipe_i.instr.align_status;
         end else begin
           id_ex_pipe_o.instr                <= if_id_pipe_i.instr;
         end

--- a/rtl/cv32e40x_if_stage.sv
+++ b/rtl/cv32e40x_if_stage.sv
@@ -238,7 +238,7 @@ module cv32e40x_if_stage import cv32e40x_pkg::*;
     .A_EXT                ( A_EXT                       ),
     .CORE_REQ_TYPE        ( obi_inst_req_t              ),
     .CORE_RESP_TYPE       ( inst_resp_t                 ),
-    .BUS_RESP_TYPE        ( inst_resp_t                 ),
+    .BUS_RESP_TYPE        ( obi_inst_resp_t             ),
     .PMA_NUM_REGIONS      ( PMA_NUM_REGIONS             ),
     .PMA_CFG              ( PMA_CFG                     ),
     .DEBUG                ( DEBUG                       ),

--- a/rtl/cv32e40x_if_stage.sv
+++ b/rtl/cv32e40x_if_stage.sv
@@ -160,7 +160,9 @@ module cv32e40x_if_stage import cv32e40x_pkg::*;
       PC_BOOT:       branch_addr_n = {boot_addr_i[31:2], 2'b0};
       PC_JUMP:       branch_addr_n = jump_target_id_i;
       PC_BRANCH:     branch_addr_n = branch_target_ex_i;
-      PC_MRET:       branch_addr_n = mepc_i;                                                      // PC is restored when returning from IRQ/exception
+      // An mret that restarts a CLIC pointer fetch must make sure the address is aligned to XLEN/8.
+      // Clearing branch_addr_n[1] when an mepc is used as part of CLIC pointer fetch.
+      PC_MRET:       branch_addr_n = {mepc_i[31:2], (mepc_i[1] & !ctrl_fsm_i.pc_set_clicv), mepc_i[0]}; // PC is restored when returning from IRQ/exception
       PC_DRET:       branch_addr_n = dpc_i;
       PC_WB_PLUS4:   branch_addr_n = ctrl_fsm_i.pipe_pc;                                          // Jump to next instruction forces prefetch buffer reload
       PC_TRAP_EXC:   branch_addr_n = {mtvec_addr_i, 7'h0};                                        // All the exceptions go to base address

--- a/rtl/cv32e40x_if_stage.sv
+++ b/rtl/cv32e40x_if_stage.sv
@@ -129,15 +129,6 @@ module cv32e40x_if_stage import cv32e40x_pkg::*;
   obi_inst_req_t     bus_trans;
   obi_inst_req_t     core_trans;
 
-  logic              alcheck_resp_valid;
-  inst_resp_t        alcheck_resp;
-  logic              alcheck_trans_valid;
-  logic              alcheck_trans_ready;
-  obi_inst_req_t     alcheck_trans;
-
-  logic              align_check_en;
-  logic              address_misaligned;
-
   // Local instr_valid
   logic              instr_valid;
 
@@ -271,48 +262,13 @@ module cv32e40x_if_stage import cv32e40x_pkg::*;
     .core_resp_valid_o    ( prefetch_resp_valid         ),
     .core_resp_o          ( prefetch_inst_resp          ),
 
-    .bus_trans_valid_o    ( alcheck_trans_valid         ),
-    .bus_trans_ready_i    ( alcheck_trans_ready         ),
-    .bus_trans_o          ( alcheck_trans               ),
-    .bus_resp_valid_i     ( alcheck_resp_valid          ),
-    .bus_resp_i           ( alcheck_resp                )
+    .bus_trans_valid_o    ( bus_trans_valid             ),
+    .bus_trans_ready_i    ( bus_trans_ready             ),
+    .bus_trans_o          ( bus_trans                   ),
+    .bus_resp_valid_i     ( bus_resp_valid              ),
+    .bus_resp_i           ( bus_resp                    )
   );
 
-
-  assign align_check_en = prefetch_trans_ptr;
-  assign address_misaligned = |prefetch_trans_addr[1:0];
-
-  cv32e40x_align_check
-  #(
-    .IF_STAGE             ( 1                    ),
-    .CORE_RESP_TYPE       ( inst_resp_t          ),
-    .BUS_RESP_TYPE        ( obi_inst_resp_t      ),
-    .CORE_REQ_TYPE        ( obi_inst_req_t       )
-  )
-  align_check_i
-  (
-    .clk                  ( clk                     ),
-    .rst_n                ( rst_n                   ),
-    .align_check_en_i     ( align_check_en          ),
-    .misaligned_access_i  ( address_misaligned      ),
-
-    .core_one_txn_pend_n  ( prefetch_one_txn_pend_n ),
-    .core_align_err_wait_i( 1'b1                    ),
-    .core_align_err_o     (                         ), // Unconnected on purpose
-
-    .core_trans_valid_i   ( alcheck_trans_valid     ),
-    .core_trans_ready_o   ( alcheck_trans_ready     ),
-    .core_trans_i         ( alcheck_trans           ),
-    .core_resp_valid_o    ( alcheck_resp_valid      ),
-    .core_resp_o          ( alcheck_resp            ),
-
-    .bus_trans_valid_o    ( bus_trans_valid         ),
-    .bus_trans_ready_i    ( bus_trans_ready         ),
-    .bus_trans_o          ( bus_trans               ),
-    .bus_resp_valid_i     ( bus_resp_valid          ),
-    .bus_resp_i           ( bus_resp                )
-
-  );
 
   //////////////////////////////////////////////////////////////////////////////
   // OBI interface
@@ -380,8 +336,7 @@ module cv32e40x_if_stage import cv32e40x_pkg::*;
 
 
   // Set flag to indicate that instruction/sequence will be aborted due to known exceptions or trigger match
-  assign abort_op_o = instr_decompressed.bus_resp.err || (instr_decompressed.mpu_status != MPU_OK) ||
-                      (instr_decompressed.align_status != ALIGN_OK) || trigger_match_i;
+  assign abort_op_o = instr_decompressed.bus_resp.err || (instr_decompressed.mpu_status != MPU_OK) || trigger_match_i;
 
   // Signal current privilege level of IF
   assign priv_lvl_if_o = prefetch_priv_lvl;
@@ -446,7 +401,7 @@ module cv32e40x_if_stage import cv32e40x_pkg::*;
           // For mret pointers, the pointer address is only needed downstream if the pointer fetch fails.
           // If the pointer fetch is successful, the address of the mret (i.e. the previous PC) is needed.
           if(prefetch_is_mret_ptr ?
-             (instr_decompressed.bus_resp.err || (instr_decompressed.mpu_status != MPU_OK) || (instr_decompressed.align_status != ALIGN_OK)) :
+             (instr_decompressed.bus_resp.err || (instr_decompressed.mpu_status != MPU_OK)) :
              1'b1) begin
             if_id_pipe_o.pc                    <= pc_if_o;
           end
@@ -470,7 +425,6 @@ module cv32e40x_if_stage import cv32e40x_pkg::*;
           // Need to update bus error status and mpu status, but may omit the 32-bit instruction word
           if_id_pipe_o.instr.bus_resp.err <= instr_decompressed.bus_resp.err;
           if_id_pipe_o.instr.mpu_status   <= instr_decompressed.mpu_status;
-          if_id_pipe_o.instr.align_status <= instr_decompressed.align_status;
         end else begin
           // Regular instruction, update the whole instr field
           if_id_pipe_o.instr          <= seq_valid ? seq_instr : instr_decompressed;

--- a/rtl/cv32e40x_if_stage.sv
+++ b/rtl/cv32e40x_if_stage.sv
@@ -117,7 +117,6 @@ module cv32e40x_if_stage import cv32e40x_pkg::*;
   logic                       prefetch_trans_valid;
   logic                       prefetch_trans_ready;
   logic [31:0]                prefetch_trans_addr;
-  logic                       prefetch_trans_ptr;
   inst_resp_t                 prefetch_inst_resp;
   logic                       prefetch_one_txn_pend_n;
   logic [ALBUF_CNT_WIDTH-1:0] prefetch_outstnd_cnt_q;
@@ -211,7 +210,6 @@ module cv32e40x_if_stage import cv32e40x_pkg::*;
     .trans_valid_o            ( prefetch_trans_valid        ),
     .trans_ready_i            ( prefetch_trans_ready        ),
     .trans_addr_o             ( prefetch_trans_addr         ),
-    .trans_ptr_o              ( prefetch_trans_ptr          ),
 
     .resp_valid_i             ( prefetch_resp_valid         ),
     .resp_i                   ( prefetch_inst_resp          ),

--- a/rtl/cv32e40x_mpu.sv
+++ b/rtl/cv32e40x_mpu.sv
@@ -176,9 +176,8 @@ module cv32e40x_mpu import cv32e40x_pkg::*;
 
   // Forward transaction response towards core
   assign core_resp_valid_o      = bus_resp_valid_i || mpu_err_trans_valid;
-  assign core_resp_o.bus_resp   = bus_resp_i.bus_resp;
   assign core_resp_o.mpu_status = mpu_status;
-  assign core_resp_o.align_status = bus_resp_i.align_status;
+
 
   // Report MPU errors to the core immediately
   assign core_mpu_err_o = mpu_err;
@@ -213,15 +212,18 @@ module cv32e40x_mpu import cv32e40x_pkg::*;
   // Tie to 1'b0 if this MPU is instantiatied in the IF stage
   generate
     if (IF_STAGE) begin: mpu_if
-      assign instr_fetch_access = 1'b1;
-      assign load_access        = 1'b0;
-      assign core_trans_we      = 1'b0;
+      assign instr_fetch_access     = 1'b1;
+      assign load_access            = 1'b0;
+      assign core_trans_we          = 1'b0;
+      assign core_resp_o.bus_resp   = bus_resp_i;
     end
     else begin: mpu_lsu
-      assign instr_fetch_access    = 1'b0;
-      assign load_access           = !core_trans_i.we;
-      assign core_trans_we         = core_trans_i.we;
-      assign core_resp_o.wpt_match = 1'b0; // Will be set by upstream wpt-module within load_store_unit
+      assign instr_fetch_access       = 1'b0;
+      assign load_access              = !core_trans_i.we;
+      assign core_trans_we            = core_trans_i.we;
+      assign core_resp_o.wpt_match    = 1'b0; // Will be set by upstream wpt-module within load_store_unit
+      assign core_resp_o.align_status = bus_resp_i.align_status;
+      assign core_resp_o.bus_resp     = bus_resp_i.bus_resp;
     end
   endgenerate
 

--- a/rtl/cv32e40x_prefetch_unit.sv
+++ b/rtl/cv32e40x_prefetch_unit.sv
@@ -53,7 +53,6 @@ module cv32e40x_prefetch_unit import cv32e40x_pkg::*;
   output logic        trans_valid_o,
   input  logic        trans_ready_i,
   output logic [31:0] trans_addr_o,
-  output logic        trans_ptr_o,
 
   input  logic        resp_valid_i,
   input  inst_resp_t  resp_i,
@@ -100,8 +99,7 @@ module cv32e40x_prefetch_unit import cv32e40x_pkg::*;
     .fetch_priv_lvl_access_o  ( fetch_priv_lvl_resp  ),
     .trans_valid_o            ( trans_valid_o        ),
     .trans_ready_i            ( trans_ready_i        ),
-    .trans_addr_o             ( trans_addr_o         ),
-    .trans_ptr_o              ( trans_ptr_o          )
+    .trans_addr_o             ( trans_addr_o         )
   );
 
 

--- a/rtl/cv32e40x_prefetcher.sv
+++ b/rtl/cv32e40x_prefetcher.sv
@@ -58,8 +58,7 @@ module cv32e40x_prefetcher import cv32e40x_pkg::*;
   // Transaction request interface
   output logic                     trans_valid_o,           // Transaction request valid (to bus interface adapter)
   input  logic                     trans_ready_i,           // Transaction request ready (transaction gets accepted when trans_valid_o and trans_ready_i are both 1)
-  output logic [31:0]              trans_addr_o,            // Transaction address (only valid when trans_valid_o = 1). No stability requirements.
-  output logic                     trans_ptr_o              // Transaction is fetching a pointer
+  output logic [31:0]              trans_addr_o             // Transaction address (only valid when trans_valid_o = 1). No stability requirements.
 );
 
 
@@ -78,8 +77,6 @@ module cv32e40x_prefetcher import cv32e40x_pkg::*;
   // Alignment buffer controls number of outstanding transactions
   // and will always be ready to accept responses.
   assign trans_valid_o = fetch_valid_i;
-
-  assign trans_ptr_o = fetch_ptr_access_o;
 
   assign fetch_ready_o = trans_valid_o && trans_ready_i;
 

--- a/rtl/include/cv32e40x_pkg.sv
+++ b/rtl/include/cv32e40x_pkg.sv
@@ -909,7 +909,6 @@ typedef enum logic[3:0] {
 } pc_mux_e;
 
 // Exception Cause
-parameter EXC_CAUSE_INSTR_MISALIGNED = 11'h00;
 parameter EXC_CAUSE_INSTR_FAULT      = 11'h01;
 parameter EXC_CAUSE_ILLEGAL_INSN     = 11'h02;
 parameter EXC_CAUSE_BREAKPOINT       = 11'h03;
@@ -983,7 +982,7 @@ typedef enum logic [1:0] {
 
 typedef enum logic [2:0] {MPU_IDLE, MPU_RE_ERR_RESP, MPU_RE_ERR_WAIT, MPU_WR_ERR_RESP, MPU_WR_ERR_WAIT} mpu_state_e;
 
-// ALIGN status. Used when checking alignment for atomics and mret pointers
+// ALIGN status. Used when checking alignment for atomics
 typedef enum logic [1:0] {
                           ALIGN_OK         = 2'h0,
                           ALIGN_RE_ERR     = 2'h1,
@@ -1047,7 +1046,6 @@ typedef struct packed {
 typedef struct packed {
  obi_inst_resp_t             bus_resp;
  mpu_status_e                mpu_status;
- align_status_e              align_status;   // Alignment status (for mret pointers)
 } inst_resp_t;
 
 // Reset value for the inst_resp_t type
@@ -1055,9 +1053,7 @@ parameter inst_resp_t INST_RESP_RESET_VAL = '{
   // Setting rdata[1:0] to 2'b11 to easily assert that all
   // instructions in ID are uncompressed
   bus_resp     : '{rdata: 32'h3, err: 1'b0},
-  mpu_status   : MPU_OK,
-  align_status : ALIGN_OK
-
+  mpu_status   : MPU_OK
 };
 
 // Reset value for the obi_inst_req_t type

--- a/sva/cv32e40x_controller_fsm_sva.sv
+++ b/sva/cv32e40x_controller_fsm_sva.sv
@@ -639,16 +639,6 @@ if (CLIC) begin
                   $stable(mintstatus_i))
     else `uvm_error("controller", "mintstatus changed after taking an NMI")
 
-  // The only possible cause for a instruction misaligned exception is an mret pointer.
-  a_mret_ptr_exception:
-  assert property (@(posedge clk) disable iff (!rst_n)
-                  (exception_cause_wb == EXC_CAUSE_INSTR_MISALIGNED) &&
-                  exception_in_wb
-                  |->
-                  mret_ptr_in_wb)
-
-    else `uvm_error("controller", "Instruction address misaligned exception without mret pointer.")
-
 end else begin // CLIC
   // Check that CLIC related signals are inactive when CLIC is not configured.
   a_clic_inactive:

--- a/sva/cv32e40x_core_sva.sv
+++ b/sva/cv32e40x_core_sva.sv
@@ -214,7 +214,7 @@ always_ff @(posedge clk , negedge rst_ni)
         expected_ebrk_mepc <= ex_wb_pipe.pc;
       end
 
-      if (!first_instr_err_found && (ex_wb_pipe.instr.mpu_status == MPU_OK) && (ex_wb_pipe.instr.align_status == ALIGN_OK) && !irq_ack && !pending_debug &&
+      if (!first_instr_err_found && (ex_wb_pipe.instr.mpu_status == MPU_OK) &&!irq_ack && !pending_debug &&
          !(ctrl_fsm.pc_mux == PC_TRAP_NMI) &&
           ex_wb_pipe.instr_valid && ex_wb_pipe.instr.bus_resp.err && !ctrl_debug_mode_n ) begin
         first_instr_err_found   <= 1'b1;

--- a/sva/cv32e40x_if_stage_sva.sv
+++ b/sva/cv32e40x_if_stage_sva.sv
@@ -42,8 +42,6 @@ module cv32e40x_if_stage_sva
   input  logic          prefetch_is_clic_ptr,
   input  logic          prefetch_is_mret_ptr,
   input  logic [31:0]   branch_addr_n,
-  input  logic          align_err_i,
-  input  logic          alcheck_trans_valid,
   input  logic          id_ready_i,
   input  logic          ptr_in_if_o
 );
@@ -112,31 +110,11 @@ module cv32e40x_if_stage_sva
     a_aligned_mret_ptr:
       assert property (@(posedge clk) disable iff (!rst_n)
                       (ctrl_fsm_i.pc_set_clicv) &&
-                      (ctrl_fsm_i.pc_mux == PC_MRET) &&
-                      (branch_addr_n[1:0] != 2'b00)
+                      (ctrl_fsm_i.pc_mux == PC_MRET)
                       |->
-                      align_err_i
-                      )
-          else `uvm_error("if_stage", "Misaligned mret pointer not flagged with error")
+                      (branch_addr_n[1:0] != 2'b00))
+          else `uvm_error("if_stage", "Misaligned mret pointer")
 
-    // Aligned errors may only happen for mret pointers that are not otherwise blocked by the MPU
-    a_aligned_err_mret_ptr:
-      assert property (@(posedge clk) disable iff (!rst_n)
-                      align_err_i &&            // Alignment error flagged
-                      alcheck_trans_valid       // Transaction not blocked by MPU
-                      |->
-                      ((ctrl_fsm_i.pc_set_clicv) &&     // We have a pc_set for an mret pointer this cycle
-                      (ctrl_fsm_i.pc_mux == PC_MRET))
-                      or
-                      prefetch_is_mret_ptr)             // Or the trans_valid comes after the pc_set and an mret pointer is flagged
-          else `uvm_error("if_stage", "Alignment error withouth mret pointer")
-  end else begin
-
-    // Without CLIC support there shall never be an aligned error in the IF stage.
-    a_no_align_err:
-      assert property (@(posedge clk) disable iff (!rst_n)
-                      !align_err_i)
-          else `uvm_error("if_stage", "Alignment error withouth CLIC support.")
   end
 
   // Tablejump pointer shall always be aligned

--- a/sva/cv32e40x_if_stage_sva.sv
+++ b/sva/cv32e40x_if_stage_sva.sv
@@ -112,7 +112,7 @@ module cv32e40x_if_stage_sva
                       (ctrl_fsm_i.pc_set_clicv) &&
                       (ctrl_fsm_i.pc_mux == PC_MRET)
                       |->
-                      (branch_addr_n[1:0] != 2'b00))
+                      (branch_addr_n[1:0] == 2'b00))
           else `uvm_error("if_stage", "Misaligned mret pointer")
 
   end


### PR DESCRIPTION
- Removed alignment check from IF stage
- Removed exception code 0 (instruction address misaligned)
- Clearing mintthresh on mret into lower privilege
- Clearing mintthresh on dret into user mode
- Enforcing XLEN/8 alignment on pointer address when performing mret when mcause.minhv==1