### PR TITLE
Fixed todo's related to mul_en/div_en i EX stage

### DIFF
--- a/rtl/cv32e40x_div.sv
+++ b/rtl/cv32e40x_div.sv
@@ -260,8 +260,8 @@ module cv32e40x_div import cv32e40x_pkg::*;
 
       DIV_FINISH: begin
         valid_o = valid_i && !(halt_i || kill_i); // No valid outputs while halted or killed
+        ready_o = (ready_i && !halt_i) || kill_i;
         if (ready_i) begin
-          ready_o    = !halt_i || kill_i;
           next_state = DIV_IDLE;
         end
       end
@@ -306,7 +306,7 @@ module cv32e40x_div import cv32e40x_pkg::*;
        res_inv_q   <= 1'b0;
     end else begin
       // If stage is halted, the divider should have no state updates
-      if ((valid_i && !halt_i) || kill_i) begin
+      if (!halt_i || kill_i) begin
        state       <= next_state;
        remainder_q <= remainder_d;
        divisor_q   <= divisor_d;

--- a/rtl/cv32e40x_ex_stage.sv
+++ b/rtl/cv32e40x_ex_stage.sv
@@ -103,8 +103,6 @@ module cv32e40x_ex_stage import cv32e40x_pkg::*;
   logic [31:0]    div_result;
 
   // Gated enable signals factoring in instr_valid)
-  logic           mul_en_gated;
-  logic           div_en_gated;
   logic           lsu_en_gated;
 
   // Divider signals
@@ -116,6 +114,9 @@ module cv32e40x_ex_stage import cv32e40x_pkg::*;
   logic [5:0]     div_shift_amt;
   logic [31:0]    div_op_b_shifted;
 
+  // Multiplier signals
+  logic           mul_en;
+
   // Misc signals
   logic           previous_exception;
   logic           first_op;
@@ -126,14 +127,15 @@ module cv32e40x_ex_stage import cv32e40x_pkg::*;
 
   assign instr_valid = id_ex_pipe_i.instr_valid && !ctrl_fsm_i.kill_ex && !ctrl_fsm_i.halt_ex;
 
-  // todo: consider not factoring halt_ex into the mul/div/lsu_en_gated below
-  //       Halting EX currently reset state of these units. The IF stage sequencer is _not_ reset on a halt_if.
-  //       Maybe we need to split out valid and halt into the submodules?
-  assign mul_en_gated = id_ex_pipe_i.mul_en && instr_valid; // Factoring in instr_valid to kill mul instructions on kill/halt
-  assign div_en_gated = id_ex_pipe_i.div_en && instr_valid; // Factoring in instr_valid to kill div instructions on kill/halt
+  // The multiplier and divider both factors in halt_ex and kill_ex.
+  // MUL/DIV instructions in flight will keep state while halted, and reset state on kill.
+  assign mul_en = id_ex_pipe_i.mul_en && id_ex_pipe_i.instr_valid; // Valid MUL in EX, not affected by kill/halt
+  assign div_en = id_ex_pipe_i.div_en && id_ex_pipe_i.instr_valid; // Valid DIV in EX, not affected by kill/halt
+
+  // The lsu_en_gated factors in halt_ex and kill_ex via instr_valid.
+  // A halted or killed LSU instruction must not generate a data_req to ensure no OBI protocol is violated.
   assign lsu_en_gated = id_ex_pipe_i.lsu_en && instr_valid; // Factoring in instr_valid to suppress bus transactions on kill/halt
 
-  assign div_en = id_ex_pipe_i.div_en && id_ex_pipe_i.instr_valid; // Valid DIV in EX, not affected by kill/halt
 
   // If pipeline is handling a valid CSR AND the same instruction is accepted by the eXtension interface
   // we need to convert the instruction to an illegal instruction and signal commit_kill to the eXtension interface.
@@ -250,11 +252,10 @@ module cv32e40x_ex_stage import cv32e40x_pkg::*;
          // Result
          .result_o           ( div_result                           ),
 
-         // divider enable, not affected by kill/halt
-         .div_en_i           ( div_en                               ),
-
          // Handshakes
-         .valid_i            ( div_en_gated                         ),
+         .halt_i             ( ctrl_fsm_i.halt_ex                   ),
+         .kill_i             ( ctrl_fsm_i.kill_ex                   ),
+         .valid_i            ( div_en                               ),
          .ready_o            ( div_ready                            ),
          .valid_o            ( div_valid                            ),
          .ready_i            ( wb_ready_i                           )
@@ -300,8 +301,11 @@ module cv32e40x_ex_stage import cv32e40x_pkg::*;
          // Result
          .result_o        ( mul_result                    ),
 
+         .halt_i          ( ctrl_fsm_i.halt_ex            ),
+         .kill_i          ( ctrl_fsm_i.kill_ex            ),
+
          // Handshakes
-         .valid_i         ( mul_en_gated                  ),
+         .valid_i         ( mul_en                        ),
          .ready_o         ( mul_ready                     ),
          .valid_o         ( mul_valid                     ),
          .ready_i         ( wb_ready_i                    )

