### PR TITLE
Implement the Zicond standard ISA extension

### DIFF
--- a/rtl/cv32e40x_alu.sv
+++ b/rtl/cv32e40x_alu.sv
@@ -49,7 +49,8 @@
 
 module cv32e40x_alu import cv32e40x_pkg::*;
 #(
-  parameter b_ext_e B_EXT  = B_NONE
+  parameter b_ext_e  B_EXT  = B_NONE
+  parameter ic_ext_e IC_EXT = IC_NONE
 )
 (
   input  alu_opcode_e       operator_i,
@@ -328,6 +329,25 @@ module cv32e40x_alu import cv32e40x_pkg::*;
     end
   endgenerate
 
+  // TODO: make a cool heading for conditional zeroing?
+
+  logic czeqz_result [31:0];
+  logic cznez_result [31:0];
+
+  generate
+    if (IC_EXT == ZICOND) begin: icond
+
+      assign czeqz_result = operand_a_i & {(32){ |operand_b_i}};
+      assign cznez_result = operand_a_i & {(32){~|operand_b_i}};
+
+    end else begin: no_icond
+
+      assign czeqz_result = 32'h0;
+      assign cznez_result = 32'h0;
+
+    end
+  endgenerate
+
   ////////////////////////////////////////////////////////
   //   ____                 _ _     __  __              //
   //  |  _ \ ___  ___ _   _| | |_  |  \/  |_   ___  __  //
@@ -397,8 +417,8 @@ module cv32e40x_alu import cv32e40x_pkg::*;
       ALU_B_CLMULH : result_o = clmulh_result;
       ALU_B_CLMULR : result_o = clmulr_result;
 
-	  ALU_CZEQZ    : result_o = operand_a_i & (32){~&operand_b_i};
-	  ALU_CZNEZ    : result_o = operand_a_i & (32){&operand_b_i};
+      ALU_CZEQZ    : result_o = czeqz_result;
+      ALU_CZNEZ    : result_o = cznez_result; 
 
       default: ;
     endcase

--- a/rtl/cv32e40x_alu.sv
+++ b/rtl/cv32e40x_alu.sv
@@ -397,6 +397,9 @@ module cv32e40x_alu import cv32e40x_pkg::*;
       ALU_B_CLMULH : result_o = clmulh_result;
       ALU_B_CLMULR : result_o = clmulr_result;
 
+	  ALU_CZEQZ    : result_o = operand_a_i & (32){~&operand_b_i};
+	  ALU_CZNEZ    : result_o = operand_a_i & (32){&operand_b_i};
+
       default: ;
     endcase
 

--- a/rtl/cv32e40x_alu.sv
+++ b/rtl/cv32e40x_alu.sv
@@ -418,7 +418,7 @@ module cv32e40x_alu import cv32e40x_pkg::*;
       ALU_B_CLMULR : result_o = clmulr_result;
 
       ALU_CZEQZ    : result_o = czeqz_result;
-      ALU_CZNEZ    : result_o = cznez_result; 
+      ALU_CZNEZ    : result_o = cznez_result;
 
       default: ;
     endcase

--- a/rtl/cv32e40x_alu.sv
+++ b/rtl/cv32e40x_alu.sv
@@ -329,7 +329,7 @@ module cv32e40x_alu import cv32e40x_pkg::*;
     end
   endgenerate
 
-  // TODO: make a cool heading for conditional zeroing?
+  // TODO:style make a cool heading for conditional zeroing?
 
   logic czeqz_result [31:0];
   logic cznez_result [31:0];

--- a/rtl/cv32e40x_core.sv
+++ b/rtl/cv32e40x_core.sv
@@ -529,6 +529,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .A_EXT                        ( A_EXT                     ),
     .B_EXT                        ( B_EXT                     ),
     .M_EXT                        ( M_EXT                     ),
+    .IC_EXT                       ( IC_EXT                    ),
     .X_EXT                        ( X_EXT                     ),
     .REGFILE_NUM_READ_PORTS       ( REGFILE_NUM_READ_PORTS    ),
     .CLIC                         ( CLIC                      )
@@ -600,6 +601,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
     .X_EXT                      ( X_EXT                        ),
     .B_EXT                      ( B_EXT                        ),
     .M_EXT                      ( M_EXT                        )
+    .IC_EXT                     ( IC_EXT                       )
   )
   ex_stage_i
   (

--- a/rtl/cv32e40x_core.sv
+++ b/rtl/cv32e40x_core.sv
@@ -36,6 +36,7 @@ module cv32e40x_core import cv32e40x_pkg::*;
   parameter a_ext_e                     A_EXT                                   = A_NONE,
   parameter b_ext_e                     B_EXT                                   = B_NONE,
   parameter m_ext_e                     M_EXT                                   = M,
+  parameter ic_ext_e                    IC_EXT                                  = IC_NONE,
   parameter bit                         DEBUG                                   = 1,
   parameter logic [31:0]                DM_REGION_START                         = 32'hF0000000,
   parameter logic [31:0]                DM_REGION_END                           = 32'hF0003FFF,

--- a/rtl/cv32e40x_decoder.sv
+++ b/rtl/cv32e40x_decoder.sv
@@ -240,7 +240,7 @@ module cv32e40x_decoder import cv32e40x_pkg::*;
       assign dec_m_rf_illegal_addr = 1'b0;
       assign decoder_m_ctrl = DECODER_CTRL_ILLEGAL_INSN;
     end
-    
+
     if (IC_EXT != IC_NONE) begin: zicond_decoder
       // RV32Zicond extension decoder
       cv32e40x_zicond_decoder

--- a/rtl/cv32e40x_decoder.sv
+++ b/rtl/cv32e40x_decoder.sv
@@ -118,12 +118,14 @@ module cv32e40x_decoder import cv32e40x_pkg::*;
   logic dec_a_rf_illegal_addr;
   logic dec_b_rf_illegal_addr;
   logic dec_m_rf_illegal_addr;
+  logic dec_zicond_rf_illegal_addr;
   logic rf_illegal_waddr;
 
   decoder_ctrl_t decoder_i_ctrl, decoder_i_ctrl_int;
   decoder_ctrl_t decoder_m_ctrl, decoder_m_ctrl_int;
   decoder_ctrl_t decoder_a_ctrl, decoder_a_ctrl_int;
   decoder_ctrl_t decoder_b_ctrl, decoder_b_ctrl_int;
+  decoder_ctrl_t decoder_zicond_ctrl, decoder_zicond_ctrl_int;
   decoder_ctrl_t decoder_ctrl_mux;
 
   assign instr_rdata = if_id_pipe_i.instr.bus_resp.rdata;
@@ -238,6 +240,29 @@ module cv32e40x_decoder import cv32e40x_pkg::*;
       assign dec_m_rf_illegal_addr = 1'b0;
       assign decoder_m_ctrl = DECODER_CTRL_ILLEGAL_INSN;
     end
+    
+    if (IC_EXT != IC_NONE) begin: zicond_decoder
+      // RV32Zicond extension decoder
+      cv32e40x_zicond_decoder
+      zicond_decoder_i
+      (
+       .instr_rdata_i  ( instr_rdata             ),
+       .decoder_ctrl_o ( decoder_zicond_ctrl_int )
+      );
+
+      assign dec_zicond_rf_illegal_addr = (decoder_zicond_ctrl_int.rf_re[0] && rf_illegal_raddr_o[0]) ||
+                                          (decoder_zicond_ctrl_int.rf_re[1] && rf_illegal_raddr_o[1]) ||
+                                          (decoder_zicond_ctrl_int.rf_we    && rf_illegal_waddr);
+
+      // Take illegal compressed instruction and illegal RV32E GPR address into account
+      assign decoder_zicond_ctrl = (dec_zicond_rf_illegal_addr || if_id_pipe_i.illegal_c_insn) ?
+                                   DECODER_CTRL_ILLEGAL_INSN :
+                                   decoder_zicond_ctrl_int;
+
+    end else begin: no_zicond_decoder
+      assign dec_zicond_rf_illegal_addr = 1'b0;
+      assign decoder_zicond_ctrl = DECODER_CTRL_ILLEGAL_INSN;
+    end
 
   endgenerate
 
@@ -249,6 +274,7 @@ module cv32e40x_decoder import cv32e40x_pkg::*;
       !decoder_a_ctrl.illegal_insn : decoder_ctrl_mux = decoder_a_ctrl; // A decoder got a match
       !decoder_i_ctrl.illegal_insn : decoder_ctrl_mux = decoder_i_ctrl; // I decoder got a match
       !decoder_b_ctrl.illegal_insn : decoder_ctrl_mux = decoder_b_ctrl; // B decoder got a match
+      !decoder_zicond_ctrl.illegal_insn : decoder_ctrl_mux = decoder_zicond_ctrl; // Zicond decoder got a match
       default                      : decoder_ctrl_mux = DECODER_CTRL_ILLEGAL_INSN; // No match from decoders, illegal instruction
     endcase
   end

--- a/rtl/cv32e40x_ex_stage.sv
+++ b/rtl/cv32e40x_ex_stage.sv
@@ -32,10 +32,10 @@
 
 module cv32e40x_ex_stage import cv32e40x_pkg::*;
 #(
-  parameter bit      X_EXT            = 1'b0,
-  parameter b_ext_e  B_EXT            = B_NONE,
-  parameter m_ext_e  M_EXT            = M,
-  parameter ic_ext_e IC_EXT           = IC_NONE
+  parameter bit      X_EXT           = 1'b0,
+  parameter b_ext_e  B_EXT           = B_NONE,
+  parameter m_ext_e  M_EXT           = M,
+  parameter ic_ext_e IC_EXT          = IC_NONE
 )
 (
   input  logic        clk,

--- a/rtl/cv32e40x_ex_stage.sv
+++ b/rtl/cv32e40x_ex_stage.sv
@@ -32,9 +32,10 @@
 
 module cv32e40x_ex_stage import cv32e40x_pkg::*;
 #(
-  parameter bit     X_EXT            = 1'b0,
-  parameter b_ext_e B_EXT            = B_NONE,
-  parameter m_ext_e M_EXT            = M
+  parameter bit      X_EXT            = 1'b0,
+  parameter b_ext_e  B_EXT            = B_NONE,
+  parameter m_ext_e  M_EXT            = M,
+  parameter ic_ext_e IC_EXT           = IC_NONE
 )
 (
   input  logic        clk,
@@ -193,7 +194,7 @@ module cv32e40x_ex_stage import cv32e40x_pkg::*;
   ////////////////////////////
 
   cv32e40x_alu
-    #(.B_EXT(B_EXT))
+    #(.B_EXT(B_EXT) .IC_EXT(IC_EXT))
   alu_i
   (
     .operator_i          ( id_ex_pipe_i.alu_operator     ),

--- a/rtl/cv32e40x_i_decoder.sv
+++ b/rtl/cv32e40x_i_decoder.sv
@@ -245,16 +245,18 @@ module cv32e40x_i_decoder import cv32e40x_pkg::*;
 
           unique case ({instr_rdata_i[30:25], instr_rdata_i[14:12]})
             // RV32I ALU operations
-            {6'b00_0000, 3'b000}: decoder_ctrl_o.alu_operator = ALU_ADD;  // Add
-            {6'b10_0000, 3'b000}: decoder_ctrl_o.alu_operator = ALU_SUB;  // Sub
-            {6'b00_0000, 3'b010}: decoder_ctrl_o.alu_operator = ALU_SLT;  // Set Lower Than
-            {6'b00_0000, 3'b011}: decoder_ctrl_o.alu_operator = ALU_SLTU; // Set Lower Than Unsigned
-            {6'b00_0000, 3'b100}: decoder_ctrl_o.alu_operator = ALU_XOR;  // Xor
-            {6'b00_0000, 3'b110}: decoder_ctrl_o.alu_operator = ALU_OR;   // Or
-            {6'b00_0000, 3'b111}: decoder_ctrl_o.alu_operator = ALU_AND;  // And
-            {6'b00_0000, 3'b001}: decoder_ctrl_o.alu_operator = ALU_SLL;  // Shift Left Logical
-            {6'b00_0000, 3'b101}: decoder_ctrl_o.alu_operator = ALU_SRL;  // Shift Right Logical
-            {6'b10_0000, 3'b101}: decoder_ctrl_o.alu_operator = ALU_SRA;  // Shift Right Arithmetic
+            {6'b00_0000, 3'b000}: decoder_ctrl_o.alu_operator = ALU_ADD;   // Add
+            {6'b10_0000, 3'b000}: decoder_ctrl_o.alu_operator = ALU_SUB;   // Sub
+            {6'b00_0000, 3'b010}: decoder_ctrl_o.alu_operator = ALU_SLT;   // Set Lower Than
+            {6'b00_0000, 3'b011}: decoder_ctrl_o.alu_operator = ALU_SLTU;  // Set Lower Than Unsigned
+            {6'b00_0000, 3'b100}: decoder_ctrl_o.alu_operator = ALU_XOR;   // Xor
+            {6'b00_0000, 3'b110}: decoder_ctrl_o.alu_operator = ALU_OR;    // Or
+            {6'b00_0000, 3'b111}: decoder_ctrl_o.alu_operator = ALU_AND;   // And
+            {6'b00_0000, 3'b001}: decoder_ctrl_o.alu_operator = ALU_SLL;   // Shift Left Logical
+            {6'b00_0000, 3'b101}: decoder_ctrl_o.alu_operator = ALU_SRL;   // Shift Right Logical
+            {6'b10_0000, 3'b101}: decoder_ctrl_o.alu_operator = ALU_SRA;   // Shift Right Arithmetic
+            {6'b00_0111, 3'b101}: decoder_ctrl_o.alu_operator = ALU_CZEQZ; // Conditional-zero equal-to-zero
+            {6'b00_0111, 3'b111}: decoder_ctrl_o.alu_operator = ALU_CZNEZ; // Conditional-zero not-equal-to-zero
             default: begin
               decoder_ctrl_o = DECODER_CTRL_ILLEGAL_INSN;
             end

--- a/rtl/cv32e40x_i_decoder.sv
+++ b/rtl/cv32e40x_i_decoder.sv
@@ -245,18 +245,16 @@ module cv32e40x_i_decoder import cv32e40x_pkg::*;
 
           unique case ({instr_rdata_i[30:25], instr_rdata_i[14:12]})
             // RV32I ALU operations
-            {6'b00_0000, 3'b000}: decoder_ctrl_o.alu_operator = ALU_ADD;   // Add
-            {6'b10_0000, 3'b000}: decoder_ctrl_o.alu_operator = ALU_SUB;   // Sub
-            {6'b00_0000, 3'b010}: decoder_ctrl_o.alu_operator = ALU_SLT;   // Set Lower Than
-            {6'b00_0000, 3'b011}: decoder_ctrl_o.alu_operator = ALU_SLTU;  // Set Lower Than Unsigned
-            {6'b00_0000, 3'b100}: decoder_ctrl_o.alu_operator = ALU_XOR;   // Xor
-            {6'b00_0000, 3'b110}: decoder_ctrl_o.alu_operator = ALU_OR;    // Or
-            {6'b00_0000, 3'b111}: decoder_ctrl_o.alu_operator = ALU_AND;   // And
-            {6'b00_0000, 3'b001}: decoder_ctrl_o.alu_operator = ALU_SLL;   // Shift Left Logical
-            {6'b00_0000, 3'b101}: decoder_ctrl_o.alu_operator = ALU_SRL;   // Shift Right Logical
-            {6'b10_0000, 3'b101}: decoder_ctrl_o.alu_operator = ALU_SRA;   // Shift Right Arithmetic
-            {6'b00_0111, 3'b101}: decoder_ctrl_o.alu_operator = ALU_CZEQZ; // Conditional-zero equal-to-zero
-            {6'b00_0111, 3'b111}: decoder_ctrl_o.alu_operator = ALU_CZNEZ; // Conditional-zero not-equal-to-zero
+            {6'b00_0000, 3'b000}: decoder_ctrl_o.alu_operator = ALU_ADD;  // Add
+            {6'b10_0000, 3'b000}: decoder_ctrl_o.alu_operator = ALU_SUB;  // Sub
+            {6'b00_0000, 3'b010}: decoder_ctrl_o.alu_operator = ALU_SLT;  // Set Lower Than
+            {6'b00_0000, 3'b011}: decoder_ctrl_o.alu_operator = ALU_SLTU; // Set Lower Than Unsigned
+            {6'b00_0000, 3'b100}: decoder_ctrl_o.alu_operator = ALU_XOR;  // Xor
+            {6'b00_0000, 3'b110}: decoder_ctrl_o.alu_operator = ALU_OR;   // Or
+            {6'b00_0000, 3'b111}: decoder_ctrl_o.alu_operator = ALU_AND;  // And
+            {6'b00_0000, 3'b001}: decoder_ctrl_o.alu_operator = ALU_SLL;  // Shift Left Logical
+            {6'b00_0000, 3'b101}: decoder_ctrl_o.alu_operator = ALU_SRL;  // Shift Right Logical
+            {6'b10_0000, 3'b101}: decoder_ctrl_o.alu_operator = ALU_SRA;  // Shift Right Arithmetic
             default: begin
               decoder_ctrl_o = DECODER_CTRL_ILLEGAL_INSN;
             end

--- a/rtl/cv32e40x_id_stage.sv
+++ b/rtl/cv32e40x_id_stage.sv
@@ -36,6 +36,7 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
   parameter a_ext_e      A_EXT                  = A_NONE,
   parameter b_ext_e      B_EXT                  = B_NONE,
   parameter m_ext_e      M_EXT                  = M,
+  parameter ic_ext_e     IC_EXT                 = IC_NONE,
   parameter bit          X_EXT                  = 0,
   parameter int unsigned REGFILE_NUM_READ_PORTS = 2,
   parameter bit          CLIC                   = 1
@@ -390,6 +391,7 @@ module cv32e40x_id_stage import cv32e40x_pkg::*;
     .A_EXT                           ( A_EXT                     ),
     .B_EXT                           ( B_EXT                     ),
     .M_EXT                           ( M_EXT                     ),
+    .IC_EXT                          ( IC_EXT                    ),
     .CLIC                            ( CLIC                      )
   )
   decoder_i

--- a/rtl/cv32e40x_zicond_decoder.sv
+++ b/rtl/cv32e40x_zicond_decoder.sv
@@ -1,0 +1,62 @@
+// Copyright 2018 ETH Zurich and University of Bologna.
+// TODO: figure out this legal bit
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License.  You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+// TODO: find out if the description common thingy is necessary.
+
+module cv32e40x_zicond_decoder import cv32e40x_pkg::*;
+// TODO: Check if any parameters are needed. It's unlikely IMO.
+//#(
+//    parameter bit CLIC              = 1
+//)
+(
+   // from IF/ID pipeline
+   input logic [31:0] instr_rdata_i,
+   output decoder_ctrl_t decoder_ctrl_o
+);
+
+  always_comb
+  begin
+
+    // Default assignments
+    decoder_ctrl_o = DECODER_CTRL_ILLEGAL_INSN;
+    decoder_ctrl_o.illegal_insn = 1'b0;
+
+    unique case (instr_rdata_i[6:0])
+
+      OPCODE_OP: begin  // Register-Register ALU operation
+        if ((instr_rdata_i[31:30] == 2'b11) || (instr_rdata_i[31:30] == 2'b10)) begin
+          decoder_ctrl_o = DECODER_CTRL_ILLEGAL_INSN;
+        end else begin
+          decoder_ctrl_o.alu_en           = 1'b1;
+          decoder_ctrl_o.alu_op_a_mux_sel = OP_A_REGA_OR_FWD;
+          decoder_ctrl_o.alu_op_b_mux_sel = OP_B_REGB_OR_FWD;
+          decoder_ctrl_o.rf_we            = 1'b1;
+          decoder_ctrl_o.rf_re[0]         = 1'b1;
+          decoder_ctrl_o.rf_re[1]         = 1'b1; // both instructions have two operands
+
+          unique case ({instr_rdata_i[30:25], instr_rdata_i[14:12]})
+            {6'b00_0111, 3'b101}: decoder_ctrl_o.alu_operator = ALU_CZEQZ; // Conditional-zero equal-to-zero
+            {6'b00_0111, 3'b111}: decoder_ctrl_o.alu_operator = ALU_CZNEZ; // Conditional-zero not-equal-to-zero
+            default: begin
+              decoder_ctrl_o = DECODER_CTRL_ILLEGAL_INSN;
+            end
+          endcase
+        end
+      end
+
+      default: begin
+        decoder_ctrl_o = DECODER_CTRL_ILLEGAL_INSN;
+      end
+    endcase
+
+  end // always_comb
+
+endmodule

--- a/rtl/cv32e40x_zicond_decoder.sv
+++ b/rtl/cv32e40x_zicond_decoder.sv
@@ -1,5 +1,5 @@
 // Copyright 2018 ETH Zurich and University of Bologna.
-// TODO: figure out this legal bit
+// TODO:Contribution figure out this legal bit
 // Copyright and related rights are licensed under the Solderpad Hardware
 // License, Version 0.51 (the "License"); you may not use this file except in
 // compliance with the License.  You may obtain a copy of the License at
@@ -9,13 +9,9 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
-// TODO: find out if the description common thingy is necessary.
+// TODO:Contribution find out if the common description thingy is necessary.
 
 module cv32e40x_zicond_decoder import cv32e40x_pkg::*;
-// TODO: Check if any parameters are needed. It's unlikely IMO.
-//#(
-//    parameter bit CLIC              = 1
-//)
 (
    // from IF/ID pipeline
    input logic [31:0] instr_rdata_i,

--- a/rtl/cv32e40x_zicond_decoder.sv
+++ b/rtl/cv32e40x_zicond_decoder.sv
@@ -1,5 +1,5 @@
-// Copyright 2018 ETH Zurich and University of Bologna.
-// TODO:Contribution figure out this legal bit
+// Copyright 2026 TODO:Contribution figure out the necessity and/or what to
+// put here.
 // Copyright and related rights are licensed under the Solderpad Hardware
 // License, Version 0.51 (the "License"); you may not use this file except in
 // compliance with the License.  You may obtain a copy of the License at

--- a/rtl/include/cv32e40x_pkg.sv
+++ b/rtl/include/cv32e40x_pkg.sv
@@ -87,6 +87,10 @@ typedef enum logic [ALU_OP_WIDTH-1:0]
  ALU_B_ORN    = 6'b101110, // funct3 = 110, zbb
  ALU_B_ANDN   = 6'b101111, // funct3 = 111, zbb
 
+ // TODO: set proper values for these two opcodes
+ ALU_CZEQZ    = 6'bzzzzzz, // (funct3 = 101)
+ ALU_CZNEZ    = 6'bzzzzzz, // (funct3 = 111)
+
  ALU_EQ       = 6'b010000, // funct3 = 000
  ALU_NE       = 6'b010001, // funct3 = 001
  ALU_SLT      = 6'b011010, // funct3 = 010, signed(3)

--- a/rtl/include/cv32e40x_pkg.sv
+++ b/rtl/include/cv32e40x_pkg.sv
@@ -1557,6 +1557,9 @@ typedef struct packed {
   // Enum used for configuration of M extension
   typedef enum logic [1:0] {M_NONE, M, ZMMUL} m_ext_e;
 
+  // Enum used for configuration of Zicond extension
+  typedef enum logic {IC_NONE, ZICOND} ic_ext_e;
+
   // Pipe PC mux selector defines. Used to control PC mux in control FSM
   typedef enum logic[1:0] {
     PC_IF,

--- a/rtl/include/cv32e40x_pkg.sv
+++ b/rtl/include/cv32e40x_pkg.sv
@@ -87,7 +87,7 @@ typedef enum logic [ALU_OP_WIDTH-1:0]
  ALU_B_ORN    = 6'b101110, // funct3 = 110, zbb
  ALU_B_ANDN   = 6'b101111, // funct3 = 111, zbb
 
- // TODO: set proper values for these two opcodes
+ // TODO:Zicond set proper values for these two opcodes
  ALU_CZEQZ    = 6'bzzzzzz, // (funct3 = 101)
  ALU_CZNEZ    = 6'bzzzzzz, // (funct3 = 111)
 


### PR DESCRIPTION
This PR is to add optional support for the [Zicond](https://docs.riscv.org/reference/isa/extensions/zicond/_attachments/riscv-zicond.pdf) standard RISC-V ISA extension, which was ratified a few years ago, to this core. It implements the extension's two conditional-zero instructions within the ALU, and introduces an extra instruction decoder module to enable them.

The Zicond decoder is essentially a severely stripped-down copy of the pre-existing RV32I decoder, and the new ALU functions have been written in the style of the other optional extensions.

As this core is designed to handle computationally-intensive tasks, I think Zicond would be a welcome addition to its instruction set. If I understand the pipeline correctly, these conditional instructions can turn some branches, which take three or four cycles when taken, into integer computational instructions, which take one cycle in all cases. I envisage that this could have positive effects on the core's performance on branch-heavy workloads.

Don't be surprised if this code is a little broken as it stands. I've only ever written a little Verilog, and I wrote all of this with no tools beyond SystemVerilog syntax highlighting.

I'm opening a draft to share this work (such as it is) with the project, gauge whether this is a desirable extension, and see whether my general approach to modifying the core is sound or not. I'm also hoping to get some advice on assigning values to the two new ALU opcodes introduced in this PR (`ALU_CZEQZ` and `ALU_CZNEZ`), which are currently `6'bzzzzzz` placeholders.

I also have a few outstanding questions about a header and copyright notices in `cv32e40x_zicond_decoder.sv`.

I'll mark this as ready for review once I've given it a once-over with a language server, and resolved any errors that crop up.