### PR TITLE
Removed exception codes 4 and 6 for misaligned atomics.

### DIFF
--- a/bhv/cv32e40x_wrapper.sv
+++ b/bhv/cv32e40x_wrapper.sv
@@ -631,6 +631,7 @@ endgenerate
          .lsu_pma_err_ex_i         ( core_i.load_store_unit_i.mpu_i.pma_i.pma_err_o                       ),
          .lsu_pma_atomic_ex_i      ( core_i.load_store_unit_i.mpu_i.pma_i.atomic_access_i                 ),
          .lsu_pma_cfg_ex_i         ( core_i.load_store_unit_i.mpu_i.pma_i.pma_cfg                         ),
+         .lsu_atomic_align_err_ex_i( core_i.load_store_unit_i.align_check_i.align_err                     ),
          .lsu_misaligned_ex_i      ( core_i.load_store_unit_i.misaligned_access                           ),
          .buffer_trans_ex_i        ( core_i.load_store_unit_i.buffer_trans                                ),
          .buffer_trans_valid_ex_i  ( core_i.load_store_unit_i.buffer_trans_valid                          ),

--- a/bhv/include/cv32e40x_rvfi_pkg.sv
+++ b/bhv/include/cv32e40x_rvfi_pkg.sv
@@ -32,7 +32,8 @@ package cv32e40x_rvfi_pkg;
   typedef enum logic [1:0] { // Memory error types
     MEM_ERR_IO_ALIGN          = 2'h0,
     MEM_ERR_ATOMIC            = 2'h1,
-    MEM_ERR_PMP               = 2'h2
+    MEM_ERR_PMP               = 2'h2,
+    MEM_ERR_ATOMIC_MISALIGN   = 2'h3
   } mem_err_t;
 
   typedef struct packed { // Autonomously updated CSRs

--- a/rtl/cv32e40x_controller_fsm.sv
+++ b/rtl/cv32e40x_controller_fsm.sv
@@ -353,8 +353,8 @@ module cv32e40x_controller_fsm import cv32e40x_pkg::*;
                                 !dcsr_i.ebreakm && !debug_mode_q)                                                            ? EXC_CAUSE_BREAKPOINT       :
                               (mpu_status_wb_i == MPU_WR_FAULT)                                                              ? EXC_CAUSE_STORE_FAULT      :
                               (mpu_status_wb_i == MPU_RE_FAULT)                                                              ? EXC_CAUSE_LOAD_FAULT       :
-                              (align_status_wb_i == ALIGN_WR_ERR)                                                            ? EXC_CAUSE_STORE_MISALIGNED :
-                                                                                                                               EXC_CAUSE_LOAD_MISALIGNED;
+                              (align_status_wb_i == ALIGN_WR_ERR)                                                            ? EXC_CAUSE_STORE_FAULT      :
+                                                                                                                               EXC_CAUSE_LOAD_FAULT;
 
   assign ctrl_fsm_o.exception_cause_wb = exception_cause_wb;
 

--- a/rtl/cv32e40x_debug_triggers.sv
+++ b/rtl/cv32e40x_debug_triggers.sv
@@ -77,8 +77,7 @@ import cv32e40x_pkg::*;
   output logic        etrigger_wb_o        // Exception trigger match
 );
 
-  // Set mask for supported exception codes for exception triggers.
-  // Codes 4 and 6 for misaligned load/stores can only occur when A_EXT != A_NONE
+  // Set mask for supported exception codes for exception triggers
   localparam logic [31:0] ETRIGGER_TDATA2_MASK = (1 << EXC_CAUSE_INSTR_BUS_FAULT) | (1 << EXC_CAUSE_ECALL_MMODE) | (1 << EXC_CAUSE_STORE_FAULT) |
                                                    (1 << EXC_CAUSE_LOAD_FAULT) | (1 << EXC_CAUSE_BREAKPOINT) | (1 << EXC_CAUSE_ILLEGAL_INSN) | (1 << EXC_CAUSE_INSTR_FAULT);
 

--- a/rtl/cv32e40x_debug_triggers.sv
+++ b/rtl/cv32e40x_debug_triggers.sv
@@ -80,8 +80,7 @@ import cv32e40x_pkg::*;
   // Set mask for supported exception codes for exception triggers.
   // Codes 4 and 6 for misaligned load/stores can only occur when A_EXT != A_NONE
   localparam logic [31:0] ETRIGGER_TDATA2_MASK = (1 << EXC_CAUSE_INSTR_BUS_FAULT) | (1 << EXC_CAUSE_ECALL_MMODE) | (1 << EXC_CAUSE_STORE_FAULT) |