--- a/rtl/cv32e40x_mult.sv
+++ b/rtl/cv32e40x_mult.sv
@@ -163,7 +163,7 @@ module cv32e40x_mult import cv32e40x_pkg::*;
       default: ;
     endcase
 
-    // Allow kill at any time unless EX stage is halted
+    // Allow kill at any time
     if (!valid_i || kill_i) begin
       mulh_state_next = MUL_ALBL;
       ready_o = 1'b1;

--- a/rtl/cv32e40x_mult.sv
+++ b/rtl/cv32e40x_mult.sv
@@ -130,10 +130,7 @@ module cv32e40x_mult import cv32e40x_pkg::*;
         else begin
           // Single cycle multiplication
           valid_o         = valid_i && !(halt_i || kill_i);
-
-          if (ready_i) begin
-            ready_o       = !halt_i || kill_i;
-          end
+          ready_o         = (ready_i && !halt_i) || kill_i;
         end
       end
 
@@ -156,9 +153,9 @@ module cv32e40x_mult import cv32e40x_pkg::*;
         valid_o           = valid_i && !(halt_i || kill_i);
         mulh_a            = mulh_ah;
         mulh_b            = mulh_bh;
+        ready_o           = (ready_i && !halt_i) || kill_i;
 
         if (ready_i) begin
-          ready_o         = !halt_i || kill_i;
           mulh_state_next = MUL_ALBL;
           mulh_acc_next   = '0;
         end
@@ -180,7 +177,7 @@ module cv32e40x_mult import cv32e40x_pkg::*;
       mulh_acc   <=  '0;
       mulh_state <= MUL_ALBL;
     end else begin
-      if ((valid_i && !halt_i) || kill_i) begin
+      if (!halt_i || kill_i) begin
         mulh_acc   <= mulh_acc_next;
         mulh_state <= mulh_state_next;
       end

--- a/rtl/cv32e40x_mult.sv
+++ b/rtl/cv32e40x_mult.sv
@@ -170,20 +170,21 @@ module cv32e40x_mult import cv32e40x_pkg::*;
     // Allow kill at any time
     if (!valid_i || kill_i) begin
       mulh_state_next = MUL_ALBL;
-      ready_o = 1'b1;
-      valid_o = 1'b0;
-      mulh_acc_next = '0;
-      mulh_shift    = 1'b0;
-      mulh_a        = mulh_al;
-      mulh_b        = mulh_bl;
+      valid_o         = 1'b0;
+      ready_o         = 1'b1;
+      mulh_acc_next   = '0;
+      mulh_shift      = 1'b0;
+      mulh_a          = mulh_al;
+      mulh_b          = mulh_bl;
     end else begin
       if (halt_i) begin
-        valid_o = 1'b0;
-        ready_o = 1'b0;
-        mulh_acc_next = '0;
-        mulh_shift    = 1'b0;
-        mulh_a        = mulh_al;
-        mulh_b        = mulh_bl;
+        mulh_state_next = mulh_state;
+        valid_o         = 1'b0;
+        ready_o         = 1'b0;
+        mulh_acc_next   = mulh_acc;
+        mulh_shift      = 1'b0;
+        mulh_a          = mulh_al;
+        mulh_b          = mulh_bl;
       end
     end
   end // always_comb

--- a/sva/cv32e40x_mult_sva.sv
+++ b/sva/cv32e40x_mult_sva.sv
@@ -41,7 +41,9 @@ module cv32e40x_mult_sva
    input logic [16:0] mulh_bl,
    input logic [16:0] mulh_ah,
    input logic [16:0] mulh_bh,
-   input logic [33:0] int_result);
+   input logic [33:0] int_result,
+   input logic        halt_i,
+   input logic        kill_i);
 
   ////////////////////////////////////////
   ////  Assertions on module boundary ////
@@ -54,13 +56,16 @@ module cv32e40x_mult_sva
     assert property (@(posedge clk) disable iff (!rst_n)
                      (valid_i && (operator_i == MUL_M32)) |-> (result_o == mul_result))
       else `uvm_error("mult", "MUL result check failed")
-  a_mul_valid : // check that MUL result is immediately qualified by valid_o
+  a_mul_valid : // check that MUL result is immediately qualified by valid_o unless EX is halted or killed
     assert property (@(posedge clk) disable iff (!rst_n)
-                     (valid_i && (operator_i == MUL_M32)) |-> valid_o)
+                     (valid_i && (operator_i == MUL_M32) &&
+                     !(halt_i || kill_i))
+                     |->
+                     valid_o)
       else `uvm_error("mult", "MUL result wasn't immediately valid")
 
 
-  // Check result for all MULH flavors 
+  // Check result for all MULH flavors
   logic               mulh_result_valid;
   assign mulh_result_valid = ((operator_i == MUL_H) && valid_i) && valid_o;
 


### PR DESCRIPTION
Factored halt_ex/kill_ex out of mul_en and div_en - multiplier and divider now handles them theirselves.
In the divider, div_en_i and valid_i was then duplicates, changed to using only valid_i.

SEC clean (with multiplier operation converted to add to enable converging SEC)