### PR TITLE
a_minhv_unique require clic, add todo for a_no_wfi_wakeup_on_wfe:

### DIFF
--- a/sva/cv32e40x_controller_fsm_sva.sv
+++ b/sva/cv32e40x_controller_fsm_sva.sv
@@ -486,7 +486,7 @@ endgenerate
   a_no_wfi_wakeup_on_wfe:
   assert property (@(posedge clk) disable iff (!rst_n)
                     (ctrl_fsm_cs == SLEEP) && ex_wb_pipe_i.instr_valid && ex_wb_pipe_i.sys_en && ex_wb_pipe_i.sys_wfi_insn &&
-                    !(irq_wu_ctrl_i || pending_nmi) && wu_wfe_i && !pending_async_debug
+                    !(irq_wu_ctrl_i || pending_nmi) && wu_wfe_i && !pending_async_debug //TODO: krdosvik, wu_wfe_i is never set, wait for Henrik to add wfe agent
                     |=>
                     (ctrl_fsm_cs == SLEEP))
     else `uvm_error("controller", "WFI instruction woke up to wu_wfe_i")

--- a/sva/cv32e40x_controller_fsm_sva.sv
+++ b/sva/cv32e40x_controller_fsm_sva.sv
@@ -486,7 +486,7 @@ endgenerate
   a_no_wfi_wakeup_on_wfe:
   assert property (@(posedge clk) disable iff (!rst_n)
                     (ctrl_fsm_cs == SLEEP) && ex_wb_pipe_i.instr_valid && ex_wb_pipe_i.sys_en && ex_wb_pipe_i.sys_wfi_insn &&
-                    !(irq_wu_ctrl_i || pending_nmi) && wu_wfe_i && !pending_async_debug //TODO: krdosvik, wu_wfe_i is never set, wait for Henrik to add wfe agent
+                    !(irq_wu_ctrl_i || pending_nmi) && wu_wfe_i && !pending_async_debug
                     |=>
                     (ctrl_fsm_cs == SLEEP))
     else `uvm_error("controller", "WFI instruction woke up to wu_wfe_i")


### PR DESCRIPTION
Add TODO for assertion: a_no_wfi_wakeup_on_wfe
Make sure CLIC is enabled when checking a_minhv_unique. If CLIC is disabled make sure a_minhv_unique's antecedent never occurs