### PR TITLE
Optimized CSR stalls

### DIFF
--- a/rtl/cv32e40x_controller.sv
+++ b/rtl/cv32e40x_controller.sv
@@ -59,7 +59,6 @@ module cv32e40x_controller import cv32e40x_pkg::*;
   input  logic        sys_en_id_i,
   input  logic        sys_mret_id_i,
   input  logic        csr_en_raw_id_i,
-  input  csr_opcode_e csr_op_id_i,
   input  logic        first_op_id_i,
   input  logic        last_op_id_i,
   input  logic        abort_op_id_i,
@@ -118,6 +117,7 @@ module cv32e40x_controller import cv32e40x_pkg::*;
   input  logic        csr_mnxti_read_i,           // MNXTI is read in CSR (EX)
 
   input  logic        csr_irq_enable_write_i,     // An interrupt may be enabled by a write (WB)
+  input  csr_hz_t     csr_hz_i,
 
   input logic [REGFILE_NUM_READ_PORTS-1:0] rf_re_id_i,
   input rf_addr_t     rf_raddr_id_i[REGFILE_NUM_READ_PORTS],
@@ -262,7 +262,6 @@ module cv32e40x_controller import cv32e40x_pkg::*;
     .alu_jmpr_id_i              ( alu_jmpr_id_i            ),
     .sys_mret_id_i              ( sys_mret_id_i            ),
     .csr_en_raw_id_i            ( csr_en_raw_id_i          ),
-    .csr_op_id_i                ( csr_op_id_i              ),
 
     // From EX
     .csr_counter_read_i         ( csr_counter_read_i       ),
@@ -276,6 +275,8 @@ module cv32e40x_controller import cv32e40x_pkg::*;
     .lsu_atomic_ex_i            ( lsu_atomic_ex_i          ),
     .lsu_atomic_wb_i            ( lsu_atomic_wb_i          ),
     .lsu_bus_busy_i             ( lsu_bus_busy_i           ),
+
+    .csr_hz_i                   ( csr_hz_i                 ),
 
     // Outputs
     .ctrl_byp_o                 ( ctrl_byp_o               )

--- a/rtl/cv32e40x_controller_bypass.sv
+++ b/rtl/cv32e40x_controller_bypass.sv
@@ -236,6 +236,17 @@ module cv32e40x_controller_bypass import cv32e40x_pkg::*;
       ctrl_byp_o.jalr_stall = 1'b0;
     end
 
+    ////////////////
+    // CSR stalls //
+    ////////////////
+
+    // Implicit CSR read in ID: Conservatively stall on any implicit CSR write in EX or WB
+    // Implicit CSR read in ID: Conservatively stall on any explicit CSR write in EX or WB
+    // Implicit CSR read in EX: Conservatively stall on any implicit CSR write in WB
+    // Implicit CSR read in EX: Conservatively stall on any explicit CSR write in WB
+    // Explicit CSR read in EX: Conservatively stall on any implicit CSR write in WB
+    // Explicit CSR read in EX: Precise stall on any explicit CSR write in WB
+
     // Stall ID because of an implicit CSR read is in ID while CSR (implicit or explicit) is written in EX/WB
     // This stall is very conservative as it stalls on any CSR access in EX or WB.
     // mret reads mcause and mepc (via controller_fsm) in the ID stage

--- a/rtl/cv32e40x_controller_bypass.sv
+++ b/rtl/cv32e40x_controller_bypass.sv
@@ -149,8 +149,8 @@ module cv32e40x_controller_bypass import cv32e40x_pkg::*;
   assign csr_write_in_ex_wb = csr_write_in_ex || csr_write_in_wb;
 
   // Detect RAW hazard for explicit CSR accesses in EX vs WB
-  assign csr_expl_hz_ex = (csr_hz_i.expl_re_ex && csr_hz_i.expl_we_ex) &&
-                          (csr_hz_i.expl_raddr_ex == csr_hz_i.expl_waddr_ex);
+  assign csr_expl_hz_ex = (csr_hz_i.expl_re_ex && csr_hz_i.expl_we_wb) &&
+                          (csr_hz_i.expl_raddr_ex == csr_hz_i.expl_waddr_wb);
 
   /////////////////////////////////////////////////////////////
   //  ____  _        _ _    ____            _             _  //

