### PR TITLE
Removed parameter CLIC_INTTHRESHBITS from the user manual.

### DIFF
--- a/docs/user_manual/source/control_status_registers.rst
+++ b/docs/user_manual/source/control_status_registers.rst
@@ -1321,11 +1321,6 @@ Detailed:
 
 This register holds the machine mode interrupt level threshold.
 
-.. note::
-  The ``CLIC_INTTHRESHBITS`` parameter specifies the number of bits actually implemented in the ``mintthresh.th`` field.
-  The implemented bits are kept left justified in the most-significant bits of the 8-bit field, with the lower unimplemented
-  bits treated as hardwired to 1.
-
 .. _csr-mscratchcsw:
 
 Machine Scratch Swap for Priv Mode Change (``mscratchcsw``)

--- a/docs/user_manual/source/integration.rst
+++ b/docs/user_manual/source/integration.rst
@@ -33,8 +33,7 @@ Instantiation Template
       .PMA_NUM_REGIONS            (            1 ),
       .PMA_CFG                    (    PMA_CFG[] ),
       .CLIC                       (            0 ),
-      .CLIC_ID_WIDTH              (            5 ),
-      .CLIC_INTTHRESHBITS         (            8 )
+      .CLIC_ID_WIDTH              (            5 )
   ) u_core (
       // Clock and reset
       .clk_i                    (),
@@ -195,8 +194,6 @@ Parameters
   |                                |                         |               | number of supported interrupts in CLIC mode is                     |
   |                                |                         |               | ``2^CLIC_ID_WIDTH``. Trap vector table alignment is restricted     |
   |                                |                         |               | as described in :ref:`csr-mtvt`.                                   |
-  +--------------------------------+-------------------------+---------------+--------------------------------------------------------------------+
-  | ``CLIC_INTTHRESHBITS``         | int unsigned (1..8)     | 8             | Number of bits actually implemented in ``mintthresh.th`` field.    |
   +--------------------------------+-------------------------+---------------+--------------------------------------------------------------------+
 
 Interfaces


### PR DESCRIPTION
mintthresh.th is now always 8 bits wide