### PR TITLE
Dret to lower privilege mode no longer clears mintthresh.

### DIFF
--- a/rtl/cv32e40x_clic_int_controller.sv
+++ b/rtl/cv32e40x_clic_int_controller.sv
@@ -51,7 +51,7 @@ module cv32e40x_clic_int_controller import cv32e40x_pkg::*;
 
   // From cs_registers
   input  mstatus_t                   mstatus_i,                 // Current mstatus from CSR
-  input  logic [7:0]                 mintthresh_i,              // Current interrupt threshold from CSR
+  input  logic [7:0]                 mintthresh_th_i,           // Current interrupt threshold from CSR
   input  mintstatus_t                mintstatus_i,              // Current mintstatus from CSR
   input  mcause_t                    mcause_i,                  // Current mcause from CSR
   input  privlvl_t                   priv_lvl_i,                // Current privilege level of core
@@ -112,7 +112,7 @@ module cv32e40x_clic_int_controller import cv32e40x_pkg::*;
   //
   // The interrupt-level threshold is only valid when running in the associated privilege mode.
 
-  assign effective_irq_level = (mintthresh_i > mintstatus_i.mil) ? mintthresh_i : mintstatus_i.mil;
+  assign effective_irq_level = (mintthresh_th_i > mintstatus_i.mil) ? mintthresh_th_i : mintstatus_i.mil;
 
   ///////////////////////////
   // Outputs to controller //
@@ -154,7 +154,7 @@ module cv32e40x_clic_int_controller import cv32e40x_pkg::*;
   // The mxnti path to interrupts does not take mstatus.mie or dcsr.stepie into account.
   assign mnxti_irq_pending_o = clic_irq_q &&
     (clic_irq_level_q > mcause_i.mpil) &&
-    (clic_irq_level_q > mintthresh_i)  &&
+    (clic_irq_level_q > mintthresh_th_i)  &&
     !clic_irq_shv_q;
 
   // If mnxti_irq_pending is true, the currently flopped ID and level will be sent to cs_registers

--- a/rtl/cv32e40x_core.sv
+++ b/rtl/cv32e40x_core.sv
@@ -232,7 +232,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
 
   logic [MTVT_ADDR_WIDTH-1:0] mtvt_addr;
 
-  logic [7:0]  mintthresh;
+  logic [7:0]  mintthresh_th;
   mintstatus_t mintstatus;
 
   mcause_t     mcause;
@@ -827,7 +827,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .mepc_o                     ( mepc                   ),
     .mie_o                      ( mie                    ),
     .mintstatus_o               ( mintstatus             ),
-    .mintthresh_o               ( mintthresh             ),
+    .mintthresh_th_o            ( mintthresh_th          ),
     .mstatus_o                  ( mstatus                ),
     .mtvec_addr_o               ( mtvec_addr             ),
     .mtvec_mode_o               ( mtvec_mode             ),
@@ -1048,7 +1048,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
 
         // From cs_registers
         .mstatus_i            ( mstatus            ),
-        .mintthresh_i         ( mintthresh         ),
+        .mintthresh_th_i      ( mintthresh_th      ),
         .mintstatus_i         ( mintstatus         ),
         .mcause_i             ( mcause             ),
         .priv_lvl_i           ( priv_lvl           ),

--- a/rtl/cv32e40x_cs_registers.sv
+++ b/rtl/cv32e40x_cs_registers.sv
@@ -64,7 +64,7 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
   output logic [31:0]                   mepc_o,
   output logic [31:0]                   mie_o,
   output mintstatus_t                   mintstatus_o,
-  output logic [7:0]                    mintthresh_o,
+  output logic [7:0]                    mintthresh_th_o,
   output mstatus_t                      mstatus_o,
   output logic [24:0]                   mtvec_addr_o,
   output logic  [1:0]                   mtvec_mode_o,
@@ -1140,11 +1140,7 @@ dcsr_we        = 1'b1;
           mcause_n       = mcause_rdata;
           mcause_we      = 1'b1;
 
-          // Dret to lower privilege mode clear mintthresh
-          if (priv_lvl_n < PRIV_LVL_M) begin
-            mintthresh_n  = 32'h00000000;
-            mintthresh_we = 1'b1;
-          end
+          // Dret to lower privilege mode does not clear mintthresh
         end
 
       end //ctrl_fsm_i.csr_restore_dret
@@ -1555,7 +1551,7 @@ dcsr_we        = 1'b1;
   assign mepc_o        = mepc_rdata;
   assign mie_o         = mie_rdata;
   assign mintstatus_o  = mintstatus_rdata;
-  assign mintthresh_o  = mintthresh_rdata[7:0];
+  assign mintthresh_th_o  = mintthresh_rdata[7:0];
   assign mstatus_o     = mstatus_rdata;
   assign mtvec_addr_o  = mtvec_rdata.addr;
   assign mtvec_mode_o  = mtvec_rdata.mode;


### PR DESCRIPTION
Renamed mintthres_o to mintthresh_th_o in cs_registers.