### PR TITLE
Remove assertion checking that PMA regions defined as main also suppo…

### DIFF
--- a/sva/cv32e40x_mpu_sva.sv
+++ b/sva/cv32e40x_mpu_sva.sv
@@ -184,10 +184,6 @@ module cv32e40x_mpu_sva import cv32e40x_pkg::*; import uvm_pkg::*;
   generate for (genvar i = 0; i < PMA_NUM_REGIONS; i++)
     begin : a_pma_no_illegal_configs
     always_comb begin
-        if (PMA_CFG[i].main == 1'b1) begin
-          a_main_atomic : assert (PMA_CFG[i].atomic == 1'b1)
-            else `uvm_error("mpu", "PMA regions configured as main must also support atomic operations");
-        end
         if (PMA_CFG[i].main == 1'b0) begin
           a_io_noncacheable : assert (PMA_CFG[i].cacheable == 1'b0)
             else `uvm_error("mpu", "PMA regions configured as I/O cannot be defined as cacheable");


### PR DESCRIPTION
…rt atomics.

This was a requirement in older versions of riscv-priv spec (e.g. v1.10)