### PR TITLE
User Manual Abbreviations - `CSR` and `RVFI` in Section Names

### DIFF
--- a/docs/user_manual/source/control_status_registers.rst
+++ b/docs/user_manual/source/control_status_registers.rst
@@ -1,7 +1,7 @@
 .. _cs-registers:
 
-Control and Status Registers
-============================
+Control and Status Registers (CSRs)
+===================================
 
 CSR Map
 -------

--- a/docs/user_manual/source/rvfi.rst
+++ b/docs/user_manual/source/rvfi.rst
@@ -1,7 +1,7 @@
 .. _rvfi:
 
-RISC-V Formal Interface
-=======================
+RISC-V Formal Interface (RVFI)
+==============================
 
 .. note::
 


### PR DESCRIPTION
This PR adds ` (CSR)` and ` (RVFI)` to the corresponding section headers in the user manual.

The reason is that I several times have wanted to look up those things, hit `ctrl+f` and found nothing, having to stop for a moment and try to remember what we titled our section headers or scan through the list of sections until I find it.
This change will alleviate some discontentment.

I have not tested this in any way.
For those familiar with the formatting, you might visually recognize if it is correct or not.