### PR TITLE
Added dedicated LSU operand registers

### DIFF
--- a/rtl/cv32e40x_id_stage.sv
+++ b/rtl/cv32e40x_id_stage.sv
@@ -516,6 +516,9 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
       id_ex_pipe_o.csr_en                 <= 1'b0;
       id_ex_pipe_o.csr_op                 <= CSR_OP_READ;
 
+      id_ex_pipe_o.lsu_operand_a          <= 32'b0;
+      id_ex_pipe_o.lsu_operand_b          <= 32'b0;
+      id_ex_pipe_o.lsu_operand_c          <= 32'b0;
       id_ex_pipe_o.lsu_en                 <= 1'b0;
       id_ex_pipe_o.lsu_we                 <= 1'b0;
       id_ex_pipe_o.lsu_size               <= 2'b0;
@@ -561,15 +564,15 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
 
         // Operands
         if (alu_op_a_mux_sel != OP_A_NONE) begin
-          id_ex_pipe_o.alu_operand_a        <= operand_a;               // Used by most ALU, CSR and LSU instructions
+          id_ex_pipe_o.alu_operand_a        <= operand_a;               // Used by most ALU and CSR instructions
         end
         if (alu_op_b_mux_sel != OP_B_NONE) begin
-          id_ex_pipe_o.alu_operand_b        <= operand_b;               // Used by most ALU, CSR and LSU instructions
+          id_ex_pipe_o.alu_operand_b        <= operand_b;               // Used by most ALU and CSR instructions
         end
 
         if (op_c_mux_sel != OP_C_NONE)
         begin
-          id_ex_pipe_o.operand_c            <= operand_c;               // Used by LSU stores and some ALU instructions
+          id_ex_pipe_o.operand_c            <= operand_c;               // Used by some ALU instructions
         end
 
         id_ex_pipe_o.alu_en                 <= alu_en;
@@ -604,6 +607,10 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
 
         id_ex_pipe_o.lsu_en                 <= lsu_en;
         if (lsu_en) begin
+          // Dedicated LSU operand registers to prevent ALU operands from being visible at the data memory interface
+          id_ex_pipe_o.lsu_operand_a        <= operand_a;
+          id_ex_pipe_o.lsu_operand_b        <= operand_b;
+          id_ex_pipe_o.lsu_operand_c        <= operand_c;               // Used by LSU stores
           id_ex_pipe_o.lsu_we               <= lsu_we;
           id_ex_pipe_o.lsu_size             <= lsu_size;
           id_ex_pipe_o.lsu_sext             <= lsu_sext;

--- a/rtl/cv32e40x_load_store_unit.sv
+++ b/rtl/cv32e40x_load_store_unit.sv
@@ -210,10 +210,10 @@ module cv32e40x_load_store_unit import cv32e40x_pkg::*;
   // Transaction (before aligner)
   // Generate address from operands (atomic memory transactions do not use an address offset computation)
   always_comb begin
-    trans.addr  = id_ex_pipe_i.lsu_atop[5] ? id_ex_pipe_i.alu_operand_a : (id_ex_pipe_i.alu_operand_a + id_ex_pipe_i.alu_operand_b);
+    trans.addr  = id_ex_pipe_i.lsu_atop[5] ? id_ex_pipe_i.lsu_operand_a : (id_ex_pipe_i.lsu_operand_a + id_ex_pipe_i.lsu_operand_b);
     trans.we    = id_ex_pipe_i.lsu_we;
     trans.size  = id_ex_pipe_i.lsu_size;
-    trans.wdata = id_ex_pipe_i.operand_c;
+    trans.wdata = id_ex_pipe_i.lsu_operand_c;
     trans.mode  = priv_lvl_lsu_i;
     trans.dbg   = ctrl_fsm_i.debug_mode;
 

--- a/rtl/include/cv32e40x_pkg.sv
+++ b/rtl/include/cv32e40x_pkg.sv
@@ -1193,6 +1193,9 @@ typedef struct packed {
   csr_opcode_e  csr_op;
 
   // LSU
+  logic [31:0]  lsu_operand_a;
+  logic [31:0]  lsu_operand_b;
+  logic [31:0]  lsu_operand_c;
   logic         lsu_en;
   logic         lsu_we;
   logic [1:0]   lsu_size;


### PR DESCRIPTION
Based on a discussion with @Silabs-ArjanB 

This PR introduces dedicated registers for LSU operands, which prevents the operands of non-LSU instructions from leaking to the data memory interface. 
In the current version, internal data is always encoded as an address and forwarded, even if _data_req_o_ is low.
A connected device that does not conform to the OBI protocol (because it's buggy or malicious) could use this covert channel to undermine security features such as _data_ind_timing_.

I have implemented the identical fix in my setup for cv32e40s to ensure that non-LSU operands do not leak to the data memory interface. 
There may still be invalid memory requests and thus stale data, but only for LSU instructions.
Also, I have not yet considered compressed instructions.

I have not run any functional verification with this fix implemented.