### PR TITLE
Fix for issue #881

### DIFF
--- a/docs/user_manual/source/exceptions_interrupts.rst
+++ b/docs/user_manual/source/exceptions_interrupts.rst
@@ -185,7 +185,6 @@ which reflects an intended custom extension in the RISC-V CLINT mode interrupt a
 After reset, all interrupts, except for NMIs, are disabled.
 To enable any of the ``irq_i[31:0]`` interrupts, both the global interrupt enable (``MIE``) bit in the ``mstatus`` CSR and the corresponding individual interrupt enable bit in the ``mie`` CSR need to be set. For more information, see the :ref:`cs-registers` documentation.
 
-
 If multiple interrupts are pending, they are handled in the fixed priority order defined by [RISC-V-PRIV]_.
 The highest priority is given to the interrupt with the highest ID, except for the Machine Timer Interrupt, which has the lowest priority. So from high to low priority the interrupts are
 ordered as follows:
@@ -201,7 +200,7 @@ ordered as follows:
 * ``irq_i[7]``
 
 The ``irq_i[31:0]`` interrupt lines are level-sensitive. The NMIs are triggered by load/store bus fault events.
-To clear the ``irq_i[31:0]`` interrupts at the external source, |corev| relies on a software-based mechanism in which the interrupt handler signals completion of the handling routine to the interrupt source, e.g., through a memory-mapped register, which then deasserts the corresponding interrupt line.
+To clear the ``irq_i[31:0]`` interrupts at the external source, |corev| relies on a software-based mechanism in which the interrupt handler clears the interrupt at the source, e.g., through a memory-mapped register, which then deasserts the corresponding interrupt line.
 
 In Debug Mode, all interrupts are ignored independent of ``mstatus.MIE`` and the content of the ``mie`` CSR.
 
@@ -318,24 +317,21 @@ also impacts the alignment requirement for the trap vector table, see :ref:`csr-
 
 Interrupt prioritization is mostly performed in the part of CLIC that is external to the core, with the exception that |corev| prioritizes all NMIs above interrupts received via ``clic_irq_i``.
 
-The ``clic_irq_i``, ``clic_irq_id_i``, ``clic_irq_level_i``, ``clic_irq_priv_i`` and ``clic_irq_shv_i`` signals are controlled via the externally memory mapped CLIC module.
-After reset, all interrupts, except for NMIs, are disabled.
+The ``clic_irq_i``, ``clic_irq_id_i``, ``clic_irq_level_i``, ``clic_irq_priv_i`` and ``clic_irq_shv_i`` signals are controlled via an externally memory mapped CLIC module.
+After reset, all interrupts, except for NMIs, are (at least globally) disabled.
 To enable any of the CLIC interrupts, both the global interrupt enable (``MIE``) bit in the ``mstatus`` CSR and the corresponding individual interrupt enables and levels in the external CLIC module must be configured.
-
 
 The external CLIC module prioritizes all interrupts and presents |corev| with the highest priority pending and enabled interrupt.
 |corev| will then prioritize the interrupts including NMI as follows:
-
 
 * ``store bus fault NMI (1025)``
 * ``load bus fault NMI (1024)``
 * ``clic_irq_i`` with index, level and selective hardware vectoring defined by ``clic_irq_id_i``, ``clic_irq_level_i`` and ``clic_irq_shv_i`` respectively.
 
-
 The ``clic_irq_i`` interrupt line is level-sensitive. The NMIs are triggered by load/store bus fault events.
-To clear the ``clic_irq_i`` interrupt at the external source, |corev| relies on a software-based mechanism in which the interrupt handler signals completion of the handling routine to the interrupt source, e.g., through a memory-mapped register, which then deasserts the corresponding interrupt line.
+To clear the ``clic_irq_i`` interrupt at the external source, |corev| relies on a software-based mechanism in which the interrupt handler clears the interupt at the source, e.g., through a memory-mapped register.
 
-In Debug Mode, all interrupts are ignored independent of ``mstatus.MIE`` and the configuration of the external CLIC module.
+In Debug Mode, all interrupts are ignored independent of ``mstatus.MIE`` and the configuration of an external CLIC module.
 
 |corev| can trigger the following interrupts as reported in ``mcause``:
 


### PR DESCRIPTION
Added information about priority of CLIC interupts vs NMIs in the "Exceptions and Interrupts" chapter in the user manual.