### PR TITLE
Improve Verilator compatibility

### DIFF
--- a/rtl/cv32e40x_core.sv
+++ b/rtl/cv32e40x_core.sv
@@ -400,7 +400,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
   assign dbg_ack   = ctrl_fsm.dbg_ack;
 
   // Gate off the internal debug_request signal if debug support is not configured.
-  assign debug_req_gated = DEBUG ? debug_req_i : 1'b0;
+  assign debug_req_gated = (DEBUG != 0) ? debug_req_i : 1'b0;
 
   //////////////////////////////////////////////////////////////////////////////////////////////
   //   ____ _            _      __  __                                                   _    //

--- a/rtl/cv32e40x_cs_registers.sv
+++ b/rtl/cv32e40x_cs_registers.sv
@@ -93,7 +93,7 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
   // Interrupts
   input  logic [31:0]                   mip_i,
   input  logic                          mnxti_irq_pending_i,
-  input  logic [CLIC_ID_WIDTH-1:0]    mnxti_irq_id_i,
+  input  logic [CLIC_ID_WIDTH-1:0]      mnxti_irq_id_i,
   input  logic [7:0]                    mnxti_irq_level_i,
   output logic                          clic_pa_valid_o,        // CSR read data is an address to a function pointer
   output logic [31:0]                   clic_pa_o,              // Address to CLIC function pointer
@@ -271,13 +271,13 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
 
 
   // Performance Counter Signals
-  logic [31:0] [63:0]           mhpmcounter_q;                                  // Performance counters
+  logic [63:0]                  mhpmcounter_q[31:0];                            // Performance counters
   logic [31:0] [63:0]           mhpmcounter_n;                                  // Performance counters next value
   logic [31:0] [63:0]           mhpmcounter_rdata;                              // Performance counters next value
   logic [31:0] [1:0]            mhpmcounter_we;                                 // Performance counters write enable
   logic [31:0] [31:0]           mhpmevent_q, mhpmevent_n, mhpmevent_rdata;      // Event enable
   logic [31:0]                  mcountinhibit_q, mcountinhibit_n, mcountinhibit_rdata; // Performance counter inhibit
-  logic [NUM_HPM_EVENTS-1:0]    hpm_events;                                     // Events for performance counters
+  logic                         hpm_events[NUM_HPM_EVENTS-1:0];                 // Events for performance counters
   logic [31:0] [63:0]           mhpmcounter_increment;                          // Increment of mhpmcounter_q
   logic [31:0]                  mhpmcounter_write_lower;                        // Write 32 lower bits of mhpmcounter_q
   logic [31:0]                  mhpmcounter_write_upper;                        // Write 32 upper bits mhpmcounter_q
@@ -535,7 +535,7 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
       end
 
       CSR_DCSR: begin
-        if (DEBUG) begin
+        if (DEBUG != 0) begin
           csr_rdata_int = dcsr_rdata;
           illegal_csr_read = !ctrl_fsm_i.debug_mode;
         end else begin
@@ -545,7 +545,7 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
       end
 
       CSR_DPC: begin
-        if (DEBUG) begin
+        if (DEBUG != 0) begin
           csr_rdata_int = dpc_rdata;
           illegal_csr_read = !ctrl_fsm_i.debug_mode;
         end else begin
@@ -555,7 +555,7 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
       end
 
       CSR_DSCRATCH0: begin
-        if (DEBUG) begin
+        if (DEBUG != 0) begin
           csr_rdata_int = dscratch0_rdata;
           illegal_csr_read = !ctrl_fsm_i.debug_mode;
         end else begin
@@ -565,7 +565,7 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
       end
 
       CSR_DSCRATCH1: begin
-        if (DEBUG) begin
+        if (DEBUG != 0) begin
           csr_rdata_int = dscratch1_rdata;
           illegal_csr_read = !ctrl_fsm_i.debug_mode;
         end else begin
@@ -1239,7 +1239,7 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
   );
 
   generate
-    if (DEBUG) begin : gen_debug_csr
+    if (DEBUG != 0) begin : gen_debug_csr
       cv32e40x_csr
       #(
         .WIDTH      (32),
@@ -1533,7 +1533,7 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
   assign priv_lvl_rdata     = PRIV_LVL_M;
 
   // dcsr_rdata factors in the flop outputs and the nmip bit from the controller
-  assign dcsr_rdata = DEBUG ? {dcsr_q[31:4], ctrl_fsm_i.pending_nmi, dcsr_q[2:0]} : 32'h0;
+  assign dcsr_rdata = (DEBUG != 0) ? {dcsr_q[31:4], ctrl_fsm_i.pending_nmi, dcsr_q[2:0]} : 32'h0;
 
 
   assign mcause_rdata = mcause_q;

--- a/rtl/cv32e40x_debug_triggers.sv
+++ b/rtl/cv32e40x_debug_triggers.sv
@@ -108,13 +108,13 @@ import cv32e40x_pkg::*;
       logic [DBG_NUM_TRIGGERS-1 : 0] tdata2_we_int;
 
       // CSR instance outputs
-      logic [31:0] tdata1_q[DBG_NUM_TRIGGERS];
-      logic [31:0] tdata2_q[DBG_NUM_TRIGGERS];
+      logic [31:0] tdata1_q[DBG_NUM_TRIGGERS-1:0];
+      logic [31:0] tdata2_q[DBG_NUM_TRIGGERS-1:0];
       logic [31:0] tselect_q;
 
       // CSR read data, possibly WARL resolved