--- a/rtl/cv32e40x_controller_bypass.sv
+++ b/rtl/cv32e40x_controller_bypass.sv
@@ -49,7 +49,6 @@ module cv32e40x_controller_bypass import cv32e40x_pkg::*;
   input  logic        alu_jmpr_id_i,              // ALU jump register (JALR)
   input  logic        sys_mret_id_i,              // mret in ID
   input  logic        csr_en_raw_id_i,            // CSR in ID (not gated with deassert)
-  input  csr_opcode_e csr_op_id_i,                // CSR opcode (ID) // todo: Not used (is this on purpose or should it be used here?)
 
   // From EX
   input  logic        csr_counter_read_i,         // CSR is reading a counter (EX).
@@ -64,6 +63,9 @@ module cv32e40x_controller_bypass import cv32e40x_pkg::*;
   input  lsu_atomic_e lsu_atomic_wb_i,
   input  logic        lsu_bus_busy_i,
 
+  // From CS registers
+  input  csr_hz_t     csr_hz_i,
+
   // Controller Bypass outputs
   output ctrl_byp_t   ctrl_byp_o
 );
@@ -76,6 +78,11 @@ module cv32e40x_controller_bypass import cv32e40x_pkg::*;
   logic [REGFILE_NUM_READ_PORTS-1:0] rf_rd_wb_hz;
 
   logic                              csr_write_in_ex_wb;        // Detect CSR write in EX or WB (implicit and explicit)
+  logic                              csr_write_in_ex;           // Detect CSR write in EX (implicit and explicit)
+  logic                              csr_write_in_wb;           // Detect CSR write in WB (implicit and explicit)
+  logic                              csr_impl_write_in_ex;      // Detect implicit CSR write in EX
+  logic                              csr_impl_write_in_wb;      // Detect implicit CSR write in WB
+  logic                              csr_expl_hz_ex;            // Explicit CSR hazard in EX
 
   logic                              rf_we_ex;                  // EX register file write enable
   logic                              rf_we_wb;                  // WB register file write enable
@@ -89,8 +96,6 @@ module cv32e40x_controller_bypass import cv32e40x_pkg::*;
   logic                              csr_unqual_id;             // Explicit or implicit CSR in ID (not qualified)
   logic                              jmpr_unqual_id;            // JALR in ID (not qualified with alu_en)
   logic                              tbljmp_unqual_id;          // Table jump in ID (not qualified with alu_en)
-
-  // todo: make all qualifiers here, and use those signals later in the file
 
   assign rf_we_ex = id_ex_pipe_i.rf_we && id_ex_pipe_i.instr_valid;
   assign rf_we_wb = ex_wb_pipe_i.rf_we && ex_wb_pipe_i.instr_valid;
@@ -115,7 +120,37 @@ module cv32e40x_controller_bypass import cv32e40x_pkg::*;
   assign jmpr_unqual_id = alu_jmpr_id_i && if_id_pipe_i.instr_valid;
   assign tbljmp_unqual_id = if_id_pipe_i.instr_meta.tbljmp && if_id_pipe_i.instr_valid;
 
