### PR TITLE
Fix todo in assertion a_valid_jump.

### DIFF
--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -225,7 +225,8 @@ module cv32e40x_wrapper
         #(.X_EXT(X_EXT),
           .DEBUG(DEBUG),
           .CLIC(CLIC),
-          .CLIC_ID_WIDTH(CLIC_ID_WIDTH))
+          .CLIC_ID_WIDTH(CLIC_ID_WIDTH),
+          .RV32(RV32))
         controller_fsm_sva   (
                               .lsu_outstanding_cnt          (core_i.load_store_unit_i.cnt_q),
                               .rf_we_wb_i                   (core_i.wb_stage_i.rf_we_wb_o  ),
@@ -244,6 +245,9 @@ module cv32e40x_wrapper
                               .instr_req_o                  (core_i.instr_req_o),
                               .instr_dbg_o                  (core_i.instr_dbg_o),
                               .mstatus_i                    (core_i.cs_registers_i.mstatus_rdata),
+                              .rf_mem_i                     (core_i.register_file_wrapper_i.register_file_i.mem),
+                              .alu_jmpr_id_i                (core_i.alu_jmpr_id),
+                              .jalr_fw_id_i                 (core_i.id_stage_i.jalr_fw),
                               .*);
   bind cv32e40x_cs_registers:
     core_i.cs_registers_i

--- a/rtl/cv32e40x_controller.sv
+++ b/rtl/cv32e40x_controller.sv
@@ -36,6 +36,7 @@ module cv32e40x_controller import cv32e40x_pkg::*;
   parameter int unsigned REGFILE_NUM_READ_PORTS = 2,
   parameter bit          CLIC                   = 0,
   parameter int unsigned CLIC_ID_WIDTH          = 5,
+  parameter rv32_e       RV32                   = RV32I,
   parameter bit          DEBUG                  = 1
 )
 (
@@ -151,6 +152,7 @@ module cv32e40x_controller import cv32e40x_pkg::*;
     .X_EXT                       ( X_EXT                    ),
     .CLIC                        ( CLIC                     ),
     .CLIC_ID_WIDTH               ( CLIC_ID_WIDTH            ),
+    .RV32                        ( RV32                     ),
     .DEBUG                       ( DEBUG                    )
   )
   controller_fsm_i

--- a/rtl/cv32e40x_controller_fsm.sv
+++ b/rtl/cv32e40x_controller_fsm.sv
@@ -34,7 +34,8 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
   parameter bit          X_EXT         = 0,
   parameter bit          DEBUG         = 1,
   parameter bit          CLIC          = 0,
-  parameter int unsigned CLIC_ID_WIDTH = 5
+  parameter int unsigned CLIC_ID_WIDTH = 5,
+  parameter rv32_e       RV32          = RV32I
 )
 (
   // Clocks and reset

--- a/rtl/cv32e40x_core.sv
+++ b/rtl/cv32e40x_core.sv
@@ -896,6 +896,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .REGFILE_NUM_READ_PORTS         ( REGFILE_NUM_READ_PORTS ),
     .CLIC                           ( CLIC                   ),
     .CLIC_ID_WIDTH                  ( CLIC_ID_WIDTH          ),
+    .RV32                           ( RV32                   ),
     .DEBUG                          ( DEBUG                  )
   )
   controller_i


### PR DESCRIPTION
a_valid_jump cannot assert that we don't jump when ID is halted, so it was decided to add an assertion verifying that the register used for JALR is stable until JALR retires.