-                                                   (1 << EXC_CAUSE_LOAD_FAULT) | (1 << EXC_CAUSE_BREAKPOINT) | (1 << EXC_CAUSE_ILLEGAL_INSN) | (1 << EXC_CAUSE_INSTR_FAULT) |
-                                                   (32'(A_EXT != A_NONE) << EXC_CAUSE_LOAD_MISALIGNED) | (32'(A_EXT != A_NONE) << EXC_CAUSE_STORE_MISALIGNED);
+                                                   (1 << EXC_CAUSE_LOAD_FAULT) | (1 << EXC_CAUSE_BREAKPOINT) | (1 << EXC_CAUSE_ILLEGAL_INSN) | (1 << EXC_CAUSE_INSTR_FAULT);
 
 
   // CSR write data

--- a/rtl/include/cv32e40x_pkg.sv
+++ b/rtl/include/cv32e40x_pkg.sv
@@ -939,9 +939,7 @@ typedef enum logic[3:0] {
 parameter EXC_CAUSE_INSTR_FAULT      = 11'h01;
 parameter EXC_CAUSE_ILLEGAL_INSN     = 11'h02;
 parameter EXC_CAUSE_BREAKPOINT       = 11'h03;
-parameter EXC_CAUSE_LOAD_MISALIGNED  = 11'h04;
 parameter EXC_CAUSE_LOAD_FAULT       = 11'h05;
-parameter EXC_CAUSE_STORE_MISALIGNED = 11'h06;
 parameter EXC_CAUSE_STORE_FAULT      = 11'h07;
 parameter EXC_CAUSE_ECALL_MMODE      = 11'h0B;
 parameter EXC_CAUSE_INSTR_BUS_FAULT  = 11'h18;

--- a/sva/cv32e40x_rvfi_sva.sv
+++ b/sva/cv32e40x_rvfi_sva.sv
@@ -269,7 +269,7 @@ if ((A_EXT == A) || (A_EXT == ZALRSC)) begin
   // cause_type MEM_ERR_IO_ALIGN
   //
   // Misaligned atomics which are otherwise not blocked by the PMA (cfg is main and atomic) shall use either
-  // EXC_CAUSE_LOAD_MISALIGNED or EXC_CAUSE_STORE_MISALIGNED with cause_type MEM_ERR_IO_ALIGN.
+  // EXC_CAUSE_LOAD_FAULT or EXC_CAUSE_STORE_FAULT with cause_type MEM_ERR_ATOMIC_MISALIGN.
   a_aligned_lr_access_fault_trap:
   assert property (@(posedge clk_i) disable iff (!rst_ni)
                   pc_mux_exception && (lsu_atomic_wb_i == AT_LR) && lsu_en_wb_i &&
@@ -286,8 +286,8 @@ if ((A_EXT == A) || (A_EXT == ZALRSC)) begin
                   lsu_split_q_wb_i
                   |=>
                   rvfi_valid &&
-                  ((rvfi_trap.cause_type == MEM_ERR_IO_ALIGN) &&
-                  (rvfi_trap.exception_cause == EXC_CAUSE_LOAD_MISALIGNED))
+                  ((rvfi_trap.cause_type == MEM_ERR_ATOMIC_MISALIGN) &&
+                  (rvfi_trap.exception_cause == EXC_CAUSE_LOAD_FAULT))
                   or
                   ((rvfi_trap.cause_type == MEM_ERR_ATOMIC) &&
                   (rvfi_trap.exception_cause == EXC_CAUSE_LOAD_FAULT))
@@ -312,8 +312,8 @@ if ((A_EXT == A) || (A_EXT == ZALRSC)) begin
                   lsu_split_q_wb_i
                   |=>
                   rvfi_valid &&
-                  ((rvfi_trap.cause_type == MEM_ERR_IO_ALIGN) &&
-                  (rvfi_trap.exception_cause == EXC_CAUSE_STORE_MISALIGNED))
+                  ((rvfi_trap.cause_type == MEM_ERR_ATOMIC_MISALIGN) &&
+                  (rvfi_trap.exception_cause == EXC_CAUSE_STORE_FAULT))
                   or
                   ((rvfi_trap.cause_type == MEM_ERR_ATOMIC) &&
                   (rvfi_trap.exception_cause == EXC_CAUSE_STORE_FAULT))
@@ -340,8 +340,8 @@ if (A_EXT == A) begin
                   lsu_split_q_wb_i
                   |=>
                   rvfi_valid &&
-                  ((rvfi_trap.cause_type == MEM_ERR_IO_ALIGN) &&
-                  (rvfi_trap.exception_cause == EXC_CAUSE_STORE_MISALIGNED))
+                  ((rvfi_trap.cause_type == MEM_ERR_ATOMIC_MISALIGN) &&
+                  (rvfi_trap.exception_cause == EXC_CAUSE_STORE_FAULT))
                   or
                   ((rvfi_trap.cause_type == MEM_ERR_ATOMIC) &&
                   (rvfi_trap.exception_cause == EXC_CAUSE_STORE_FAULT))


### PR DESCRIPTION
Misaligned atomics will now issue codes 5 and 7 if they otherwise pass the MMU. The rvfi_trap.cause_type field will be set to 3 to mark that codes 5 and 7 are for misaligned atomics.