-  assign csr_unqual_id = csr_exp_unqual_id || sys_mret_unqual_id || tbljmp_unqual_id;
+  // Any implicit CSR reads from the ID stage
+  // mret reads mepc and mcause
+  // tablejumps read jvt
+  assign csr_unqual_id = sys_mret_unqual_id || tbljmp_unqual_id;
+
+  // Detect any implicit CSR write in EX
+  // mret, dret and CLIC/mret pointers implicitly writes to CSRs. (dret is killing IF/ID/EX once it is in WB and can be disregarded here.
+  // Some CSR instructions perform writes to other CSRs, encoded by 'ex_wb_pipe_i.csr_impl_wr'
+  assign csr_impl_write_in_ex = (id_ex_pipe_i.instr_valid &&
+                                 (((id_ex_pipe_i.sys_en && id_ex_pipe_i.sys_mret_insn) || id_ex_pipe_i.instr_meta.clic_ptr || id_ex_pipe_i.instr_meta.mret_ptr) ||
+                                    id_ex_pipe_i.csr_en && csr_hz_i.impl_wr_ex));
+
+  // Detect any implicit CSR write in WB
+  // mret, dret and CLIC/mret pointers implicitly writes to CSRs. (dret is killing IF/ID/EX once it is in WB and can be disregarded here.
+  // Some CSR instructions perform writes to other CSRs, encoded by 'ex_wb_pipe_i.csr_impl_wr'
+  assign csr_impl_write_in_wb = (ex_wb_pipe_i.instr_valid &&
+                                 (((ex_wb_pipe_i.sys_en && ex_wb_pipe_i.sys_mret_insn) || ex_wb_pipe_i.instr_meta.clic_ptr || ex_wb_pipe_i.instr_meta.mret_ptr) ||
+                                    ex_wb_pipe_i.csr_en && ex_wb_pipe_i.csr_impl_wr));
+
+  // Detect implicit and explicit CSR writes in EX
+  assign csr_write_in_ex = (id_ex_pipe_i.instr_valid && (id_ex_pipe_i.csr_en || csr_impl_write_in_ex));
+
+  // Detect implicit and explicit CSR writes in WB
+  assign csr_write_in_wb = (ex_wb_pipe_i.instr_valid && (ex_wb_pipe_i.csr_en || csr_impl_write_in_wb));
+
+  // Any CSR access (implicit or explicit) in any of EX and WB stages
+  assign csr_write_in_ex_wb = csr_write_in_ex || csr_write_in_wb;
+
+  // Detect RAW hazard for explicit CSR accesses in EX vs WB
+  assign csr_expl_hz_ex = (csr_hz_i.expl_re_ex && csr_hz_i.expl_we_ex) &&
+                          (csr_hz_i.expl_raddr_ex == csr_hz_i.expl_waddr_ex);
 
   /////////////////////////////////////////////////////////////
   //  ____  _        _ _    ____            _             _  //
@@ -125,25 +160,6 @@ module cv32e40x_controller_bypass import cv32e40x_pkg::*;
   // |____/ \__\__,_|_|_|  \____\___/|_| |_|\__|_|  \___/|_| //
   //                                                         //
   /////////////////////////////////////////////////////////////
-
-  //TODO:OK:low This CSR stall check is very restrictive
-  //         Should only check EX vs WB, and also CSR/rd addr
-  //         Also consider whether ID or EX should be stalled
-  // The controller mechanism for checking mcause.mpp/mcause.minhv when an mret is in the ID stage depends on this stall.
-  // Detect when a CSR insn is in ID (including WFI which reads mstatus.tw and priv level)
-  // Note that hazard detection uses the registered instr_valid signals. Usage of the local
-  // instr_valid signals would lead to a combinatorial loop via the halt signal.
-  //
-  // For handling of mscratchcsw[l], the cs_registers depend on this stall to be able to read mstatus.mpp, mcause.mpil and mintstatus.
-  //   - The hazard here is really between EX (CSR read) and WB (CSR write). This stall works by creating a bubble in EX while the the
-  //     'offending' write moves to WB (mscratchcsw[l] stays in ID.) Since we don't squash bubbles this should be safe.
-
-  // Detect when a CSR insn  in in EX or WB
-  // mret, dret and CLIC pointers implicitly writes to CSR. (dret is killing IF/ID/EX once it is in WB and can be disregarded here.
-  assign csr_write_in_ex_wb = (
-                              (id_ex_pipe_i.instr_valid && (id_ex_pipe_i.csr_en || (id_ex_pipe_i.sys_en && id_ex_pipe_i.sys_mret_insn) || id_ex_pipe_i.instr_meta.clic_ptr || id_ex_pipe_i.instr_meta.mret_ptr)) ||
-                              (ex_wb_pipe_i.instr_valid && (ex_wb_pipe_i.csr_en || (ex_wb_pipe_i.sys_en && ex_wb_pipe_i.sys_mret_insn) || ex_wb_pipe_i.instr_meta.clic_ptr || ex_wb_pipe_i.instr_meta.mret_ptr))
-                              );
 
   // Stall ID when instruction that can trigger sleep (e.g. WFI or WFE) is active in EX.
   // Prevent load/store following a sleep instruction in the pipeline
