### PR TITLE
Update jvt settings csr.yaml.m4

### DIFF
--- a/yaml/csr.yaml.m4
+++ b/yaml/csr.yaml.m4
@@ -4667,22 +4667,13 @@ ifelse(eval(ZC != 0), 1, [[[
   address: 0x017
   privilege_mode: U
   rv32:
-    - field_name: Base_31_10
+    - field_name: Base_31_6
       description: >
-        Upper bits of vector table base address, 1024 byte aligned
+        Table Jump Base Address, 64 byte aligned
       type: WARL
       reset_val: 0
       msb: 31
-      lsb: 10
-    - field_name: Base_9_6
-      description: >
-        Lower bits of vector table base address, 1024 byte aligned always 0
-      type: WARL
-      reset_val: 0
-      msb: 9
       lsb: 6
-      warl_legalize: |
-        val_out = val_in if val_in == 0 else val_orig
     - field_name: Mode
       description: >
         Jump table mode


### PR DESCRIPTION
Description:

Jvt setting has changed, and is now the following:
![image](https://github.com/openhwgroup/cv32e40s/assets/110398284/a68b37b3-1fd4-4780-8941-ee4730835718)

This PR updates the yaml file accordingly. 

This PR is related to another PR in the verif repo: https://github.com/openhwgroup/core-v-verif/pull/1894
(This PR is "moved" from the cv32e40s repo. See: https://github.com/openhwgroup/cv32e40s/pull/453)