### PR TITLE
Todo removal: Bus errors in LSU

### DIFF
--- a/rtl/cv32e40x_core.sv
+++ b/rtl/cv32e40x_core.sv
@@ -383,7 +383,8 @@ module cv32e40x_core import cv32e40x_pkg::*;
   assign m_c_obi_data_if.s_gnt.gnt           = data_gnt_i;
   assign m_c_obi_data_if.s_rvalid.rvalid     = data_rvalid_i;
   assign m_c_obi_data_if.resp_payload.rdata  = data_rdata_i;
-  assign m_c_obi_data_if.resp_payload.err    = data_err_i;
+  assign m_c_obi_data_if.resp_payload.err[0] = data_err_i;
+  assign m_c_obi_data_if.resp_payload.err[1] = 1'b0; // Will be assigned in the response filter
   assign m_c_obi_data_if.resp_payload.exokay = data_exokay_i;
 
   assign debug_havereset_o = ctrl_fsm.debug_havereset;

--- a/rtl/cv32e40x_load_store_unit.sv
+++ b/rtl/cv32e40x_load_store_unit.sv
@@ -146,7 +146,6 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
   obi_data_req_t  filter_trans;
   logic           filter_resp_valid;
   obi_data_resp_t filter_resp;
-  logic [1:0]     filter_err;
 
   // Transaction request (from cv32e40x_write_buffer to cv32e40x_data_obi_interface)
   logic           bus_trans_valid;
@@ -692,8 +691,7 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
 
   // Validate bus_error on rvalid from the bus (WB stage)
   // For bufferable transfers, this can happen many cycles after the pipeline control logic has seen the filtered resp_valid
-  // Todo: This bypasses the MPU, could be merged with mpu_status_e and passed through the MPU instead
-  assign lsu_err_1_o = xif_res_q ? '0 : filter_err;
+  assign lsu_err_1_o = xif_res_q ? '0 : resp.bus_resp.err;
 
   //////////////////////////////////////////////////////////////////////////////
   // WPT
@@ -869,7 +867,6 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
        .trans_i      ( filter_trans       ),
        .resp_valid_o ( filter_resp_valid  ),
        .resp_o       ( filter_resp        ),
-       .err_o        ( filter_err         ),
 
        .valid_o      ( buffer_trans_valid ),
        .ready_i      ( buffer_trans_ready ),
@@ -939,7 +936,7 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
       // XIF memory result
       assign xif_mem_result_if.mem_result.id    = xif_id_q;
       assign xif_mem_result_if.mem_result.rdata = rdata_ext;
-      assign xif_mem_result_if.mem_result.err   = filter_err[0]; // forward bus errors to coprocessor
+      assign xif_mem_result_if.mem_result.err   = resp.bus_resp.err[0]; // forward bus errors to coprocessor
       assign xif_mem_result_if.mem_result.dbg   = '0;            // TODO:XIF forward debug triggers
     end else begin : no_x_ext
       assign xif_mem_if.mem_resp.exc            = '0;

--- a/rtl/cv32e40x_lsu_response_filter.sv
+++ b/rtl/cv32e40x_lsu_response_filter.sv
@@ -54,12 +54,8 @@ module cv32e40x_lsu_response_filter
    output logic           busy_o,
    output logic           bus_busy_o,      // There are outstanding transactions on the bus side.
    output logic           resp_valid_o,
-   output obi_data_resp_t resp_o, // Todo: This also carries the obi error field. Could replace by data_resp_t
-
-   // Todo: This error signal could be merged with mpu_status_e, and be signaled via the resp_o above (if replaced by data_resp_t).
-   //       This would make the error flow all the way through the MPU and not bypass the MPU as it does now.
-   output logic [1:0]     err_o  // bit0: flag for error, bit1: type (1 for store, 0 for load)
-   );
+   output obi_data_resp_t resp_o
+);
 
   localparam CNT_WIDTH = $clog2(DEPTH+1);
 
@@ -169,10 +165,9 @@ module cv32e40x_lsu_response_filter
   assign resp_valid_o = (bus_resp_is_bufferable) ? core_resp_is_bufferable : resp_valid_i;
   assign trans_o      = trans_i;
 
-  assign err_o[0] = resp_valid_i && resp_i.err;
-  assign err_o[1] = outstanding_q[bus_cnt_q].store;
-
   // bus_resp goes straight through
-  assign resp_o = resp_i;
+  assign resp_o.rdata  = resp_i.rdata;
+  assign resp_o.err    = {outstanding_q[bus_cnt_q].store, (resp_valid_i && resp_i.err[0])};
+  assign resp_o.exokay = resp_i.exokay;
 
 endmodule

--- a/rtl/include/cv32e40x_pkg.sv
+++ b/rtl/include/cv32e40x_pkg.sv
@@ -1053,7 +1053,7 @@ typedef struct packed {
 
 typedef struct packed {
   logic [DATA_DATA_WIDTH-1:0] rdata;
-  logic                       err;
+  logic [1:0]                 err; // bit0: Error from bus, bit1: 0 for load, 1 for store
   logic                       exokay;
 } obi_data_resp_t;
 


### PR DESCRIPTION
Routing bus errors in LSU all the way through MPU, not outputting it from the response filter.

SEC clean with assumes for correct OBI protocol.