@@ -184,7 +200,8 @@ module cv32e40x_controller_bypass import cv32e40x_pkg::*;
   begin
     ctrl_byp_o.load_stall          = 1'b0;
     ctrl_byp_o.deassert_we         = 1'b0;
-    ctrl_byp_o.csr_stall           = 1'b0;
+    ctrl_byp_o.csr_stall_id        = 1'b0;
+    ctrl_byp_o.csr_stall_ex        = 1'b0;
     ctrl_byp_o.minstret_stall      = 1'b0;
     ctrl_byp_o.irq_enable_stall    = 1'b0;
 
@@ -219,9 +236,25 @@ module cv32e40x_controller_bypass import cv32e40x_pkg::*;
       ctrl_byp_o.jalr_stall = 1'b0;
     end
 
-    // Stall because of CSR read (direct or implied) in ID while CSR (implied or direct) is written in EX/WB
+    // Stall ID because of an implicit CSR read is in ID while CSR (implicit or explicit) is written in EX/WB
+    // This stall is very conservative as it stalls on any CSR access in EX or WB.
+    // mret reads mcause and mepc (via controller_fsm) in the ID stage
+    // tablejumps read jvt in the ID stage
     if (csr_unqual_id && csr_write_in_ex_wb) begin
-      ctrl_byp_o.csr_stall = 1'b1;
+      ctrl_byp_o.csr_stall_id = 1'b1;
+    end
+
+    // Stall EX because of
+    // 1: an implicit CSR read is being performed while an implicit or explicit CSR write is in WB,
+    // 2: or an explicit CSR read is in EX while any implicit write is in WB (conservative stall)
+    // 3: or an explicit CSR read is in EX while an explicit CSR write to the same CSR is in WB. (exact stall)
+    //
+    // Cases like accesses to mscratchcsw[l] and mnxti which reads multiple CSRs are handled by 1 above.
+    if ((csr_hz_i.impl_re_ex && csr_write_in_wb) ||
+        (id_ex_pipe_i.csr_en && id_ex_pipe_i.instr_valid && csr_impl_write_in_wb) ||
+        csr_expl_hz_ex) begin
+
+      ctrl_byp_o.csr_stall_ex = 1'b1;
     end
 
     // Stall (EX) due to performance counter read

--- a/rtl/cv32e40x_controller_fsm.sv
+++ b/rtl/cv32e40x_controller_fsm.sv
@@ -301,9 +301,9 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
   //   An extra table jump flag is used in the logic for taken jumps to disinguish between
   //   regular jumps and table jumps.
   // Table jumps do an implicit read of the JVT CSR, so csr_stall must be accounted for.
-  assign jump_in_id = (jmp_id && !if_id_pipe_i.instr_meta.tbljmp && !ctrl_byp_i.jalr_stall) ||
-                      (jmp_id &&  if_id_pipe_i.instr_meta.tbljmp && !ctrl_byp_i.csr_stall ) ||
-                      (sys_mret_id && !ctrl_byp_i.csr_stall);
+  assign jump_in_id = (jmp_id && !if_id_pipe_i.instr_meta.tbljmp && !ctrl_byp_i.jalr_stall)    ||
+                      (jmp_id &&  if_id_pipe_i.instr_meta.tbljmp && !ctrl_byp_i.csr_stall_id ) ||
+                      (sys_mret_id && !ctrl_byp_i.csr_stall_id);
 
   // Blocking on branch_taken_q, as a jump has already been taken
   assign jump_taken_id = jump_in_id && !branch_taken_q;
@@ -651,7 +651,7 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
     //   - If not checking for id_stage_haltable for interrupts and debug, the core could end up in a situation where it tries to create a bubble
     //     by halting ID, but the condition disallowing interrupt or debug will not disappear until the sequence currently handled by the ID stage
     //     is done. This would create an unrecoverable deadlock.
