### PR TITLE
Bugfix for mret with mcause.minhv==1

### DIFF
--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -411,6 +411,8 @@ if (CLIC) begin : clic_asserts
                                  .ctrl_fsm_cs             (core_i.controller_i.controller_fsm_i.ctrl_fsm_cs),
                                  .ctrl_fsm                (core_i.ctrl_fsm),
                                  .dcsr                    (core_i.dcsr),
+                                 .ex_wb_pipe_i            (core_i.ex_wb_pipe),
+                                 .last_op_wb_i            (core_i.last_op_wb),
                                  .*);
 end
 endgenerate

--- a/rtl/cv32e40x_controller_fsm.sv
+++ b/rtl/cv32e40x_controller_fsm.sv
@@ -378,10 +378,13 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
   // fence in wb
   assign fence_in_wb  = ex_wb_pipe_i.sys_en && ex_wb_pipe_i.sys_fence_insn && ex_wb_pipe_i.instr_valid;
 
-  // mret in wb - only valid when last_op_wb_i == 1 (which means only mret that did not cause a CLIC pointer fetch)
-  // Restricts CSR updates due to mret to not happen if the mret caused a CLIC pointer fetch, such CSR updates
-  // should only happen once the instruction fully completes (pointer arrives in WB).
-  assign mret_in_wb = ex_wb_pipe_i.sys_en && ex_wb_pipe_i.sys_mret_insn && ex_wb_pipe_i.instr_valid && last_op_wb_i;
+  // mret in wb - only valid when ex_wb_pipe_i.first_op == 1.
+  // Regular mret instruction will have first_op == last_op == 1.
+  // Mret with mcause.minhv==1 will restart a CLIC pointer fetch. The mret instruction will have first_op==1 && last_op==0
+  // while the pointer will finish the sequence with first_op==0 and last_op==1. The mret related CSR updates will happen
+  // once the mret instruction reaches WB. The pointer fetch may generate an exception, causing further CSR updates
+  // once the attempted pointer fetch reaches WB.
+  assign mret_in_wb = ex_wb_pipe_i.sys_en && ex_wb_pipe_i.sys_mret_insn && ex_wb_pipe_i.instr_valid && ex_wb_pipe_i.first_op;
 
   // CLIC pointer (caused by mret) in WB.
   assign mret_ptr_in_wb = ex_wb_pipe_i.instr_meta.mret_ptr && ex_wb_pipe_i.instr_valid;
@@ -671,7 +674,6 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
     ctrl_fsm_o.kill_wb          = 1'b0;
 
     ctrl_fsm_o.csr_restore_mret = 1'b0;
-    ctrl_fsm_o.csr_restore_mret_ptr = 1'b0;
     ctrl_fsm_o.csr_restore_dret = 1'b0;
 
     ctrl_fsm_o.csr_save_cause   = 1'b0;
@@ -1041,12 +1043,6 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
           // Regular mret in WB restores CSR regs
           if (mret_in_wb && !ctrl_fsm_o.kill_wb && !ctrl_fsm_o.halt_wb) begin
             ctrl_fsm_o.csr_restore_mret  = !debug_mode_q;
-          end
-
-          // For mret that caused a CLIC pointer fetch, CSR updates will happen once the pointer reaches WB.
-          // If the pointer has associated exceptions, the csr_restore_mret_ptr will not happen
-          if (mret_ptr_in_wb && !ctrl_fsm_o.kill_wb && !ctrl_fsm_o.halt_wb && !exception_in_wb) begin
-            ctrl_fsm_o.csr_restore_mret_ptr  = !debug_mode_q;
           end
 
         end // !debug or interrupts

--- a/rtl/cv32e40x_cs_registers.sv
+++ b/rtl/cv32e40x_cs_registers.sv
@@ -1129,8 +1129,7 @@ module cv32e40x_cs_registers import cv32e40x_pkg::*;
         end
       end //ctrl_fsm_i.csr_save_cause
 
-      ctrl_fsm_i.csr_restore_mret,
-      ctrl_fsm_i.csr_restore_mret_ptr: begin // MRET
+      ctrl_fsm_i.csr_restore_mret: begin // MRET
         priv_lvl_n     = privlvl_t'(mstatus_rdata.mpp);
         priv_lvl_we    = 1'b1;
 