-      logic [31:0] tdata1_rdata[DBG_NUM_TRIGGERS];
-      logic [31:0] tdata2_rdata[DBG_NUM_TRIGGERS];
+      logic [31:0] tdata1_rdata[DBG_NUM_TRIGGERS-1:0];
+      logic [31:0] tdata2_rdata[DBG_NUM_TRIGGERS-1:0];
 
       // IF, EX and WB stages trigger match
       logic [DBG_NUM_TRIGGERS-1 : 0] trigger_match_if;
@@ -127,7 +127,7 @@ import cv32e40x_pkg::*;
       // LSU address match signals
       logic [DBG_NUM_TRIGGERS-1 : 0] lsu_addr_match_en;
       logic [DBG_NUM_TRIGGERS-1 : 0] lsu_addr_match;
-      logic [3:0]                    lsu_byte_addr_match[DBG_NUM_TRIGGERS];
+      logic [3:0]                    lsu_byte_addr_match[DBG_NUM_TRIGGERS-1:0];
 
       // Enable matching based on privilege level per trigger
       logic [DBG_NUM_TRIGGERS-1 : 0] priv_lvl_match_en_if;
@@ -140,7 +140,7 @@ import cv32e40x_pkg::*;
       logic [31:0] lsu_addr_high;     // The highest accessed address of an LSU transaction
 
       // Exception trigger code match
-      logic [31:0] exception_match[DBG_NUM_TRIGGERS];
+      logic [31:0] exception_match[DBG_NUM_TRIGGERS-1:0];
 
       // Write data
       always_comb begin

--- a/rtl/cv32e40x_pma.sv
+++ b/rtl/cv32e40x_pma.sv
@@ -98,7 +98,7 @@ module cv32e40x_pma import cv32e40x_pkg::*;
 
   // Tie of atomic attribute if A_EXT=0
   generate
-    if (A_EXT) begin: pma_atomic
+    if (A_EXT != A_NONE) begin: pma_atomic
       assign pma_cfg_atomic = pma_cfg.atomic;
     end
     else begin: pma_no_atomic


### PR DESCRIPTION
# Improve Verilator compatibility
This pull request applies some changes to the RTL to avoid compilation errors with Verilator. In particular:
- Use explicit comparison in test statements on parameters (e.g., `if (DEBUG != 0)` instead of `if (DEBUG)`)
- Use unpacked array definition when both concurrent and continuous assignments are performed on the same signal
- Use downward ranges in signal definitions (e.g., `logic [N-1]` instead of `logic [N]`

## Component
**RTL**: 
- `rtl/cv32e40x_core.sv`
- `rtl/cv32e40x_cs_registers.sv`
- `rtl/cv32e40x_debug_triggers.sv`
- `rtl/cv32e40x_pma.sv`

## Revision
The fixes are currently applied to revision [f17028f](https://github.com/openhwgroup/cv32e40x/commit/f17028f2369373d9443e4636f2826218e8d54e0f) (v0.9.0).

## Limitations
This PR only solves a subset of suppressible Verilator warnings (e.g., through waiver files). In particular, the following waivers are known to be necessary to compile with no warnings:
```systemverilog
lint_off -rule PINCONNECTEMPTY -file "*/carus_cpu_subsystem.sv" -match "Cell pin connected by name with empty reference: '*'"
lint_off -rule PINCONNECTEMPTY -file "*/cv32e40x_if_stage.sv" -match "Cell pin connected by name with empty reference: '*'"
lint_off -rule PINCONNECTEMPTY -file "*/cv32e40x_load_store_unit.sv" -match "Cell pin connected by name with empty reference: 'core_align_err_o'"
lint_off -rule DECLFILENAME -file "*/cv32e40x_sim_clock_gate.sv" -match "Filename '*' does not match MODULE name: '*'"
lint_off -rule UNUSED -file "*/cv32e40x_*.sv" -match "Parameter is not used: '*'"
lint_off -rule UNUSED -file "*/if_xif*.sv" -match "Parameter is not used: '*'"
lint_off -rule UNUSED -file "*/if_xif.sv" -match "Signal is not used: 'compressed_*'"
lint_off -rule UNUSED -file "*/if_xif.sv" -match "Signal is not used: 'mem_*'"
lint_off -rule UNUSED -file "*/cv32e40x_*.sv" -match "Bits of signal are not*used: *"
lint_off -rule UNUSED -file "*/cv32e40x_*.sv" -match "Signal is not*used: *"
lint_off -rule WIDTH -file "*/cv32e40x_*.sv" -match "Operator * expects *"
lint_off -rule LITENDIAN -file "*/cv32e40x_*.sv" -match "Little bit endian vector: left < right of bit range: *"
lint_off -rule UNOPTFLAT -file "*/cv32e40x_*.sv" -match "Signal unoptimizable: *"
lint_off -rule UNOPTFLAT -file "*/if_xif*.sv" -match "Signal unoptimizable: *"
lint_off -rule BLKANDNBLK -file "*/cv32e40x_csr.sv" -match "Unsupported: Blocked and non-blocking assignments to same variable: *"
lint_off -rule UNDRIVEN -file "*/cv32e40x_align_check.sv" -match "Bits of signal are not driven: 'core_resp_o'[2]"
lint_off -rule COMBDLY -file "*/cv32e40x_sim_clock_gate.sv"
```

## Status
The included changes are currently applied to the `cv32e40x` core in [`X-HEEP` ](https://github.com/esl-epfl/x-heep). No bugs related to these changes are currently known.