-    ctrl_fsm_o.halt_id          = (ctrl_byp_i.jalr_stall || ctrl_byp_i.load_stall || ctrl_byp_i.csr_stall || ctrl_byp_i.sleep_stall || ctrl_byp_i.mnxti_id_stall) ||
+    ctrl_fsm_o.halt_id          = (ctrl_byp_i.jalr_stall || ctrl_byp_i.load_stall || ctrl_byp_i.csr_stall_id || ctrl_byp_i.sleep_stall || ctrl_byp_i.mnxti_id_stall) ||
                                   ((pending_interrupt || pending_nmi || pending_nmi_early) && debug_interruptible && id_stage_haltable)                             ||
                                   ((pending_async_debug || pending_sync_debug) && id_stage_haltable);
 
@@ -663,7 +663,8 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
     // Halting while handling atomics for the following two scenarios to avoid mix of atomics and non-atomics outstanding at the same time:
     //   - An atomic is in EX while there is an LSU instruction in WB (including atomics)
     //   - Any LSU instruction is in EX while there is an outstanding atomic in WB
-    ctrl_fsm_o.halt_ex          = ctrl_byp_i.minstret_stall || ctrl_byp_i.xif_exception_stall || ctrl_byp_i.irq_enable_stall || ctrl_byp_i.mnxti_ex_stall || ctrl_byp_i.atomic_stall;
+    ctrl_fsm_o.halt_ex          = ctrl_byp_i.minstret_stall || ctrl_byp_i.xif_exception_stall || ctrl_byp_i.irq_enable_stall ||
+                                  ctrl_byp_i.mnxti_ex_stall || ctrl_byp_i.atomic_stall || ctrl_byp_i.csr_stall_ex;
     ctrl_fsm_o.halt_wb          = 1'b0;
     ctrl_fsm_o.halt_limited_wb  = 1'b0;
 

--- a/rtl/cv32e40x_core.sv
+++ b/rtl/cv32e40x_core.sv
@@ -243,6 +243,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
   privlvl_t     priv_lvl;
 
   logic         csr_mnxti_read;
+  csr_hz_t      csr_hz;
 
   // CLIC signals for returning pointer addresses
   // when mnxti is accessed
@@ -322,7 +323,6 @@ module cv32e40x_core import cv32e40x_pkg::*;
   logic        sys_en_id;
   logic        sys_mret_insn_id;
   logic        csr_en_raw_id;
-  csr_opcode_e csr_op_id;
   logic        csr_illegal;
 
   // CSR illegal in EX due to offloading and pipeline accept
@@ -559,7 +559,6 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .alu_jmpr_o                   ( alu_jmpr_id               ),
     .sys_mret_insn_o              ( sys_mret_insn_id          ),
     .csr_en_raw_o                 ( csr_en_raw_id             ),
-    .csr_op_o                     ( csr_op_id                 ),
     .alu_en_o                     ( alu_en_id                 ),
     .sys_en_o                     ( sys_en_id                 ),
 
@@ -614,6 +613,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .csr_rdata_i                ( csr_rdata                    ),
     .csr_illegal_i              ( csr_illegal                  ),
     .csr_mnxti_read_i           ( csr_mnxti_read               ),
+    .csr_hz_i                   ( csr_hz                       ),
 
     // Branch decision
     .branch_decision_o          ( branch_decision_ex           ),
@@ -848,6 +848,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .csr_counter_read_o         ( csr_counter_read       ),
     .csr_mnxti_read_o           ( csr_mnxti_read         ),
     .csr_irq_enable_write_o     ( csr_irq_enable_write   ),
+    .csr_hz_o                   ( csr_hz                 ),
 
     // Interface to CSRs (SRAM like)
     .csr_rdata_o                ( csr_rdata              ),
@@ -940,7 +941,6 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .sys_en_id_i                    ( sys_en_id              ),
     .sys_mret_id_i                  ( sys_mret_insn_id       ),
     .csr_en_raw_id_i                ( csr_en_raw_id          ),
-    .csr_op_id_i                    ( csr_op_id              ),
     .first_op_id_i                  ( first_op_id            ),
 
     // LSU
@@ -970,6 +970,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .mtvec_mode_i                   ( mtvec_mode             ),
     .mcause_i                       ( mcause                 ),
     .mintstatus_i                   ( mintstatus             ),
