### PR TITLE
Fix for issue #892

### DIFF
--- a/bhv/cv32e40x_rvfi.sv
+++ b/bhv/cv32e40x_rvfi.sv
@@ -840,7 +840,7 @@ module cv32e40x_rvfi
       // Indicate that the trap is a synchronous trap into debug mode
       rvfi_trap_next.debug       = 1'b1;
       // Special case for debug entry from debug mode caused by EBREAK as it is not captured by ctrl_fsm_i.debug_cause
-      rvfi_trap_next.debug_cause = (ebreak_in_wb_i && debug_mode_q_i) ? DBG_CAUSE_EBREAK : ctrl_fsm_i.debug_cause;
+      rvfi_trap_next.debug_cause = ctrl_fsm_i.debug_cause;
     end
 
     if (pc_mux_exception) begin
@@ -1049,7 +1049,7 @@ module cv32e40x_rvfi
           // Debug cause input only valid during debug taken
           // Special case for debug entry from debug mode caused by EBREAK as it is not captured by ctrl_fsm_i.debug_cause
           // A higher priority debug request (e.g. trigger match) will pull ebreak_in_wb_i low and allow the debug cause to propagate
-          debug_cause[STAGE_IF] <=  (ebreak_in_wb_i && debug_mode_q_i) ? DBG_CAUSE_EBREAK : ctrl_fsm_i.debug_cause;
+          debug_cause[STAGE_IF] <=  ctrl_fsm_i.debug_cause;
 
           // If there is a trap in the pipeline when debug is taken, the trap will be suppressed but the side-effects will not.
           // The succeeding instruction therefore needs to re-trigger the intr signals if it it did not reach the rvfi output.

--- a/bhv/cv32e40x_rvfi.sv
+++ b/bhv/cv32e40x_rvfi.sv
@@ -839,7 +839,7 @@ module cv32e40x_rvfi
       // as asynchronous entries will kill the WB stage whereas synchronous entries will not.
       // Indicate that the trap is a synchronous trap into debug mode
       rvfi_trap_next.debug       = 1'b1;
-      // Special case for debug entry from debug mode caused by EBREAK as it is not captured by ctrl_fsm_i.debug_cause
+      // Set cause of debug for next rvfi_trap
       rvfi_trap_next.debug_cause = ctrl_fsm_i.debug_cause;
     end
 
@@ -1047,8 +1047,6 @@ module cv32e40x_rvfi
         // debug cause is saved to propagate through rvfi pipeline together with next valid instruction
         if (pc_mux_debug) begin
           // Debug cause input only valid during debug taken
-          // Special case for debug entry from debug mode caused by EBREAK as it is not captured by ctrl_fsm_i.debug_cause
-          // A higher priority debug request (e.g. trigger match) will pull ebreak_in_wb_i low and allow the debug cause to propagate
           debug_cause[STAGE_IF] <=  ctrl_fsm_i.debug_cause;
 
           // If there is a trap in the pipeline when debug is taken, the trap will be suppressed but the side-effects will not.


### PR DESCRIPTION
Changed from:
(ebreak_in_wb_i && debug_mode_q_i) ? DBG_CAUSE_EBREAK : ctrl_fsm_i.debug_cause

to:
ctrl_fsm_i.debug_cause

in both lines in question. Checked with a temporary assertion to check for correctness.