### PR TITLE
Corrections

### DIFF
--- a/bhv/cv32e40x_rvfi.sv
+++ b/bhv/cv32e40x_rvfi.sv
@@ -840,7 +840,7 @@ module cv32e40x_rvfi
       // Indicate that the trap is a synchronous trap into debug mode
       rvfi_trap_next.debug       = 1'b1;
       // Special case for debug entry from debug mode caused by EBREAK as it is not captured by ctrl_fsm_i.debug_cause
-      rvfi_trap_next.debug_cause = ebreak_in_wb_i ? DBG_CAUSE_EBREAK : ctrl_fsm_i.debug_cause;
+      rvfi_trap_next.debug_cause = (ebreak_in_wb_i && debug_mode_q_i) ? DBG_CAUSE_EBREAK : ctrl_fsm_i.debug_cause;
     end
 
     if (pc_mux_exception) begin
@@ -1049,7 +1049,7 @@ module cv32e40x_rvfi
           // Debug cause input only valid during debug taken
           // Special case for debug entry from debug mode caused by EBREAK as it is not captured by ctrl_fsm_i.debug_cause
           // A higher priority debug request (e.g. trigger match) will pull ebreak_in_wb_i low and allow the debug cause to propagate
-          debug_cause[STAGE_IF] <=  ebreak_in_wb_i ? 3'h1 : ctrl_fsm_i.debug_cause;
+          debug_cause[STAGE_IF] <=  (ebreak_in_wb_i && debug_mode_q_i) ? DBG_CAUSE_EBREAK : ctrl_fsm_i.debug_cause;
 
           // If there is a trap in the pipeline when debug is taken, the trap will be suppressed but the side-effects will not.
           // The succeeding instruction therefore needs to re-trigger the intr signals if it it did not reach the rvfi output.

--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -234,7 +234,7 @@ module cv32e40x_wrapper
                               .xif_commit_kill              (core_i.xif_commit_if.commit.commit_kill),
                               .xif_commit_valid             (core_i.xif_commit_if.commit_valid),
                               .first_op_if_i                (core_i.if_stage_i.first_op),
-                              .first_op_ex_i                (core_i.first_op_ex),
+                              .first_op_ex_i                (core_i.ex_stage_i.first_op),
                               .prefetch_valid_if_i          (core_i.if_stage_i.prefetch_valid),
                               .prefetch_is_tbljmp_ptr_if_i  (core_i.if_stage_i.prefetch_is_tbljmp_ptr),
                               .prefetch_is_mret_ptr_if_i    (core_i.if_stage_i.prefetch_is_mret_ptr),

--- a/sva/cv32e40x_rvfi_sva.sv
+++ b/sva/cv32e40x_rvfi_sva.sv
@@ -162,7 +162,7 @@ if (DEBUG) begin
   // Helper signal, indicating debug cause
   // Special case for debug entry from debug mode caused by EBREAK as it is not captured by debug_cause_i
   logic [2:0] debug_cause_int;
-  assign debug_cause_int = ebreak_in_wb_i ? 3'h1 : ctrl_fsm_i.debug_cause;
+  assign debug_cause_int = (ctrl_fsm_i.debug_mode && ebreak_in_wb_i) ? 3'h1 : ctrl_fsm_i.debug_cause;
 
   // Check that dbg_ack results in RVFI capturing a debug_cause
   // Ideally, we should assert that every dbg_ack eventually leads to rvfi_dbg,


### PR DESCRIPTION
Correct minor mistakes in cv32e40x..

1) correct bind to use an existing signal
2) add debug_mode when setting the debug_cause signal. ebreak will be repported in rfvi_dbg in debug mode, but is not a prioritized debug cause in case there are several reasons to enter debug mode.