### PR TITLE
Fix TODO in RTL. Updated use of priv-lvl signals to match cv32e40s

### DIFF
--- a/rtl/cv32e40x_core.sv
+++ b/rtl/cv32e40x_core.sv
@@ -240,6 +240,9 @@ module cv32e40x_core import cv32e40x_pkg::*;
   logic csr_wr_in_wb_flush;
   logic csr_irq_enable_write;
 
+  privlvl_t     priv_lvl_lsu;
+  privlvlctrl_t priv_lvl_if_ctrl;
+
   privlvl_t     priv_lvl;
 
   logic         csr_mnxti_read;
@@ -502,6 +505,9 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .if_valid_o          ( if_valid                 ),
     .id_ready_i          ( id_ready                 ),
 
+    // Privilege level
+    .priv_lvl_ctrl_i     ( priv_lvl_if_ctrl         ),
+
     // eXtension interface
     .xif_compressed_if   ( xif_compressed_if        ),
     .xif_offloading_id_i ( xif_offloading_id        )
@@ -705,6 +711,9 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .lsu_align_status_1_o  ( lsu_align_status_wb),
     .lsu_atomic_1_o        ( lsu_atomic_wb      ),
 
+    // Privilege level
+    .priv_lvl_lsu_i        ( priv_lvl_lsu       ),
+
     // Valid/ready
     .valid_0_i             ( lsu_valid_ex       ), // First LSU stage (EX)
     .ready_0_o             ( lsu_ready_0        ),
@@ -831,6 +840,8 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .mtvec_mode_o               ( mtvec_mode             ),
     .mtvt_addr_o                ( mtvt_addr              ),
 
+    .priv_lvl_if_ctrl_o         ( priv_lvl_if_ctrl       ),
+    .priv_lvl_lsu_o             ( priv_lvl_lsu           ),
     .priv_lvl_o                 ( priv_lvl               ),
 
     // ID/EX pipeline

--- a/rtl/cv32e40x_cs_registers.sv
+++ b/rtl/cv32e40x_cs_registers.sv
@@ -71,6 +71,8 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
   output logic [MTVT_ADDR_WIDTH-1:0]    mtvt_addr_o,
 
   output privlvl_t                      priv_lvl_o,
+  output privlvlctrl_t                  priv_lvl_if_ctrl_o,
+  output privlvl_t                      priv_lvl_lsu_o,
 
   // ID/EX pipeline
   input id_ex_pipe_t                    id_ex_pipe_i,
@@ -243,9 +245,8 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
   logic [31:0]                  mtval_n, mtval_rdata;                           // No CSR module instance
   logic                         mtval_we;                                       // Not used in RTL (used by RVFI)
 
-  privlvl_t                     priv_lvl_n, priv_lvl_q, priv_lvl_rdata; // todo: Use the priv_* signals as much as possible as in the 40S
+  privlvl_t                     priv_lvl_n, priv_lvl_q, priv_lvl_rdata;
   logic                         priv_lvl_we;
-  logic [1:0]                   priv_lvl_q_int;
 
   // Detect JVT writes (requires pipeline flush)
   logic                         csr_wr_in_wb;
@@ -1470,7 +1471,12 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
   assign mhartid_rdata      = mhartid_i;
   assign mconfigptr_rdata   = 32'h0;
 
+  // Only user mode is supported
   assign priv_lvl_rdata     = PRIV_LVL_M;
+  assign priv_lvl_q         = PRIV_LVL_M;
+  assign priv_lvl_lsu_o     = PRIV_LVL_M;
+  assign priv_lvl_if_ctrl_o.priv_lvl     = PRIV_LVL_M;
+  assign priv_lvl_if_ctrl_o.priv_lvl_set = 1'b0;
 
   // dcsr_rdata factors in the flop outputs and the nmip bit from the controller
   assign dcsr_rdata = DEBUG ? {dcsr_q[31:4], ctrl_fsm_i.pending_nmi, dcsr_q[2:0]} : 32'h0;