+    .csr_hz_i                       ( csr_hz                 ),
 
     // Trigger module
     .etrigger_wb_i                  ( etrigger_wb            ),

--- a/rtl/cv32e40x_cs_registers.sv
+++ b/rtl/cv32e40x_cs_registers.sv
@@ -85,6 +85,7 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
   // To controller_bypass
   output logic                          csr_counter_read_o,
   output logic                          csr_mnxti_read_o,
+  output csr_hz_t                       csr_hz_o,
 
   // Interface to CSRs (SRAM like)
   output logic [31:0]                   csr_rdata_o,
@@ -340,10 +341,11 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
 
   always_comb
   begin
-    illegal_csr_read   = 1'b0;
-    csr_counter_read_o = 1'b0;
-    csr_mnxti_read_o   = 1'b0;
-
+    illegal_csr_read    = 1'b0;
+    csr_counter_read_o  = 1'b0;
+    csr_mnxti_read_o    = 1'b0;
+    csr_hz_o.impl_re_ex = 1'b0;
+    csr_hz_o.impl_wr_ex = 1'b0;
     case (csr_raddr)
       // jvt: Jump vector table
       CSR_JVT:  begin
@@ -356,7 +358,12 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
       end
 
       // mstatus
-      CSR_MSTATUS: csr_rdata_int = mstatus_rdata;
+      CSR_MSTATUS: begin
+        csr_rdata_int = mstatus_rdata;
+        if (CLIC) begin
+          csr_hz_o.impl_wr_ex = 1'b1; // Writes to mcause aswell
+        end
+      end
 
       // misa
       CSR_MISA: csr_rdata_int = misa_rdata;
@@ -401,7 +408,12 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
       CSR_MEPC: csr_rdata_int = mepc_rdata;
 
       // mcause: exception cause
-      CSR_MCAUSE: csr_rdata_int = mcause_rdata;
+      CSR_MCAUSE: begin
+        csr_rdata_int = mcause_rdata;
+        if (CLIC) begin
+          csr_hz_o.impl_wr_ex = 1'b1; // Writes to mstatus as well
+        end
+      end
 
       // mtval
       CSR_MTVAL: csr_rdata_int = mtval_rdata;
@@ -416,6 +428,8 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
           // For mnxti, this is actually mstatus. The value written back to the GPR will be the address of
           // the function pointer to the interrupt handler. This is muxed in the WB stage.
           csr_rdata_int = mstatus_rdata;
+          csr_hz_o.impl_re_ex = 1'b1; // Reads mstatus
+          csr_hz_o.impl_wr_ex = 1'b1; // Writes mstatus, mcause and mintstatus
           csr_mnxti_read_o = 1'b1;
         end else begin
           csr_rdata_int    = '0;
@@ -451,6 +465,8 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
           // Safe to use mstatus_rdata here (EX timing), as there is a generic stall of the ID stage
           // whenever a CSR instruction follows another CSR instruction. Alternative implementation using
           // a local forward of mstatus_rdata is identical (SEC).
+          csr_hz_o.impl_re_ex = 1'b1; // Reads mstatus
+          csr_hz_o.impl_wr_ex = 1'b1; // Writes mscratch
           if (mstatus_rdata.mpp != PRIV_LVL_M) begin
             // Return mscratch for writing to GPR
             csr_rdata_int = mscratch_rdata;
@@ -472,6 +488,8 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
           // Safe to use mcause_rdata and mintstatus_rdata here (EX timing), as there is a generic stall of the ID stage
           // whenever a CSR instruction follows another CSR instruction. Alternative implementation using
           // a local forward of mcause_rdata and mintstatus_rdata is identical (SEC).
