### PR TITLE
Split interface definition and package import

### DIFF
--- a/rtl/cv32e40x_if_c_obi.sv
+++ b/rtl/cv32e40x_if_c_obi.sv
@@ -24,8 +24,9 @@
 // 
 // The 'c' in the interface names means 'Compressed'
 // since this interface is a subset of the full OBI spec.
-interface cv32e40x_if_c_obi import cv32e40x_pkg::*;
-#(
+import cv32e40x_pkg::*;
+
+interface cv32e40x_if_c_obi #(
     parameter type REQ_TYPE  = obi_inst_req_t,
     parameter type RESP_TYPE = obi_inst_resp_t
 );


### PR DESCRIPTION
This split is meant to avoid building errors when using verilator tool. This problem has been observed on a couple of versions of verilator and this patch resolves the issue.