--- a/rtl/cv32e40x_if_stage.sv
+++ b/rtl/cv32e40x_if_stage.sv
@@ -81,6 +81,9 @@ module cv32e40x_if_stage import cv32e40x_pkg::*;
   output logic          if_valid_o,
   input  logic          id_ready_i,
 
+  // Privilege mode
+  input privlvlctrl_t   priv_lvl_ctrl_i,
+
   // eXtension interface
   cv32e40x_if_xif.cpu_compressed xif_compressed_if,      // XIF compressed interface
   input  logic                   xif_offloading_id_i     // ID stage attempts to offload an instruction
@@ -200,6 +203,7 @@ module cv32e40x_if_stage import cv32e40x_pkg::*;
     .rst_n                    ( rst_n                       ),
 
     .ctrl_fsm_i               ( ctrl_fsm_i                  ),
+    .priv_lvl_ctrl_i          ( priv_lvl_ctrl_i             ),
 
     .branch_addr_i            ( {branch_addr_n[31:1], 1'b0} ),
 

--- a/rtl/cv32e40x_load_store_unit.sv
+++ b/rtl/cv32e40x_load_store_unit.sv
@@ -77,6 +77,9 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
   output align_status_e lsu_align_status_1_o,   // Alignment status (for atomics), WB timing
   output lsu_atomic_e lsu_atomic_1_o,           // Is there an atomic in WB, and of which type.
 
+  // Privilege mode
+  input              privlvl_t priv_lvl_lsu_i,
+
   // Handshakes
   input  logic        valid_0_i,                // Handshakes for first LSU stage (EX)
   output logic        ready_0_o,                // LSU ready for new data in EX stage
@@ -211,7 +214,7 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
     trans.we    = id_ex_pipe_i.lsu_we;
     trans.size  = id_ex_pipe_i.lsu_size;
     trans.wdata = id_ex_pipe_i.operand_c;
-    trans.mode  = PRIV_LVL_M; // Machine mode
+    trans.mode  = priv_lvl_lsu_i;
     trans.dbg   = ctrl_fsm_i.debug_mode;
 
     trans.atop  = id_ex_pipe_i.lsu_atop;

--- a/rtl/cv32e40x_prefetch_unit.sv
+++ b/rtl/cv32e40x_prefetch_unit.sv
@@ -37,6 +37,7 @@ module cv32e40x_prefetch_unit import cv32e40x_pkg::*;
   input  logic        rst_n,
 
   input  ctrl_fsm_t   ctrl_fsm_i,
+  input  privlvlctrl_t priv_lvl_ctrl_i,
 
   input  logic [31:0] branch_addr_i,
 
@@ -114,6 +115,7 @@ module cv32e40x_prefetch_unit import cv32e40x_pkg::*;
     .rst_n                 ( rst_n                   ),
 
     .ctrl_fsm_i            ( ctrl_fsm_i              ),
+    .priv_lvl_ctrl_i       ( priv_lvl_ctrl_i         ),
 
     .branch_addr_i         ( branch_addr_i           ),
     .prefetch_busy_o       ( prefetch_busy_o         ),

--- a/rtl/include/cv32e40x_pkg.sv
+++ b/rtl/include/cv32e40x_pkg.sv
@@ -468,6 +468,12 @@ typedef enum logic[1:0] {
 
 parameter privlvl_t PRIV_LVL_LOWEST = PRIV_LVL_M;
 
+// Struct used for setting privilege level
+typedef struct packed {
+  logic        priv_lvl_set;
+  privlvl_t    priv_lvl;
+} privlvlctrl_t;
+
 // Machine Vendor ID - OpenHW JEDEC ID is '2 decimal (bank 13)'
 parameter MVENDORID_OFFSET = 7'h2;      // Final byte without parity bit
 parameter MVENDORID_BANK = 25'hC;       // Number of continuation codes


### PR DESCRIPTION
SEC clean.
instr_priv_lvl_q optimized away during synth.