### PR TITLE
Fixed undriven signals

### DIFF
--- a/rtl/cv32e40x_align_check.sv
+++ b/rtl/cv32e40x_align_check.sv
@@ -161,6 +161,7 @@ module cv32e40x_align_check import cv32e40x_pkg::*;
   assign core_resp_o.bus_resp     = bus_resp_i;
   assign core_resp_o.align_status = align_status;
   assign core_resp_o.mpu_status   = MPU_OK;  // Assigned in the MPU (upstream), tied off to MPU_OK here.
+  assign core_resp_o.wpt_match    = '0;      // Assigned in the watchpoint unit (upstream), tied off to zero here.
 
   // Detect alignment error
   assign align_err = align_check_en_i && misaligned_access_i;

--- a/rtl/cv32e40x_ff_one.sv
+++ b/rtl/cv32e40x_ff_one.sv
@@ -55,6 +55,9 @@ module cv32e40x_ff_one
     genvar k;
     genvar l;
     genvar level;
+
+    assign sel_nodes[2**NUM_LEVELS-1] = 1'b0;
+
     for (level = 0; level < NUM_LEVELS; level++) begin : gen_tree
     //------------------------------------------------------------
     if (level < NUM_LEVELS-1) begin : gen_non_root_level

--- a/rtl/cv32e40x_id_stage.sv
+++ b/rtl/cv32e40x_id_stage.sv
@@ -782,6 +782,8 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
       assign xif_issue_if.issue_req.ecs       = '0;
       assign xif_issue_if.issue_req.ecs_valid = '0;
 
+      assign xif_offloading_o                 = 1'b0;
+
       logic unused_xif_signals;
       assign unused_xif_signals = xif_insn_reject | (|rf_illegal_raddr);
     end


### PR DESCRIPTION
- xif_offloading_o in id_stage was not driven when X_EXT==0
- core_resp_o.wpt_match was not driven in the align checker in the LSU
- MSB of sel_nodes within ff_one was not driven. Also fixed on cv32e40p with commit ab162975a52b79e2f2bd5dc7511a9e849485c22d.