### PR TITLE
Updates for CLIC spec (august 23)

### DIFF
--- a/rtl/cv32e40x_controller_fsm.sv
+++ b/rtl/cv32e40x_controller_fsm.sv
@@ -75,7 +75,6 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
   input  align_status_e align_status_wb_i,          // Aligned status (atomics) in WB
   input  logic [31:0]   wpt_match_wb_i,             // LSU watchpoint trigger (WB)
 
-
   // From LSU (WB)
   input  logic        data_stall_wb_i,            // WB stalled by LSU
   input  logic        lsu_valid_wb_i,             // LSU instruction in WB is valid
@@ -282,8 +281,6 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
   // index 0 for non-vectored CLINT mode and CLIC mode, 0xF for vectored CLINT mode
   assign ctrl_fsm_o.nmi_mtvec_index = (mtvec_mode_i == 2'b01) ? 5'hF : 5'h0;
 
-
-
   ////////////////////////////////////////////////////////////////////
   // ID stage
 
@@ -291,8 +288,6 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
   // Checking validity of jump/mret instruction with if_id_pipe_i.instr_valid and the respective alu_en/sys_en.
   // Using the ID stage local instr_valid would bring halt_id and kill_id into the equation
   // causing a path from data_rvalid to instr_addr_o/instr_req_o/instr_memtype_o via pc_set.
-
-
 
   assign sys_mret_id = sys_en_id_i && sys_mret_id_i && if_id_pipe_i.instr_valid;
   assign jmp_id      = alu_en_id_i && alu_jmp_id_i  && if_id_pipe_i.instr_valid;
@@ -429,7 +424,7 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
   // This CSR bit shall not be gated by debug mode or step without stepie
   assign ctrl_fsm_o.pending_nmi = nmi_pending_q;
 
-  // Debug //
+  // Debug
 
   // Single step will need to finish insn in WB, including LSU
   // LSU will now set valid_1_o only for second part of misaligned instructions.
@@ -464,7 +459,6 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
   // This causes the reason for debug entry to 'disappear' as seen from the DEBUG_TAKEN state one cycle later.
   // The signal pending_single_step should never be used outside of the FUNCTIONAL state.
   assign pending_single_step = (!debug_mode_q && dcsr_i.step && ((wb_valid_i && (last_op_wb_i || abort_op_wb_i)) || non_shv_irq_ack || (pending_nmi && nmi_allowed)));
-
 
   // Detect if there is a live CLIC pointer in the pipeline
   // This should block debug and interrupts
@@ -753,7 +747,6 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
             ctrl_fsm_o.irq_level = mintstatus_i.mil;
           end
 
-
           // Save pc from oldest valid instruction
           if (ex_wb_pipe_i.instr_valid) begin
             pipe_pc_mux_ctrl = PC_WB;
@@ -796,9 +789,8 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
           ctrl_fsm_o.csr_save_cause  = 1'b1;
           ctrl_fsm_o.csr_cause.irq = 1'b1;
 
-          // Clear mcause.minhv when taking an interrupt. (only set when taking exceptions on CLIC/mret pointers)
+          // Clear mcause.minhv when taking an interrupt (only set when taking exceptions on CLIC/mret pointers)
           ctrl_fsm_o.csr_cause.minhv  = 1'b0;
-
 
           if (CLIC) begin
             ctrl_fsm_o.csr_cause.exception_code = {1'b0, irq_id_ctrl_i};

--- a/rtl/cv32e40x_controller_fsm.sv
+++ b/rtl/cv32e40x_controller_fsm.sv
@@ -262,6 +262,9 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
   logic       clic_ptr_in_progress_id_set;
   logic       clic_ptr_in_progress_id_clear;
 
+  // Signal for or'ing int signals not used by the RTL but are used by RVFI
+  logic       unused_signals;
+
   assign sequence_interruptible = !sequence_in_progress_wb;
 
   assign id_stage_haltable = !(sequence_in_progress_id || clic_ptr_in_progress_id);
@@ -1452,6 +1455,9 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
   assign ctrl_fsm_o.debug_havereset = debug_fsm_cs[HAVERESET_INDEX];
   assign ctrl_fsm_o.debug_running   = debug_fsm_cs[RUNNING_INDEX];
   assign ctrl_fsm_o.debug_halted    = debug_fsm_cs[HALTED_INDEX];
+
+  // Tie off unused signals
+  assign unused_signals = clic_ptr_in_wb;
 
 
   //---------------------------------------------------------------------------

--- a/rtl/cv32e40x_cs_registers.sv
+++ b/rtl/cv32e40x_cs_registers.sv
@@ -1024,7 +1024,7 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
                                     cause     : ctrl_fsm_i.debug_cause,
                                     default   : 'd0
                                   };
-dcsr_we        = 1'b1;
+          dcsr_we        = 1'b1;
 
           dpc_n          = ctrl_fsm_i.pipe_pc;
           dpc_we         = 1'b1;
@@ -1106,11 +1106,6 @@ dcsr_we        = 1'b1;
             mintthresh_n  = 32'h00000000;
             mintthresh_we = 1'b1;
           end
-
-          if (ctrl_fsm_i.csr_restore_mret_ptr) begin
-            // Clear mcause.minhv if the mret also caused a successful CLIC pointer fetch
-            mcause_n.minhv = 1'b0;
-          end
         end
       end //ctrl_fsm_i.csr_restore_mret
 
@@ -1134,22 +1129,6 @@ dcsr_we        = 1'b1;
 
       end //ctrl_fsm_i.csr_restore_dret
 
-      // Clear mcause.minhv on successful CLIC pointer fetches
-      // This only happens for CLIC pointer that did not originate from an mret.
-      // In the case of mret restarting CLIC pointer fetches, minhv is cleared while
-      // ctrl_fsm_i.csr_restore_mret_ptr is asserted.
-      ctrl_fsm_i.csr_clear_minhv: begin
-        if (CLIC) begin
-          // Keep mcause values, only clear minhv bit.
-          mcause_n = mcause_rdata;
-          mcause_n.minhv = 1'b0;
-          mcause_we = 1'b1;
-
-          // Not really needed, but allows for asserting mstatus_we == mcause_we to check aliasing formally
-          mstatus_n  = mstatus_rdata;
-          mstatus_we = 1'b1;
-        end
-      end
       default:;
     endcase
 

--- a/rtl/include/cv32e40x_pkg.sv
+++ b/rtl/include/cv32e40x_pkg.sv
@@ -1370,7 +1370,6 @@ typedef struct packed {
   logic        csr_restore_mret_ptr; // Restore CSR due to mret followed by CLIC
   logic        csr_restore_dret;    // Restore CSR due to dret
   logic        csr_save_cause;      // Update CSRs
-  logic        csr_clear_minhv;     // Clear the mcause.minhv field
   logic        pending_nmi;         // An NMI is pending (for dcsr.nmip)
 
   // Performance counter events

--- a/sva/cv32e40x_controller_fsm_sva.sv
+++ b/sva/cv32e40x_controller_fsm_sva.sv
@@ -658,7 +658,6 @@ end else begin // CLIC
                   |->
                   (clic_ptr_in_progress_id_set != 1'b1)     &&
                   !ctrl_fsm_o.csr_cause.minhv       &&
-                  !ctrl_fsm_o.csr_clear_minhv       &&
                   !mcause_i.minhv                   &&
                   !if_id_pipe_i.instr_meta.clic_ptr &&
                   !id_ex_pipe_i.instr_meta.clic_ptr &&

--- a/sva/cv32e40x_cs_registers_sva.sv
+++ b/sva/cv32e40x_cs_registers_sva.sv
@@ -163,6 +163,25 @@ module cv32e40x_cs_registers_sva
     a_mcause_mstatus_alias: assert property(p_mcause_mstatus_alias)
       else `uvm_error("cs_registers", "mcause.mpp and mcause.mpie not aliased correctly")
 
+    // Whenever mepc is written by HW, mcause.minhv must also be written with the correct value.
+    // mcause.minhv is only set when an exception is taken on a CLIC or mret pointer
+    // SW can still write both mepc and mcause independently
+    property p_mepc_minhv_write;
+      @(posedge clk) disable iff (!rst_n)
+      (
+        mepc_we   // mepc is written
+        |->
+        (mcause_we && // mcause is written
+        mcause_n.minhv == ((ex_wb_pipe_i.instr_meta.clic_ptr || ex_wb_pipe_i.instr_meta.mret_ptr) && // pointer in WB
+                           (ctrl_fsm_i.pc_set && ctrl_fsm_i.pc_mux == PC_TRAP_EXC)))                 // exception taken
+        or
+        csr_we_int // SW writes mepc
+      );
+    endproperty;
+
+    a_mepc_minhv_write: assert property(p_mepc_minhv_write)
+      else `uvm_error("cs_registers", "mcause.minhv not updated correctly on mepc write.")
+
   end
 
   // Check that no csr instruction can be in WB during sleep when ctrl_fsm.halt_limited_wb is set
@@ -173,27 +192,6 @@ module cv32e40x_cs_registers_sva
 
   a_halt_limited_wb: assert property(p_halt_limited_wb)
     else `uvm_error("cs_registers", "CSR in WB while halt_limited_wb is set");
-
-
-  // Check csr_clear_minhv cannot happen at the same time as csr_save_cause or csr_restore_dret (would cause mcause_we conflict)
-  sequence seq_csr_clear_minhv;
-    ctrl_fsm_i.csr_clear_minhv;
-  endsequence
-
-  property p_minhv_unique;
-    @(posedge clk) disable iff (!rst_n)
-    (  seq_csr_clear_minhv |-> !(ctrl_fsm_i.csr_save_cause || ctrl_fsm_i.csr_restore_dret));
-  endproperty;
-
-  if (CLIC) begin
-    a_minhv_unique: assert property(p_minhv_unique)
-      else `uvm_error("cs_registers", "csr_save_cause at the same time as csr_clear_minhv.");
-
-  end else begin
-    a_minhv_unique_nocover: assert property(
-      @(posedge clk) disable iff (!rst_n)
-       not seq_csr_clear_minhv);
-  end
 
   /////////////////////////////////////////////////////////////////////////////////////////
   // Asserts to check that the CSR flops remain unchanged if a set/clear has all_zero rs1


### PR DESCRIPTION
mcause.minhv only set when taking an exception for a CLIC pointer or mret pointer restart. When jumping due to an mret, mcause.minhv is checked regardless of mcause.mpp.