+          csr_hz_o.impl_re_ex = 1'b1; // Reads mcause and mintstatus
+          csr_hz_o.impl_wr_ex = 1'b1; // Writes mscratch
           if ((mcause_rdata.mpil == '0) != (mintstatus_rdata.mil == 0)) begin
             // Return mscratch for writing to GPR
             csr_rdata_int = mscratch_rdata;
@@ -488,6 +506,7 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
       CSR_TSELECT: begin
         if (DBG_NUM_TRIGGERS > 0) begin
           csr_rdata_int = tselect_rdata;
+          csr_hz_o.impl_wr_ex = 1'b1; // Changing tselect may change tdata1 and tdata2 as well
         end else begin
           csr_rdata_int = '0;
           illegal_csr_read = 1'b1;
@@ -1553,6 +1572,12 @@ dcsr_we        = 1'b1;
     end
   endgenerate
 
+  // Set signals for explicit CSR hazard detection
+  assign csr_hz_o.expl_re_ex = id_ex_pipe_i.csr_en && id_ex_pipe_i.instr_valid;
+  assign csr_hz_o.expl_raddr_ex = csr_raddr;
+
+  assign csr_hz_o.expl_we_ex = ex_wb_pipe_i.csr_en && ex_wb_pipe_i.instr_valid && (csr_op != CSR_OP_READ);
+  assign csr_hz_o.expl_waddr_ex = csr_waddr;
   ////////////////////////////////////////////////////////////////////////
   //
   // CSR outputs

--- a/rtl/cv32e40x_ex_stage.sv
+++ b/rtl/cv32e40x_ex_stage.sv
@@ -47,6 +47,7 @@ module cv32e40x_ex_stage import cv32e40x_pkg::*;
   input  logic [31:0] csr_rdata_i,
   input  logic        csr_illegal_i,
   input  logic        csr_mnxti_read_i,
+  input  csr_hz_t     csr_hz_i,
 
   // EX/WB pipeline
   output ex_wb_pipe_t ex_wb_pipe_o,
@@ -361,6 +362,7 @@ module cv32e40x_ex_stage import cv32e40x_pkg::*;
       ex_wb_pipe_o.first_op           <= 1'b0;
       ex_wb_pipe_o.last_op            <= 1'b0;
       ex_wb_pipe_o.abort_op           <= 1'b0;
+      ex_wb_pipe_o.csr_impl_wr        <= 1'b0;
 
       ex_wb_pipe_o.priv_lvl           <= PRIV_LVL_M;
     end
@@ -399,6 +401,7 @@ module cv32e40x_ex_stage import cv32e40x_pkg::*;
           ex_wb_pipe_o.csr_wdata        <= id_ex_pipe_i.alu_operand_a;
           ex_wb_pipe_o.csr_op           <= id_ex_pipe_i.csr_op;
           ex_wb_pipe_o.csr_mnxti_access <= csr_mnxti_read_i;
+          ex_wb_pipe_o.csr_impl_wr      <= csr_hz_i.impl_wr_ex;
         end
 
         // Propagate signals needed for exception handling in WB

--- a/rtl/cv32e40x_id_stage.sv
+++ b/rtl/cv32e40x_id_stage.sv
@@ -75,7 +75,6 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
   output logic        sys_mret_insn_o,
 
   output logic        csr_en_raw_o,
-  output csr_opcode_e csr_op_o,
 
   output logic        alu_en_o,
   output logic        sys_en_o,
@@ -658,7 +657,6 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
   assign alu_jmpr_o   = alu_jmpr;
 
   assign csr_en_raw_o = csr_en_raw;
-  assign csr_op_o = csr_op;
 
   assign alu_en_o     = alu_en;
   assign sys_en_o     = sys_en;

--- a/rtl/include/cv32e40x_pkg.sv
+++ b/rtl/include/cv32e40x_pkg.sv
@@ -721,8 +721,8 @@ parameter logic [31:0] TDATA1_RST_VAL = {
   typedef struct packed {
     logic impl_re_ex; // Implicit CSR read in EX
     logic impl_wr_ex; // Implicit CSR write in EX (will perform write in WB)
-    logic expl_re_ex;
-    logic expl_we_wb;
+    logic expl_re_ex; // Conservative, using flopped instr_valid
+    logic expl_we_wb; // Conservative, using flopped instr_valid
     csr_num_e expl_raddr_ex;
     csr_num_e expl_waddr_wb;
   } csr_hz_t;

--- a/rtl/include/cv32e40x_pkg.sv
+++ b/rtl/include/cv32e40x_pkg.sv
@@ -722,9 +722,9 @@ parameter logic [31:0] TDATA1_RST_VAL = {
     logic impl_re_ex; // Implicit CSR read in EX
     logic impl_wr_ex; // Implicit CSR write in EX (will perform write in WB)
     logic expl_re_ex;
-    logic expl_we_ex;
+    logic expl_we_wb;
     csr_num_e expl_raddr_ex;
-    csr_num_e expl_waddr_ex;
+    csr_num_e expl_waddr_wb;
   } csr_hz_t;
 
 

--- a/rtl/include/cv32e40x_pkg.sv
+++ b/rtl/include/cv32e40x_pkg.sv
@@ -717,6 +717,16 @@ parameter logic [31:0] TDATA1_RST_VAL = {
   parameter TDATA1_TTYPE_HIGH = 31;
   parameter TDATA1_TTYPE_LOW  = 28;
 
+  // Struct for carrying read/write hazard signals
+  typedef struct packed {
+    logic impl_re_ex; // Implicit CSR read in EX
+    logic impl_wr_ex; // Implicit CSR write in EX (will perform write in WB)
+    logic expl_re_ex;
+    logic expl_we_ex;
+    csr_num_e expl_raddr_ex;
+    csr_num_e expl_waddr_ex;
+  } csr_hz_t;
+
 
 ///////////////////////////////////////////////
 //   ___ ____    ____  _                     //
@@ -1272,6 +1282,8 @@ typedef struct packed {
   logic         first_op;         // First part of multi operation instruction
   logic         last_op;          // Last part of multi operation instruction
   logic         abort_op;         // Instruction will be aborted due to known exceptions or trigger matches
+
+  logic         csr_impl_wr;      // A CSR instruction is doing an implicit write
 } ex_wb_pipe_t;
 
 // Performance counter events
@@ -1301,7 +1313,8 @@ typedef struct packed {
   jalr_fw_mux_e jalr_fw_mux_sel;        // Jump target forward mux sel
   logic         jalr_stall;             // Stall due to JALR hazard (JALR used result from EX or LSU result in WB)
   logic         load_stall;             // Stall due to load operation
-  logic         csr_stall;
+  logic         csr_stall_id;
+  logic         csr_stall_ex;
   logic         sleep_stall;            // Stall ID due to sleep (e.g. WFI, WFE) instruction in EX
   logic         mnxti_id_stall;         // Stall ID due to mnxti CSR access in EX
   logic         mnxti_ex_stall;         // Stall EX due to LSU instruction in WB

--- a/sva/cv32e40x_controller_fsm_sva.sv
+++ b/sva/cv32e40x_controller_fsm_sva.sv
@@ -864,17 +864,6 @@ end
                   !ctrl_fsm_o.halt_wb)
   else `uvm_error("controller", "csr_restore_mret when WB is halted")
 
-  if (CLIC) begin
-    // CSR instructions should be stalled in ID if there is a CLIC or mret pointer in EX or WB (RAW hazard)
-    a_csr_stall_on_ptr:
-    assert property (@(posedge clk) disable iff (!rst_n)
-                    (csr_en_id_i && if_id_pipe_i.instr_valid) &&
-                    (((id_ex_pipe_i.instr_meta.clic_ptr || id_ex_pipe_i.instr_meta.mret_ptr) && id_ex_pipe_i.instr_valid) ||
-                    ((ex_wb_pipe_i.instr_meta.clic_ptr || ex_wb_pipe_i.instr_meta.mret_ptr) && ex_wb_pipe_i.instr_valid))
-                    |->
-                    !id_valid_i)
-    else `uvm_error("controller", "CSR* not stalled in ID when CLIC pointer is in EX or WB")
-  end
 
 
   // When interrupts or debug is taken, the PC stored to dpc or mepc cannot come from a pointer


### PR DESCRIPTION
Conservatively stalling ID for any implicit CSR read while any implicit or explicit CSR write is in EX or WB (unchanged)
Conservatively stalling EX for any implicit CSR read while any implicit or explicit CSR write is in WB
Conservatively stalling EX for any explicit CSR rad while any implicit CSR write is in WB
Precisely stalling EX for any explicit CSR read while an explicit CSR write to the same CSR is in WB.