--- a/rtl/include/cv32e40x_pkg.sv
+++ b/rtl/include/cv32e40x_pkg.sv
@@ -1373,7 +1373,6 @@ typedef struct packed {
   logic [31:0] pipe_pc;             // PC from pipeline
   mcause_t     csr_cause;           // CSR cause (saves to mcause CSR)
   logic        csr_restore_mret;    // Restore CSR due to mret
-  logic        csr_restore_mret_ptr; // Restore CSR due to mret followed by CLIC
   logic        csr_restore_dret;    // Restore CSR due to dret
   logic        csr_save_cause;      // Update CSRs
   logic        pending_nmi;         // An NMI is pending (for dcsr.nmip)

--- a/sva/cv32e40x_clic_int_controller_sva.sv
+++ b/sva/cv32e40x_clic_int_controller_sva.sv
@@ -64,7 +64,8 @@ module cv32e40x_clic_int_controller_sva
        irq_req_ctrl_o && $stable(clic_irq_q) && $stable(clic_irq_level_q) && !(ctrl_fsm.debug_mode || (dcsr.step && !dcsr.stepie))
        |->
        ((ctrl_pending_interrupt && ctrl_interrupt_allowed) || // Interrupt pendinding and allowed to be taken
-        ($past(ex_wb_pipe_i.instr_valid) && $past(ex_wb_pipe_i.sys_en) && $past(ex_wb_pipe_i.sys_mret_insn) && !$past(last_op_wb_i))) // Interrupts enabled by mret mid-sequence
+        ($past(ex_wb_pipe_i.instr_valid) && $past(ex_wb_pipe_i.sys_en) && $past(ex_wb_pipe_i.sys_mret_insn) && !$past(last_op_wb_i)) &&
+        (ctrl_pending_interrupt && !ctrl_interrupt_allowed)) // Interrupts enabled by mret mid-sequence, not allowed to be taken
     );
   endproperty;
 

--- a/sva/cv32e40x_clic_int_controller_sva.sv
+++ b/sva/cv32e40x_clic_int_controller_sva.sv
@@ -50,7 +50,10 @@ module cv32e40x_clic_int_controller_sva
    input ctrl_state_e ctrl_fsm_cs,
 
    input ctrl_fsm_t   ctrl_fsm,
-   input dcsr_t       dcsr
+   input dcsr_t       dcsr,
+
+   input ex_wb_pipe_t ex_wb_pipe_i,
+   input logic        last_op_wb_i
 );
 
   // Check that a pending interrupt is taken as soon as possible after being enabled
@@ -59,7 +62,10 @@ module cv32e40x_clic_int_controller_sva
     ( !irq_req_ctrl_o
        ##1
        irq_req_ctrl_o && $stable(clic_irq_q) && $stable(clic_irq_level_q) && !(ctrl_fsm.debug_mode || (dcsr.step && !dcsr.stepie))
-       |-> (ctrl_pending_interrupt && ctrl_interrupt_allowed));
+       |->
+       ((ctrl_pending_interrupt && ctrl_interrupt_allowed) || // Interrupt pendinding and allowed to be taken
+        ($past(ex_wb_pipe_i.instr_valid) && $past(ex_wb_pipe_i.sys_en) && $past(ex_wb_pipe_i.sys_mret_insn) && !$past(last_op_wb_i))) // Interrupts enabled by mret mid-sequence
+    );
   endproperty;
 
   a_clic_enable: assert property(p_clic_enable)
@@ -72,7 +78,8 @@ module cv32e40x_clic_int_controller_sva
       ##1                        // Next cycle
       irq_req_ctrl_o && $stable(clic_irq_q) && $stable(clic_irq_level_q) && !(ctrl_fsm.debug_mode || (dcsr.step && !dcsr.stepie)) && // Interrupt pending but irq inputs are unchanged
       (ctrl_fsm_cs != DEBUG_TAKEN) &&  // Make sure we are not handling a debug entry already (could be a single stepped mret enabling interrupts for instance)
-      !(ctrl_pending_nmi || ctrl_pending_async_debug)   // No pending events with higher priority than interrupts are taking place
+      !(ctrl_pending_nmi || ctrl_pending_async_debug) &&  // No pending events with higher priority than interrupts are taking place
+      ctrl_interrupt_allowed                              // and interrupts are allowed (mret which restarts pointer fetch may reenable interrupts before the sequence is finished)
       |->
       ctrl_fsm.irq_ack  // We must take the interrupt if enabled (mret or CSR write) and no NMI or external debug is pending
     );


### PR DESCRIPTION
Mret with mcause.minhv==1 will now perform CSR side effects of the mret once the instruction itself reaches WB. The following table lookup will complete the instruction, and update CSRs if the table lookup failed during fetch.

Updates to RVFI to enable signaling correct CSR rdata/rmask and wdata/wmask for the combined CSR effetcts of an mret with a following table lookup.

SEC clean when mcause.minhv is assumed to be 0.